### PR TITLE
Close the fence duped from surfacefligner

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -746,7 +746,7 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerBuffer(buffer_handle_t buffer,
   native_handle_.handle_ = buffer;
   hwc_layer_.SetNativeHandle(&native_handle_);
   if (acquire_fence > 0)
-    hwc_layer_.SetAcquireFence(dup(acquire_fence));
+    hwc_layer_.SetAcquireFence(acquire_fence);
   return HWC2::Error::None;
 }
 


### PR DESCRIPTION
such fence is passed from SurfaceFlinger, we dup it here,
but no one closes the orignal fence which make
"fd leak" of SurfaceFlinger.

Change-Id: I7c04438fe6326e1de2e7345942afef33d582bb69
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-43936
Signed-off-by: Zhongmin Wu <zhongmin.wu@intel.com>