### PR TITLE
Remove unneeded break if encoder is found

### DIFF
--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -249,7 +249,6 @@ bool DrmDisplayManager::UpdateDisplayState() {
       }
     } else {
       // Try to find an encoder for the connector.
-      bool found_encoder = false;
       for (int32_t j = 0; j < connector->count_encoders; ++j) {
         ScopedDrmEncoderPtr encoder(
             drmModeGetEncoder(fd_, connector->encoders[j]));
@@ -264,13 +263,10 @@ bool DrmDisplayManager::UpdateDisplayState() {
             // Set the modes supported for each display
             display->SetDrmModeInfo(mode);
             connected_displays_.emplace_back(display.get());
-            found_encoder = true;
             break;
           }
         }
       }
-      if (found_encoder)
-        break;
     }
   }
 


### PR DESCRIPTION
When an encoder is found for the first connector, the
variable found_encoder is set to true which then causes
the loop to terminate unnecessarily. This causes only one
connector to be detected at boot time.

Jira: None
Tests: On boot, more than one connected displays are identified.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>