### PR TITLE
Update the HWC ebuild file to support .so and binary installation for Chrome OS.

### DIFF
--- a/os/chromeos/IA-Hardware-Composer-9999.ebuild
+++ b/os/chromeos/IA-Hardware-Composer-9999.ebuild
@@ -3,7 +3,8 @@
 # $Header: $
 
 EAPI=5
-inherit cros-workon eutils autotools
+
+inherit base autotools multilib flag-o-matic toolchain-funcs cros-workon eutils
 
 CROS_WORKON_PROJECT="chromiumos/third_party/IA-Hardware-Composer"
 KEYWORDS="~x86 ~amd64"
@@ -31,5 +32,5 @@ src_compile() {
 }
 
 src_install() {
-	dobin tests/testlayers
+    base_src_install
 }


### PR DESCRIPTION
Latest HWC will install shared lib .so files and testlayers binary
will be generated after the "make install", to align with latest
HWC source, this commit will support .so files and testlayers
installation(not install test json example files).

Jira: None
Tests: Build HWC in Chrome OS SDK with this ebuild file without
       error, and deploy the HWC package to Chrome OS device
       without error, the testlayers can be executed normally
       with the shared the libhwcomposer.so.* installed.

Signed-off-by: Yugang Fan <yugang.fan@intel.com>