### PR TITLE
Fix for stack corruption and solve Multi-Mode config enumeration

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -163,8 +163,8 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   *num_configs = size;
   if (!configs)
     return true;
-
-  for (uint32_t i = 0; i < size; i++)
+  
+  for (uint32_t i = 0; i < *num_configs; i++)
     configs[i] = i;
 
   return true;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -226,7 +226,6 @@ bool DrmDisplayManager::UpdateDisplayState() {
       // There is only one preferred mode per connector.
       if (mode[i].type & DRM_MODE_TYPE_PREFERRED) {
         preferred_mode = i;
-        break;
       }
     }
 


### PR DESCRIPTION
issue.

Multi-Mode config enumeration got broken in the commit ID
deb0866. Fixed the same.
Also stack corruption introduced while enabling HWC1.5 is
resolved by reverting usage of local var to store number
of config.

Jira: IAHWC-81
Test: No Stack corruption during HWC init on Android boot-up

Signed-off-by: Poornima <poornima.y.n@intel.com>
Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>