### PR TITLE
Fix screen-off problem.

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -531,6 +531,11 @@ void DrmDisplay::Disable(const DisplayPlaneStateList &composition_planes) {
       plane->SetEnabled(false);
       plane->Disable(pset.get());
     }
+
+    ret = drmModeAtomicCommit(gpu_fd_, pset.get(),
+                              DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+    if (ret)
+      ETRACE("Failed to disable display:%s\n", PRINTERROR());
   } else {
     ETRACE("Failed to allocate property set %d", -ENOMEM);
   }


### PR DESCRIPTION
There's a missing drmModeAtomicCommit call when disabling the display.
This can lead to display freeze when turning the screen back on.

Note: works ok on top of https://github.com/intel/IA-Hardware-Composer/commit/bd80e43e3640e31deae69d2af72dac16aca38817, but not on top of https://github.com/intel/IA-Hardware-Composer/commit/86099e12ed6b94b8f913c715da533a4156dc4dfd

Jira: https://01.org/jira/browse/AIA-430
Test: Display comes back up when powering back on.

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>