### PR TITLE
Disable SetCursorPosition usage

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -64,9 +64,7 @@ void HwcLayer::SetSourceCrop(const HwcRect<float>& source_crop) {
   uint32_t old_src_crop_height = source_crop_.bottom - source_crop_.top;
 
   if ((new_src_crop_width != old_src_crop_width) ||
-      (new_src_crop_height != old_src_crop_height) ||
-      (source_crop_.left != source_crop.left) ||
-      (source_crop_.right != source_crop.right)) {
+      (new_src_crop_height != old_src_crop_height)) {
     layer_cache_ |= kDisplayFrameRectChanged;
   }
 

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -165,7 +165,7 @@ class DisplayQueue {
         tracker_.state_ |= FrameStateTracker::kTrackingFrames;
         tracker_.continuous_frames_ = 0;
       } else if (tracker_.state_ & FrameStateTracker::kTrackingFrames) {
-        if (tracker_.continuous_frames_ > 10) {
+        if (tracker_.continuous_frames_ > 3) {
           tracker_.state_ &= ~FrameStateTracker::kTrackingFrames;
           tracker_.state_ |= FrameStateTracker::kRevalidateLayers;
           tracker_.continuous_frames_ = 0;

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -162,7 +162,7 @@ class DisplayQueue {
       tracker_.state_ &= ~FrameStateTracker::kPrepareComposition;
       if (tracker_.state_ & FrameStateTracker::kRenderIdleDisplay) {
         tracker_.state_ &= ~FrameStateTracker::kRenderIdleDisplay;
-	tracker_.state_ |= FrameStateTracker::kTrackingFrames;
+        tracker_.state_ |= FrameStateTracker::kTrackingFrames;
         tracker_.continuous_frames_ = 0;
       } else if (tracker_.state_ & FrameStateTracker::kTrackingFrames) {
         if (tracker_.continuous_frames_ > 10) {

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -691,6 +691,10 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
         layer.set_validated_type(HWC2::Composition::Client);
         ++*num_types;
         break;
+      case HWC2::Composition::Cursor:
+        layer.set_validated_type(HWC2::Composition::Device);
+        ++*num_types;
+        break;
       default:
         if (disable_explicit_sync_ ||
             display_->PowerMode() == HWC2_POWER_MODE_DOZE_SUSPEND) {


### PR DESCRIPTION
According to the spec setting the cursor composition to
device disables the use SetCursorPosition by SurfaceFlinger.
For now we are not using this so inform SurfaceFlinger
about the same

Jira: None
Test: System doesn't crash when moving the mouse

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>