### PR TITLE
Change the init_frames place to load test json firstly.

### DIFF
--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -660,6 +660,8 @@ int main(int argc, char *argv[]) {
     exit(-1);
   }
 
+  init_frames(primary_width, primary_height);
+
   if (display_mode) {
     printf("\nSUPPORTED DISPLAY MODE\n");
     uint32_t numConfigs, configIndex;
@@ -703,7 +705,6 @@ int main(int argc, char *argv[]) {
                           test_parameters.contrast_b);
   }
 
-  init_frames(primary_width, primary_height);
   /* clear the color buffer */
   int64_t gpu_fence_fd = -1; /* out-fence from gpu, in-fence to kms */
   std::vector<hwcomposer::HwcLayer *> layers;


### PR DESCRIPTION
Old place of init_frames() will load json after setting the display
mode/color correction, that causes testlayers always use the default
parameters.

Jira: None.
Test: Change the value of test json files (e.g. gamma*, power_mode*),
      the testlayers will change the effects accordingly.

Signed-off-by: Fan Yugang <yugang.fan@intel.com>