### PR TITLE
Fix wrong NV16 lineBytes issue in video test.

### DIFF
--- a/tests/common/videolayerrenderer.cpp
+++ b/tests/common/videolayerrenderer.cpp
@@ -61,10 +61,10 @@ static int get_bpp_from_format(uint32_t format, size_t plane) {
     case DRM_FORMAT_R8:
     case DRM_FORMAT_RGB332:
     case DRM_FORMAT_YVU420:
-    case DRM_FORMAT_NV16:
     case DRM_FORMAT_YUV444:
     case DRM_FORMAT_YUV422:
       return 8;
+    case DRM_FORMAT_NV16:
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_NV21:
     case DRM_FORMAT_NV12_Y_TILED_INTEL:

--- a/tools/colorformatter/resources/video1layer_nv12_y_tiled_intel.json
+++ b/tools/colorformatter/resources/video1layer_nv12_y_tiled_intel.json
@@ -8,7 +8,7 @@
         "x": 0,
         "y": 0
       },
-      "resource_path": "./resources/resource.nv12.yuv",
+      "resource_path": "resource.nv12.yuv",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_nv21.json
+++ b/tools/colorformatter/resources/video1layer_nv21.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 48,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.nv21.yuv",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_y16.json
+++ b/tools/colorformatter/resources/video1layer_y16.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 63,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.y16",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_y8.json
+++ b/tools/colorformatter/resources/video1layer_y8.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 62,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.y8",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_yuv422888.json
+++ b/tools/colorformatter/resources/video1layer_yuv422888.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 67,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.ycbcr_422_888",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_yuv422sp.json
+++ b/tools/colorformatter/resources/video1layer_yuv422sp.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 66,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.ycbcr_422_sp",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_yuv444888.json
+++ b/tools/colorformatter/resources/video1layer_yuv444888.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 64,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.ycbcr_444_888",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_yuyv422.json
+++ b/tools/colorformatter/resources/video1layer_yuyv422.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 100,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.yuyv422.yuv",
       "source": {
         "crop": {
           "height": 400,

--- a/tools/colorformatter/resources/video1layer_yv12.json
+++ b/tools/colorformatter/resources/video1layer_yv12.json
@@ -1,14 +1,14 @@
 {
   "layers_parameters": [
     {
-      "format": 47,
+      "format": 61,
       "frame": {
         "height": 400,
         "width": 600,
         "x": 0,
         "y": 0
       },
-      "resource_path": "resource.nv12.yuv",
+      "resource_path": "resource.yv12",
       "source": {
         "crop": {
           "height": 400,


### PR DESCRIPTION
NV16 have the same lineBytes with NV12, this commit just fixed old
wrong lineBytes.

Jira: None
Test: Use video1layer_yuv422sp.json as the test json file to render
the NV16 test image, the rendering shows normally.

Signed-off-by: Yugang Fan <yugang.fan@intel.com>