### PR TITLE
Build common and wsi as static library.

### DIFF
--- a/Makefile.sources
+++ b/Makefile.sources
@@ -1,46 +1,4 @@
-common_SOURCES =              \
-    common/compositor/compositor.cpp \
-    common/compositor/compositorthread.cpp \
-    common/compositor/factory.cpp \
-    common/compositor/nativesurface.cpp \
-    common/compositor/renderstate.cpp \
-    common/core/hwclayer.cpp \
-    common/core/hwclock.cpp \
-    common/core/overlaylayer.cpp \
-    common/core/gpudevice.cpp \
-    common/display/displayqueue.cpp \
-    common/display/displayplanemanager.cpp \
-    common/display/headless.cpp \
-    common/display/vblankeventhandler.cpp \
-    common/display/virtualdisplay.cpp \
-    common/utils/fdhandler.cpp \
-    common/utils/hwcevent.cpp \
-    common/utils/hwcthread.cpp \
-    common/utils/hwcutils.cpp \
-    common/utils/disjoint_layers.cpp \
+hwc_SOURCES =              \
     os/linux/gbmbufferhandler.cpp \
     os/linux/platformdefines.cpp \
-    wsi/physicaldisplay.cpp \
-    wsi/drm/drmdisplay.cpp \
-    wsi/drm/drmbuffer.cpp \
-    wsi/drm/drmplane.cpp \
-    wsi/drm/drmdisplaymanager.cpp \
-    wsi/drm/drmscopedtypes.cpp \
 	$(NULL)
-
-gl_SOURCES =              \
-    common/compositor/gl/egloffscreencontext.cpp \
-    common/compositor/gl/glprogram.cpp \
-    common/compositor/gl/glrenderer.cpp \
-    common/compositor/gl/glsurface.cpp \
-    common/compositor/gl/nativeglresource.cpp \
-    common/compositor/gl/shim.cpp \
-	$(NULL)
-
-vk_SOURCES =\
-    common/compositor/vk/vkprogram.cpp \
-    common/compositor/vk/vkrenderer.cpp \
-    common/compositor/vk/vksurface.cpp \
-    common/compositor/vk/nativevkresource.cpp \
-    common/compositor/vk/vkshim.cpp \
-        $(NULL)

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -1,0 +1,137 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_SHARED_LIBRARIES := \
+        libcutils \
+        libdrm \
+        libEGL \
+        libGLESv2 \
+        libhardware \
+        liblog \
+        libui \
+        libutils \
+        libhwcservice \
+        libbinder
+
+LOCAL_C_INCLUDES := \
+        system/core/include/utils \
+        $(LOCAL_PATH)/../public \
+        $(LOCAL_PATH)/core \
+        $(LOCAL_PATH)/compositor \
+        $(LOCAL_PATH)/compositor/gl \
+        $(LOCAL_PATH)/display \
+        $(LOCAL_PATH)/utils \
+        $(LOCAL_PATH)/../os \
+        $(LOCAL_PATH)/../os/android \
+        $(LOCAL_PATH)/../wsi \
+        $(LOCAL_PATH)/../wsi/drm
+
+LOCAL_SRC_FILES := \
+        compositor/compositor.cpp \
+        compositor/compositorthread.cpp \
+        compositor/factory.cpp \
+        compositor/nativesurface.cpp \
+        compositor/renderstate.cpp \
+        core/gpudevice.cpp \
+        core/hwclayer.cpp \
+        core/hwclock.cpp \
+        core/overlaylayer.cpp \
+        display/displayplanemanager.cpp \
+        display/displayqueue.cpp \
+        display/headless.cpp \
+        display/vblankeventhandler.cpp \
+        display/virtualdisplay.cpp \
+        utils/fdhandler.cpp \
+        utils/hwcevent.cpp \
+        utils/hwcthread.cpp \
+        utils/hwcutils.cpp \
+        utils/disjoint_layers.cpp
+
+ifeq ($(strip $(TARGET_USES_HWC2)), false)
+LOCAL_C_INCLUDES += \
+        system/core/libsync \
+        system/core/libsync/include
+
+LOCAL_SHARED_LIBRARIES += \
+        libsync
+
+LOCAL_CPPFLAGS += -DENABLE_DOUBLE_BUFFERING
+endif
+
+LOCAL_CPPFLAGS += \
+        -DHWC2_INCLUDE_STRINGIFICATION \
+        -DHWC2_USE_CPP11 \
+        -Wno-date-time \
+        -DUSE_ANDROID_SHIM \
+        -D_FORTIFY_SOURCE=2 \
+        -fstack-protector-strong \
+        -Wformat -Wformat-security \
+        -std=c++14 -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -Wall -Wsign-compare -Wpointer-arith \
+        -Wcast-qual -Wcast-align \
+        -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -O3
+
+ifeq ($(strip $(BOARD_DISABLE_NATIVE_COLOR_MODES)), true)
+LOCAL_CPPFLAGS += -DDISABLE_NATIVE_COLOR_MODES
+endif
+
+ifeq ($(strip $(BOARD_USES_VULKAN)), true)
+LOCAL_SHARED_LIBRARIES += \
+        libvulkan
+
+LOCAL_CPPFLAGS += \
+        -DUSE_VK \
+        -DDISABLE_EXPLICIT_SYNC
+
+LOCAL_C_INCLUDES += \
+        $(LOCAL_PATH)/compositor/vk \
+        $(LOCAL_PATH)/../../mesa/include
+
+LOCAL_SRC_FILES += \
+        compositor/vk/vkprogram.cpp \
+        compositor/vk/vkrenderer.cpp \
+        compositor/vk/vksurface.cpp \
+        compositor/vk/nativevkresource.cpp \
+        compositor/vk/vkshim.cpp
+else
+LOCAL_CPPFLAGS += \
+        -DUSE_GL
+
+LOCAL_SRC_FILES += \
+        compositor/gl/glprogram.cpp \
+        compositor/gl/glrenderer.cpp \
+        compositor/gl/glsurface.cpp \
+        compositor/gl/egloffscreencontext.cpp \
+        compositor/gl/nativeglresource.cpp \
+        compositor/gl/shim.cpp
+endif
+
+ifeq ($(strip $(BOARD_USES_MINIGBM)), true)
+LOCAL_CPPFLAGS += -DUSE_MINIGBM
+LOCAL_C_INCLUDES += \
+        $(INTEL_MINIGBM)/cros_gralloc/
+else
+LOCAL_C_INCLUDES += \
+        $(INTEL_DRM_GRALLOC)
+endif
+
+LOCAL_MODULE := libhwcomposer_common
+LOCAL_CFLAGS += -fvisibility=default
+LOCAL_LDFLAGS += -no-undefined
+include $(BUILD_STATIC_LIBRARY)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -19,16 +19,11 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 AM_MAKEFLAGS = -s
 
-SUBDIRS = \
-	common \
-	wsi \
-	. \
-	tests/third_party/json-c \
-	tests
+SUBDIRS = .
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 
-AM_CPP_INCLUDES = -I$(top_srcdir) -Ipublic -Ios -Ios/linux -Icommon/display/ -Icommon/core/ -Icommon/utils/ -Icommon/compositor/ -Iwsi -Iwsi/drm/
+AM_CPP_INCLUDES = -Icore -Iutils -Icompositor -Idisplay -I../os/ -I../os/linux/ -I../public/ -I../wsi/ 
 AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -DENABLE_DOUBLE_BUFFERING
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 
@@ -36,38 +31,28 @@ if !ENABLE_GBM
 AM_CPPFLAGS += -DUSE_MINIGBM
 endif
 
-libhwcomposer_la_LIBADD = \
+libhwcomposer_common_la_LIBADD = \
 	$(DRM_LIBS) \
 	$(GBM_LIBS) \
 	$(EGL_LIBS) \
 	-lm
 
-libhwcomposer_la_LTLIBRARIES = libhwcomposer.la
-libhwcomposer_la_SOURCES = $(hwc_SOURCES)
-libhwcomposer_ladir = $(libdir)
-libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -shared -Wl,-whole-archive,common/.libs/libhwcomposer_common.a,wsi/.libs/libhwcomposer_wsi.a,-no-whole-archive
-
+libhwcomposer_common_la_LTLIBRARIES = libhwcomposer_common.la
+libhwcomposer_common_la_SOURCES = $(common_SOURCES)
 if ENABLE_VULKAN
-AM_CPP_INCLUDES += -Icommon/compositor/vk
-AM_CPPFLAGS += -Icommon/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
-libhwcomposer_la_LDFLAGS += -Wl,--no-as-needed,-lvulkan,--as-needed
+libhwcomposer_common_la_SOURCES += $(vk_SOURCES)
+AM_CPP_INCLUDES += -Icompositor/vk
+AM_CPPFLAGS += -Icompositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
+libhwcomposer_common_la_LIBADD += -lvulkan
 else
-AM_CPP_INCLUDES += -Icommon/compositor/gl
+libhwcomposer_common_la_SOURCES += $(gl_SOURCES)
+AM_CPP_INCLUDES += -Icompositor/gl
 AM_CPPFLAGS += -DUSE_GL
-libhwcomposer_la_LIBADD += $(GLES2_LIBS)
+libhwcomposer_common_la_LIBADD += $(GLES2_LIBS)
 endif
 
-
-libhwcincdir = $(includedir)/libhwc
-libhwcinc_HEADERS =	\
-	$(top_srcdir)/public/gpudevice.h	\
-	$(top_srcdir)/public/hwcbuffer.h	\
-	$(top_srcdir)/public/hwcdefs.h	\
-	$(top_srcdir)/public/hwclayer.h	\
-	$(top_srcdir)/public/hwcrect.h	\
-	$(top_srcdir)/public/nativebufferhandler.h	\
-	$(top_srcdir)/public/nativedisplay.h	\
-	$(top_srcdir)/public/spinlock.h
+libhwcomposer_common_ladir = $(libdir)
+libhwcomposer_common_la_LDFLAGS = -version-number 0:0:1 -no-undefined -static
 
 .PHONY: ChangeLog INSTALL
 

--- a/common/Makefile.sources
+++ b/common/Makefile.sources
@@ -1,0 +1,38 @@
+common_SOURCES =              \
+    compositor/compositor.cpp \
+    compositor/compositorthread.cpp \
+    compositor/factory.cpp \
+    compositor/nativesurface.cpp \
+    compositor/renderstate.cpp \
+    core/hwclayer.cpp \
+    core/hwclock.cpp \
+    core/overlaylayer.cpp \
+    core/gpudevice.cpp \
+    display/displayqueue.cpp \
+    display/displayplanemanager.cpp \
+    display/headless.cpp \
+    display/vblankeventhandler.cpp \
+    display/virtualdisplay.cpp \
+    utils/fdhandler.cpp \
+    utils/hwcevent.cpp \
+    utils/hwcthread.cpp \
+    utils/hwcutils.cpp \
+    utils/disjoint_layers.cpp \
+	$(NULL)
+
+gl_SOURCES =              \
+    compositor/gl/egloffscreencontext.cpp \
+    compositor/gl/glprogram.cpp \
+    compositor/gl/glrenderer.cpp \
+    compositor/gl/glsurface.cpp \
+    compositor/gl/nativeglresource.cpp \
+    compositor/gl/shim.cpp \
+	$(NULL)
+
+vk_SOURCES =\
+    compositor/vk/vkprogram.cpp \
+    compositor/vk/vkrenderer.cpp \
+    compositor/vk/vksurface.cpp \
+    compositor/vk/nativevkresource.cpp \
+    compositor/vk/vkshim.cpp \
+        $(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,8 @@ AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
 AX_COMPILE_CHECK_SIZEOF(long long)
 AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
-###############################################################################
+# End of json-c
+#######################################################################
 
 PKG_CHECK_MODULES(DRM, [libdrm])
 PKG_CHECK_MODULES(GBM, [gbm])
@@ -173,6 +174,8 @@ AC_ARG_ENABLE(git-hash,
 AC_SUBST(GIT_HASH, [$git_hash])
 
 AC_CONFIG_FILES([
+		common/Makefile
+		wsi/Makefile
 		Makefile
 		tests/third_party/json-c/Makefile
 		tests/Makefile

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -1,0 +1,109 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_SHARED_LIBRARIES := \
+        libcutils \
+        libdrm \
+        libEGL \
+        libGLESv2 \
+        libhardware \
+        liblog \
+        libui \
+        libutils \
+        libhwcservice \
+        libbinder
+
+LOCAL_C_INCLUDES := \
+        system/core/include/utils \
+        $(LOCAL_PATH)/../public \
+        $(LOCAL_PATH)/../common/core \
+        $(LOCAL_PATH)/../common/compositor \
+        $(LOCAL_PATH)/../common/compositor/gl \
+        $(LOCAL_PATH)/../common/display \
+        $(LOCAL_PATH)/../common/utils \
+        $(LOCAL_PATH)/../os \
+        $(LOCAL_PATH)/../os/android \
+        $(LOCAL_PATH)/../wsi \
+        $(LOCAL_PATH)/../wsi/drm
+
+LOCAL_SRC_FILES := \
+        physicaldisplay.cpp \
+        drm/drmdisplay.cpp \
+        drm/drmbuffer.cpp \
+        drm/drmplane.cpp \
+        drm/drmdisplaymanager.cpp \
+        drm/drmscopedtypes.cpp
+
+ifeq ($(strip $(TARGET_USES_HWC2)), false)
+LOCAL_C_INCLUDES += \
+        system/core/libsync \
+        system/core/libsync/include
+
+LOCAL_SHARED_LIBRARIES += \
+        libsync
+
+LOCAL_CPPFLAGS += -DENABLE_DOUBLE_BUFFERING
+endif
+
+LOCAL_CPPFLAGS += \
+        -DHWC2_INCLUDE_STRINGIFICATION \
+        -DHWC2_USE_CPP11 \
+        -Wno-date-time \
+        -DUSE_ANDROID_SHIM \
+        -D_FORTIFY_SOURCE=2 \
+        -fstack-protector-strong \
+        -Wformat -Wformat-security \
+        -std=c++14 -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -Wall -Wsign-compare -Wpointer-arith \
+        -Wcast-qual -Wcast-align \
+        -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -O3
+
+ifeq ($(strip $(BOARD_DISABLE_NATIVE_COLOR_MODES)), true)
+LOCAL_CPPFLAGS += -DDISABLE_NATIVE_COLOR_MODES
+endif
+
+ifeq ($(strip $(BOARD_USES_VULKAN)), true)
+LOCAL_SHARED_LIBRARIES += \
+        libvulkan
+
+LOCAL_CPPFLAGS += \
+        -DUSE_VK \
+        -DDISABLE_EXPLICIT_SYNC
+
+LOCAL_C_INCLUDES += \
+        $(LOCAL_PATH)/../common/compositor/vk \
+        $(LOCAL_PATH)/../../mesa/include
+else
+LOCAL_CPPFLAGS += \
+        -DUSE_GL
+endif
+
+ifeq ($(strip $(BOARD_USES_MINIGBM)), true)
+LOCAL_CPPFLAGS += -DUSE_MINIGBM
+LOCAL_C_INCLUDES += \
+        $(INTEL_MINIGBM)/cros_gralloc/
+else
+LOCAL_C_INCLUDES += \
+        $(INTEL_DRM_GRALLOC)
+endif
+
+LOCAL_MODULE := libhwcomposer_wsi
+LOCAL_CFLAGS += -fvisibility=default
+LOCAL_LDFLAGS += -no-undefined 
+include $(BUILD_STATIC_LIBRARY)

--- a/wsi/Makefile.am
+++ b/wsi/Makefile.am
@@ -19,16 +19,11 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 AM_MAKEFLAGS = -s
 
-SUBDIRS = \
-	common \
-	wsi \
-	. \
-	tests/third_party/json-c \
-	tests
+SUBDIRS = .
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 
-AM_CPP_INCLUDES = -I$(top_srcdir) -Ipublic -Ios -Ios/linux -Icommon/display/ -Icommon/core/ -Icommon/utils/ -Icommon/compositor/ -Iwsi -Iwsi/drm/
+AM_CPP_INCLUDES = -Idrm -I../os/ -I../os/linux/ -I../public/ -I../common/display/ -I../common/core/ -I../common/utils/ -I../common/compositor/
 AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -DENABLE_DOUBLE_BUFFERING
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 
@@ -36,38 +31,26 @@ if !ENABLE_GBM
 AM_CPPFLAGS += -DUSE_MINIGBM
 endif
 
-libhwcomposer_la_LIBADD = \
+libhwcomposer_wsi_la_LIBADD = \
 	$(DRM_LIBS) \
 	$(GBM_LIBS) \
 	$(EGL_LIBS) \
 	-lm
 
-libhwcomposer_la_LTLIBRARIES = libhwcomposer.la
-libhwcomposer_la_SOURCES = $(hwc_SOURCES)
-libhwcomposer_ladir = $(libdir)
-libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -shared -Wl,-whole-archive,common/.libs/libhwcomposer_common.a,wsi/.libs/libhwcomposer_wsi.a,-no-whole-archive
+libhwcomposer_wsi_la_LTLIBRARIES = libhwcomposer_wsi.la
+libhwcomposer_wsi_la_SOURCES = $(wsi_SOURCES)
+libhwcomposer_wsi_ladir = $(libdir)
+libhwcomposer_wsi_la_LDFLAGS = -version-number 0:0:1 -no-undefined -static
 
 if ENABLE_VULKAN
-AM_CPP_INCLUDES += -Icommon/compositor/vk
-AM_CPPFLAGS += -Icommon/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
-libhwcomposer_la_LDFLAGS += -Wl,--no-as-needed,-lvulkan,--as-needed
+AM_CPP_INCLUDES += -I../common/compositor/vk
+AM_CPPFLAGS += -I../common/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
+libhwcomposer_wsi_la_LIBADD += -lvulkan
 else
-AM_CPP_INCLUDES += -Icommon/compositor/gl
+AM_CPP_INCLUDES += -I../common/compositor/gl
 AM_CPPFLAGS += -DUSE_GL
-libhwcomposer_la_LIBADD += $(GLES2_LIBS)
+libhwcomposer_wsi_la_LIBADD += $(GLES2_LIBS)
 endif
-
-
-libhwcincdir = $(includedir)/libhwc
-libhwcinc_HEADERS =	\
-	$(top_srcdir)/public/gpudevice.h	\
-	$(top_srcdir)/public/hwcbuffer.h	\
-	$(top_srcdir)/public/hwcdefs.h	\
-	$(top_srcdir)/public/hwclayer.h	\
-	$(top_srcdir)/public/hwcrect.h	\
-	$(top_srcdir)/public/nativebufferhandler.h	\
-	$(top_srcdir)/public/nativedisplay.h	\
-	$(top_srcdir)/public/spinlock.h
 
 .PHONY: ChangeLog INSTALL
 

--- a/wsi/Makefile.sources
+++ b/wsi/Makefile.sources
@@ -1,0 +1,8 @@
+wsi_SOURCES =              \
+    physicaldisplay.cpp \
+    drm/drmdisplay.cpp \
+    drm/drmbuffer.cpp \
+    drm/drmplane.cpp \
+    drm/drmdisplaymanager.cpp \
+    drm/drmscopedtypes.cpp \
+	$(NULL)


### PR DESCRIPTION
Updated the config and Makefile.am/Android.mk to support build
common and wsi as single static library for external using. Still
built libhwc which only included platform code as dynamic library
and link to whole common and wsi static lib files.

Jira: GSE-19
Test: Build and run hwc normally as before, and the common
      and wsi can be used for static linking.

Signed-off-by: Yugang Fan <yugang.fan@intel.com>