### PR TITLE
Add an option to disable Hot Plug Notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ script:
 #finally, build the hardware composer itself
 - ./autogen.sh --prefix=$WLD
 - make -j5
+- make clean
+- ./autogen.sh --prefix=$WLD --disable-hotplug-support
+- make -j5
 branches:
   only:
   - master

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,23 @@ fi])
 
 AM_CONDITIONAL([ENABLE_VULKAN], [test "x$enable_vulkan" = "xyes"])
 
+# For hotplug
+AC_ARG_ENABLE(hotplug-support,
+  AS_HELP_STRING([--disable-hotplug-support],
+    [Disable Hot Plug Support.]),
+[if test x$enableval = xyes; then
+  disable_hotplug_support=yes
+  AC_DEFINE(DISABLE_HOTPLUG_SUPPORT, 1, [Disable Hot Plug Support])
+fi])
+
+AM_CONDITIONAL(DISABLE_HOTPLUG_SUPPORT, test "x$disable_hotplug_support" = "xyes")
+
+if test "x$disable_hotplug_support" = "xyes"; then
+    AC_MSG_RESULT([Hot Plug support is disabled.])
+  else
+    AC_MSG_RESULT([Hot Plug support is enabled.])
+fi
+
 # For json-c
 AC_CONFIG_HEADER(tests/third_party/json-c/json_config.h)
 AC_ARG_ENABLE(rdrand,
@@ -69,6 +86,7 @@ else
   AC_MSG_RESULT([RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable])
 fi
 
+# For gbm
 AC_ARG_ENABLE(gbm,
   AS_HELP_STRING([--enable-gbm],
     [Enable GBM buffer manager.]),
@@ -84,6 +102,7 @@ if test "x$enable_gbm" = "xyes"; then
 else
   AC_MSG_RESULT([Mini GBM buffer manager is enabled. Use --enable-gbm to disable])
 fi
+
 
 AM_PROG_CC_C_O
 AC_PROG_CC_C99

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -103,6 +103,11 @@ LOCAL_C_INCLUDES += \
         $(INTEL_DRM_GRALLOC)
 endif
 
+ifeq ($(strip $(DISABLE_HOTPLUG_SUPPORT)), true)
+LOCAL_CPPFLAGS += \
+	-DDISABLE_HOTPLUG_NOTIFICATION
+endif
+
 LOCAL_MODULE := libhwcomposer_wsi
 LOCAL_CFLAGS += -fvisibility=default
 LOCAL_LDFLAGS += -no-undefined

--- a/wsi/Makefile.am
+++ b/wsi/Makefile.am
@@ -27,6 +27,10 @@ AM_CPP_INCLUDES = -Idrm -I../os/ -I../os/linux/ -I../public/ -I../common/display
 AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -DENABLE_DOUBLE_BUFFERING
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 
+if DISABLE_HOTPLUG_SUPPORT
+AM_CPPFLAGS += -DISABLE_HOTPLUG_NOTIFICATION
+endif
+
 if !ENABLE_GBM
 AM_CPPFLAGS += -DUSE_MINIGBM
 endif

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -44,7 +44,9 @@ DrmDisplayManager::DrmDisplayManager() : HWCThread(-8, "DisplayManager") {
 DrmDisplayManager::~DrmDisplayManager() {
   CTRACE();
   std::vector<std::unique_ptr<DrmDisplay>>().swap(displays_);
+#ifndef DISABLE_HOTPLUG_NOTIFICATION
   close(hotplug_fd_);
+#endif
   close(fd_);
 }
 
@@ -101,6 +103,7 @@ bool DrmDisplayManager::Initialize() {
     ETRACE("Failed to connect display.");
     return false;
   }
+#ifndef DISABLE_HOTPLUG_NOTIFICATION
   hotplug_fd_ = socket(PF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
   if (hotplug_fd_ < 0) {
     ETRACE("Failed to create socket for hot plug monitor. %s", PRINTERROR());
@@ -126,7 +129,7 @@ bool DrmDisplayManager::Initialize() {
     ETRACE("Failed to initalizer thread to monitor Hot Plug events. %s",
            PRINTERROR());
   }
-
+#endif
   IHOTPLUGEVENTTRACE("DisplayManager Initialization succeeded.");
 
   return true;

--- a/wsi/wsi_utils.h
+++ b/wsi/wsi_utils.h
@@ -1,0 +1,32 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef WSI_UTILS_H__
+#define WSI_UTILS_H__
+
+#ifndef DISABLE_HOTPLUG_NOTIFICATION
+#define SPIN_LOCK(X) X.lock();
+#else
+#define SPIN_LOCK(X) ((void)0)
+#endif
+
+#ifndef DISABLE_HOTPLUG_NOTIFICATION
+#define SPIN_UNLOCK(X) X.unlock();
+#else
+#define SPIN_UNLOCK(X) ((void)0)
+#endif
+
+#endif  // WSI_UTILS_H__


### PR DESCRIPTION
Not everyone needs hot plug support. In these cases, monitoring
for physical connect/disconnection of displays is not needed.
Add an option to disable hot plug support if not really
needed.

Pass --disable-hotplug-support on Linux.
One has to set DISABLE_HOTPLUG_SUPPORT in BoardConfig file in
Android.

Jira: None.
Test: Build passes and hot plug support works as today as today.
Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>