### PR TITLE
Fix libhwcomposer relink issue when static libs been updated.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,8 @@ libhwcomposer_la_LIBADD = \
 	$(DRM_LIBS) \
 	$(GBM_LIBS) \
 	$(EGL_LIBS) \
+        $(top_builddir)/common/libhwcomposer_common.la \
+        $(top_builddir)/wsi/libhwcomposer_wsi.la \
 	-lm
 
 libhwcomposer_la_LTLIBRARIES = libhwcomposer.la


### PR DESCRIPTION
The workaround of whole static link didn't use the .la file in
section of "la_LIBADD", which caused the libhwcomposer didn't
build when the two static libs got updates. Now, added the .la
to the let libtool aware timestamp changed in two static libs.
Android didn't use this WA as Android mk file has its own var
LOCAL_WHOLE_STATIC_LIBRARIES.

Jira: GSE-19
Test: Build HWC for Linux, then do some changes in common or wsi,
      and build again(just do make) to check if the new changes
      be applied in libhwcomposer and testlayers.

Signed-off-by: Yugang Fan <yugang.fan@intel.com>