### PR TITLE
Fix the external display not init when start Android UI.

### DIFF
--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -75,8 +75,8 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
         "to true. %p hotplugdisplayid: %d \n",
         this, hot_plug_display_id_);
     hotplug_callback_->Callback(hot_plug_display_id_, true);
+    display_state_ &= ~kNotifyClient;
   }
-  display_state_ &= ~kNotifyClient;
   SPIN_UNLOCK(modeset_lock_);
 }
 
@@ -90,6 +90,7 @@ void PhysicalDisplay::NotifyClientOfDisConnectedState() {
         "to false. %p hotplugdisplayid: %d \n",
         this, hot_plug_display_id_);
     hotplug_callback_->Callback(hot_plug_display_id_, false);
+    display_state_ &= ~kNotifyClient;
   }
   SPIN_UNLOCK(modeset_lock_);
 }


### PR DESCRIPTION
Jira: GSE-35
Test: Connect more than one display of Android platform and
      boot the device, the all display will show same cloned
      content.

Signed-off-by: Yugang Fan <yugang.fan@intel.com>