### PR TITLE
Android: Add setColorTransform to HWC2 to enable color correction

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -51,6 +51,8 @@ DisplayQueue::DisplayQueue(uint32_t gpu_fd, bool disable_overlay,
 
   /* use 0x80 as default brightness for all colors */
   brightness_ = 0x808080;
+  /* use HWCColorTransform::kIdentical as default color transform hint */
+  color_transform_hint_ = HWCColorTransform::kIdentical;
   /* use 0x80 as default brightness for all colors */
   contrast_ = 0x808080;
   /* use 1 as default gamma value */
@@ -438,6 +440,7 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     render_layers = display_plane_manager_->ValidateLayers(
         layers, cursor_layers, state_ & kConfigurationChanged,
         idle_frame || disable_ovelays, current_composition_planes);
+
     state_ &= ~kConfigurationChanged;
     bool gpu_rendered = true;
     for (uint32_t i = 0; i < total_cursor_layers_; i++) {
@@ -491,7 +494,8 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
   }
 #endif
   if (state_ & kNeedsColorCorrection) {
-    display_->SetColorCorrection(gamma_, contrast_, brightness_);
+    display_->SetColorCorrection(gamma_, contrast_, brightness_,
+                                 color_transform_matrix_, color_transform_hint_);
     state_ &= ~kNeedsColorCorrection;
   }
 
@@ -712,6 +716,16 @@ void DisplayQueue::SetGamma(float red, float green, float blue) {
   gamma_.red = red;
   gamma_.green = green;
   gamma_.blue = blue;
+  state_ |= kNeedsColorCorrection;
+}
+
+void DisplayQueue::SetColorTransform(const float *matrix, HWCColorTransform hint) {
+  color_transform_hint_ = hint;
+
+  if (hint == HWCColorTransform::kArbitraryMatrix) {
+    memcpy(color_transform_matrix_, matrix, sizeof(color_transform_matrix_));
+  }
+
   state_ |= kNeedsColorCorrection;
 }
 

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -59,6 +59,7 @@ class DisplayQueue {
   bool SetPowerMode(uint32_t power_mode);
   bool CheckPlaneFormat(uint32_t format);
   void SetGamma(float red, float green, float blue);
+  void SetColorTransform(const float *matrix, HWCColorTransform hint);
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue);
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue);
   void SetExplicitSyncSupport(bool disable_explicit_sync);
@@ -233,6 +234,8 @@ class DisplayQueue {
   uint32_t frame_;
   uint32_t gpu_fd_;
   uint32_t brightness_;
+  float color_transform_matrix_[16];
+  HWCColorTransform color_transform_hint_;
   uint32_t contrast_;
   uint32_t total_cursor_layers_ = 0;
   int32_t kms_fence_ = 0;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -25,6 +25,7 @@
 #include <cutils/properties.h>
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer2.h>
+#include <system/graphics.h>
 
 #include <gpudevice.h>
 #include <hwcdefs.h>
@@ -680,7 +681,19 @@ HWC2::Error IAHWC2::HwcDisplay::SetColorTransform(const float *matrix,
                                                   int32_t hint) {
   supported(__func__);
   // TODO: Force client composition if we get this
-  return unsupported(__func__, matrix, hint);
+
+  if (hint != HAL_COLOR_TRANSFORM_IDENTITY &&
+      hint != HAL_COLOR_TRANSFORM_ARBITRARY_MATRIX &&
+      hint != HAL_COLOR_TRANSFORM_VALUE_INVERSE &&
+      hint != HAL_COLOR_TRANSFORM_GRAYSCALE &&
+      hint != HAL_COLOR_TRANSFORM_CORRECT_PROTANOPIA &&
+      hint != HAL_COLOR_TRANSFORM_CORRECT_DEUTERANOPIA &&
+      hint != HAL_COLOR_TRANSFORM_CORRECT_TRITANOPIA)
+    return HWC2::Error::BadParameter;
+
+  display_->SetColorTransform(matrix, (HWCColorTransform)hint);
+
+  return HWC2::Error::None;
 }
 
 HWC2::Error IAHWC2::HwcDisplay::SetOutputBuffer(buffer_handle_t buffer,

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -71,5 +71,10 @@ enum DisplayPowerMode {
                     // updates from the client
 };
 
+enum HWCColorTransform {
+  kIdentical = 0,       // Applies no transform to the output color
+  kArbitraryMatrix = 1  // Applies an arbitrary transform defined by a 4x4 affine matrix
+};
+
 }  // namespace hwcomposer
 #endif  // PUBLIC_HWCDEFS_H_

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -141,6 +141,33 @@ class NativeDisplay {
   */
   virtual void SetGamma(float /*red*/, float /*green*/, float /*blue*/) {
   }
+
+  /**
+  * API for setting a color transform which will be applied after composition.
+  *
+  * The matrix provided is an affine color transformation of the following form:
+  *
+  * |r.r r.g r.b 0|
+  * |g.r g.g g.b 0|
+  * |b.r b.g b.b 0|
+  * |Tr  Tg  Tb  1|
+  *
+  * This matrix will be provided in row-major form: {r.r, r.g, r.b, 0, g.r, ...}.
+  *
+  * Given a matrix of this form and an input color [R_in, G_in, B_in], the output
+  * color [R_out, G_out, B_out] will be:
+  *
+  * R_out = R_in * r.r + G_in * g.r + B_in * b.r + Tr
+  * G_out = R_in * r.g + G_in * g.g + B_in * b.g + Tg
+  * B_out = R_in * r.b + G_in * g.b + B_in * b.b + Tb
+  *
+  * @param matrix a 4x4 transform matrix (16 floats) as described above
+  * @param hint a hint value to specify the transform type, applying no transform
+  *        or applying transform defined by given matrix
+  */
+  virtual void SetColorTransform(const float * /*matrix*/, HWCColorTransform /*hint*/) {
+  }
+
   /**
   * API for setting display color contrast in HWC
   * @param red valid value is 0 ~ 255, bigger value with stronger contrast

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -51,8 +51,11 @@ class DrmDisplay : public PhysicalDisplay {
   bool InitializeDisplay() override;
   void PowerOn() override;
   void UpdateDisplayConfig() override;
-  void SetColorCorrection(struct gamma_colors gamma, uint32_t contrast,
-                          uint32_t brightness) const override;
+  void SetColorCorrection(struct gamma_colors gamma,
+                          uint32_t contrast,
+                          uint32_t brightness,
+                          const float *color_transform_matrix,
+                          HWCColorTransform color_transform_hint) const override;
   void Disable(const DisplayPlaneStateList &composition_planes) override;
   bool Commit(const DisplayPlaneStateList &composition_planes,
               const DisplayPlaneStateList &previous_composition_planes,
@@ -91,6 +94,11 @@ class DrmDisplay : public PhysicalDisplay {
   float TransformGamma(float value, float gamma) const;
   float TransformContrastBrightness(float value, float brightness,
                                     float contrast) const;
+  int64_t FloatToFixedPoint(float value) const;
+  void SetColorTransformMatrix(const float *color_transform_matrix,
+                               HWCColorTransform color_transform_hint) const;
+  void ApplyPendingCTM(struct drm_color_ctm *ctm,
+                       struct drm_color_ctm_post_offset *ctm_post_offset) const;
   void ApplyPendingLUT(struct drm_color_lut *lut) const;
   bool ApplyPendingModeset(drmModeAtomicReqPtr property_set);
   bool GetFence(drmModeAtomicReqPtr property_set, int32_t *out_fence);
@@ -105,6 +113,8 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t mmHeight_ = 0;
   uint32_t out_fence_ptr_prop_ = 0;
   uint32_t dpms_prop_ = 0;
+  uint32_t ctm_id_prop_ = 0;
+  uint32_t ctm_post_offset_id_prop_ = 0;
   uint32_t lut_id_prop_ = 0;
   uint32_t crtc_prop_ = 0;
   uint32_t broadcastrgb_id_ = 0;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -387,6 +387,10 @@ void PhysicalDisplay::SetGamma(float red, float green, float blue) {
   display_queue_->SetGamma(red, green, blue);
 }
 
+void PhysicalDisplay::SetColorTransform(const float *matrix, HWCColorTransform hint) {
+  display_queue_->SetColorTransform(matrix, hint);
+}
+
 void PhysicalDisplay::SetContrast(uint32_t red, uint32_t green, uint32_t blue) {
   display_queue_->SetContrast(red, green, blue);
 }

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -81,6 +81,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool CheckPlaneFormat(uint32_t format) override;
   void SetGamma(float red, float green, float blue) override;
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue) override;
+  void SetColorTransform(const float *matrix, HWCColorTransform hint) override;
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue) override;
   void SetExplicitSyncSupport(bool disable_explicit_sync) override;
 
@@ -120,8 +121,11 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   /**
   * API for setting color correction for display.
   */
-  virtual void SetColorCorrection(struct gamma_colors gamma, uint32_t contrast,
-                                  uint32_t brightness) const = 0;
+  virtual void SetColorCorrection(struct gamma_colors gamma,
+                                  uint32_t contrast,
+                                  uint32_t brightness,
+                                  const float *color_transform_matrix,
+                                  HWCColorTransform color_transform_hint) const = 0;
 
   /**
   * API is called when display needs to be disabled.


### PR DESCRIPTION
Get 4x4 color transform matrix (CTM) from SurfaceFlinger, and convert
the matrix to 3x3 DRM CSC matrix.

Jira: OAM-49721
Test: Go to Settings-Accessibility-Color correction, set it to On
and choose the Correction mode.