### PR TITLE
Added Exit function to handle the display Disconnect

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -92,6 +92,16 @@ bool DisplayQueue::Initialize(uint32_t pipe, uint32_t width, uint32_t height,
   return true;
 }
 
+bool DisplayQueue::Exit(uint32_t power_mode) {
+  if (power_mode != kOff) {
+    HandleExit();
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
 bool DisplayQueue::SetPowerMode(uint32_t power_mode) {
   switch (power_mode) {
     case kOff:
@@ -656,9 +666,7 @@ void DisplayQueue::HandleExit() {
   state_ |= kIgnoreIdleRefresh;
   power_mode_lock_.unlock();
   vblank_handler_->SetPowerMode(kOff);
-  if (!previous_plane_state_.empty()) {
-    display_->Disable(previous_plane_state_);
-  }
+  display_->Disable();
 
   std::vector<OverlayLayer>().swap(in_flight_layers_);
   DisplayPlaneStateList().swap(previous_plane_state_);

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -54,6 +54,7 @@ class DisplayQueue {
 
   bool Initialize(uint32_t pipe, uint32_t width, uint32_t height,
                   DisplayPlaneHandler* plane_manager);
+  bool Exit(uint32_t power_mode);
 
   bool QueueUpdate(std::vector<HwcLayer*>& source_layers, int32_t* retire_fence,
                    bool idle_update);

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -537,14 +537,8 @@ bool DrmDisplay::GetFence(drmModeAtomicReqPtr property_set,
   return true;
 }
 
-void DrmDisplay::Disable(const DisplayPlaneStateList &composition_planes) {
+void DrmDisplay::Disable() {
   IHOTPLUGEVENTTRACE("Disable: Disabling Display: %p", this);
-
-  for (const DisplayPlaneState &comp_plane : composition_planes) {
-    DrmPlane *plane = static_cast<DrmPlane *>(comp_plane.plane());
-    plane->SetEnabled(false);
-    plane->SetNativeFence(-1);
-  }
 
   drmModeConnectorSetProperty(gpu_fd_, connector_, dpms_prop_,
                               DRM_MODE_DPMS_OFF);

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -53,7 +53,7 @@ class DrmDisplay : public PhysicalDisplay {
   void UpdateDisplayConfig() override;
   void SetColorCorrection(struct gamma_colors gamma, uint32_t contrast,
                           uint32_t brightness) const override;
-  void Disable(const DisplayPlaneStateList &composition_planes) override;
+  void Disable() override;
   bool Commit(const DisplayPlaneStateList &composition_planes,
               const DisplayPlaneStateList &previous_composition_planes,
               bool disable_explicit_fence, int32_t *commit_fence) override;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -110,21 +110,16 @@ void PhysicalDisplay::DisConnect() {
 
   display_state_ &= ~kDisconnectionInProgress;
 
-  if (!(display_state_ & kConnected)) {
+  if (!display_queue_->Exit(power_mode_)) {
     SPIN_UNLOCK(modeset_lock_);
-
     return;
   }
+
   IHOTPLUGEVENTTRACE(
       "PhysicalDisplay DisConnect called for Display: %p hotplugdisplayid: %d "
       "\n",
       this, hot_plug_display_id_);
   display_state_ |= kNotifyClient;
-
-  if (power_mode_ != kOff) {
-    display_queue_->SetPowerMode(kOff);
-  }
-
   display_state_ &= ~kConnected;
   display_state_ &= ~kUpdateDisplay;
   SPIN_UNLOCK(modeset_lock_);

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -124,7 +124,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   * @param composition_planes contains list of planes enabled last
   * frame.
   */
-  virtual void Disable(const DisplayPlaneStateList &composition_planes) = 0;
+  virtual void Disable() = 0;
 
   /**
   * API for showing content on display


### PR DESCRIPTION
Add Exit function in the displayqueue to handle the Display Disconnect and also
did small code cleanup in the display disable

Jira: None
Tests: Hotplug and suspend/resume works fine
Signed-off-by: Pallavi G <pallavi.g@intel.com>