### PR TITLE
Ensure VA processing the buffer with correct crop/frame

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -81,11 +81,7 @@ bool Compositor::Draw(DisplayPlaneStateList &comp_planes,
       state.surface_ = plane.GetOffScreenTarget();
       MediaState &media_state = state.media_state_;
       const OverlayLayer &layer = layers[plane.source_layers().at(0)];
-      media_state.source_buffer_ = layer.GetBuffer();
-      media_state.frame_width_ = layer.GetDisplayFrameWidth();
-      media_state.frame_height_ = layer.GetDisplayFrameHeight();
-      media_state.out_width_ = layer.GetSourceCropWidth();
-      media_state.out_height_ = layer.GetSourceCropHeight();
+      media_state.layer_ = &layer;
     } else if (plane.GetCompositionState() ==
                DisplayPlaneState::State::kRender) {
       comp = &plane;

--- a/common/compositor/renderstate.h
+++ b/common/compositor/renderstate.h
@@ -58,11 +58,7 @@ struct RenderState {
 };
 
 struct MediaState {
-  const OverlayBuffer *source_buffer_;
-  uint32_t frame_width_;
-  uint32_t frame_height_;
-  uint32_t out_width_;
-  uint32_t out_height_;
+  const OverlayLayer *layer_;
 };
 
 struct DrawState {


### PR DESCRIPTION
The surface region for VA input must be from layer's SourceCrop
and the output region for VA output must be from layer's DisplayFrame

Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>