### PR TITLE
Enable build testlayers for Android with hwc's static lib

### DIFF
--- a/Android.static.mk
+++ b/Android.static.mk
@@ -1,0 +1,161 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+ifeq ($(strip $(BOARD_USES_IA_HWCOMPOSER)), true)
+# Obtain root HWC source path
+HWC_PATH := $(call my-dir)
+
+HWC_VERSION_GIT_BRANCH := $(shell pushd $(HWC_PATH) > /dev/null; git rev-parse --abbrev-ref HEAD; popd > /dev/null)
+HWC_VERSION_GIT_SHA := $(shell pushd $(HWC_PATH) > /dev/null; git rev-parse HEAD; popd > /dev/null)
+
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := \
+        libhwcomposer_common \
+        libhwcomposer_wsi
+
+LOCAL_SHARED_LIBRARIES := \
+	libcutils \
+	libdrm \
+	libEGL \
+	libGLESv2 \
+	libhardware \
+	liblog \
+	libui \
+	libutils \
+        libhwcservice \
+	libbinder
+
+LOCAL_C_INCLUDES := \
+	system/core/include/utils \
+	$(LOCAL_PATH)/public \
+	$(LOCAL_PATH)/common/core \
+	$(LOCAL_PATH)/common/compositor \
+	$(LOCAL_PATH)/common/compositor/gl \
+	$(LOCAL_PATH)/common/display \
+	$(LOCAL_PATH)/common/utils \
+	$(LOCAL_PATH)/os \
+	$(LOCAL_PATH)/os/android \
+	$(LOCAL_PATH)/wsi \
+	$(LOCAL_PATH)/wsi/drm
+
+LOCAL_SRC_FILES := \
+	os/android/platformdefines.cpp
+
+ifeq ($(strip $(TARGET_USES_HWC2)), true)
+LOCAL_SRC_FILES += os/android/iahwc2.cpp \
+                   os/android/hwcservice.cpp
+else
+LOCAL_SRC_FILES += os/android/iahwc1.cpp
+LOCAL_C_INCLUDES += \
+        system/core/libsync \
+        system/core/libsync/include
+
+LOCAL_SHARED_LIBRARIES += \
+        libsync
+
+LOCAL_CPPFLAGS += -DENABLE_DOUBLE_BUFFERING
+endif
+
+ifeq ($(strip $(BOARD_USES_GRALLOC1)), true)
+LOCAL_SRC_FILES += os/android/gralloc1bufferhandler.cpp
+else
+LOCAL_SRC_FILES += os/android/grallocbufferhandler.cpp
+endif
+
+LOCAL_CPPFLAGS += \
+	-DHWC_VERSION_GIT_BRANCH="\"$(HWC_VERSION_GIT_BRANCH)\"" \
+	-DHWC_VERSION_GIT_SHA="\"$(HWC_VERSION_GIT_SHA)\"" \
+	-DHWC2_INCLUDE_STRINGIFICATION \
+	-DHWC2_USE_CPP11 \
+	-Wno-date-time \
+	-DUSE_ANDROID_SHIM \
+	-D_FORTIFY_SOURCE=2 \
+	-fstack-protector-strong \
+	-Wformat -Wformat-security \
+	-std=c++14 -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+	-Wall -Wsign-compare -Wpointer-arith \
+	-Wcast-qual -Wcast-align \
+	-D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+	-O3
+
+ifeq ($(strip $(BOARD_DISABLE_NATIVE_COLOR_MODES)), true)
+LOCAL_CPPFLAGS += -DDISABLE_NATIVE_COLOR_MODES
+endif
+
+ifeq ($(strip $(BOARD_USES_VULKAN)), true)
+LOCAL_SHARED_LIBRARIES += \
+        libvulkan
+
+LOCAL_CPPFLAGS += \
+        -DUSE_VK \
+        -DDISABLE_EXPLICIT_SYNC
+
+LOCAL_C_INCLUDES += \
+        $(LOCAL_PATH)/common/compositor/vk \
+        $(LOCAL_PATH)/../mesa/include
+else
+LOCAL_CPPFLAGS += \
+        -DUSE_GL
+endif
+
+ifeq ($(strip $(BOARD_USES_LIBVA)), true)
+LOCAL_C_INCLUDES += \
+	$(LOCAL_PATH)/common/compositor/va
+
+LOCAL_SHARED_LIBRARIES += \
+	libva \
+	libva-android
+endif
+
+ifeq ($(strip $(BOARD_USES_MINIGBM)), true)
+LOCAL_CPPFLAGS += -DUSE_MINIGBM
+LOCAL_C_INCLUDES += \
+	$(INTEL_MINIGBM)/cros_gralloc/
+else
+LOCAL_C_INCLUDES += \
+	$(INTEL_DRM_GRALLOC)
+endif
+
+LOCAL_MODULE := libhwcomposer.$(TARGET_BOARD_PLATFORM)
+include $(BUILD_STATIC_LIBRARY)
+
+# Static lib: libhwcomposer_common and libhwcomposer_wsi
+include $(HWC_PATH)/common/Android.mk
+include $(HWC_PATH)/wsi/Android.mk
+
+ifeq ($(strip $(TARGET_USES_HWC2)), true)
+# libhwcservice
+HWC_BUILD_DIRS := \
+$(HWC_PATH)/os/android/libhwcservice/Android.mk \
+$(HWC_PATH)/os/android/libhwcservice/utils/Android.mk
+
+include $(HWC_BUILD_DIRS)
+
+# Include tests only if eng build
+ifneq (,$(filter eng,$(TARGET_BUILD_VARIANT)))
+#include $(HWC_PATH)/tests/hwc-val/tests/hwc/Android.mk
+endif
+
+endif
+
+# Include tests only if eng build
+ifneq (,$(filter eng,$(TARGET_BUILD_VARIANT)))
+# Commenting for now include when ld issue is resolved
+#include $(HWC_PATH)/tests/third_party/json-c/Android.mk
+endif
+
+endif

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -154,7 +154,6 @@ void *Gralloc1BufferHandler::Map(HWCNativeHandle handle, uint32_t x,
       reinterpret_cast<gralloc1_device_t *>(device_);
   uint32_t status = lock_(gralloc1_dvc, handle->imported_handle_, GRALLOC_USAGE_SW_READ_RARELY,
           GRALLOC_USAGE_SW_READ_RARELY, &rect, map_data, acquireFence);
-  ALOGI("%s - lock returned: %u", __FUNCTION__, status);
   return (GRALLOC1_ERROR_NONE == status) ? *map_data : NULL;
 }
 

--- a/tests/Android.mk
+++ b/tests/Android.mk
@@ -6,7 +6,7 @@ TARGET_BOARD_PLATFORM := android_ia
 
 
 LOCAL_REQUIRED_MODULES := libjson-c \
-                          hwcomposer.$(TARGET_BOARD_PLATFORM)
+                          libhwcomposer.$(TARGET_BOARD_PLATFORM)
 #LOCAL_LDLIBS   += -L$(PRODUCT_OUT)/vendor/lib/hw/ -l:gralloc.android_ia.so -l:hwcomposer.android_ia.so
 
 
@@ -27,6 +27,9 @@ LOCAL_CPPFLAGS += \
 	-fstack-protector-strong \
 	-fPIE -Wformat -Wformat-security
 
+LOCAL_WHOLE_STATIC_LIBRARIES := \
+  libhwcomposer.$(TARGET_BOARD_PLATFORM)
+
 LOCAL_SHARED_LIBRARIES := \
 	libcutils \
 	libdrm \
@@ -37,8 +40,15 @@ LOCAL_SHARED_LIBRARIES := \
 	libsync \
 	libui \
 	libutils \
-	libjson-c \
-	libhwcomposer.$(TARGET_BOARD_PLATFORM)
+	libjson-c
+
+ifeq ($(strip $(BOARD_USES_LIBVA)), true)
+
+LOCAL_SHARED_LIBRARIES += \
+  libva \
+  libva-android
+
+endif
 
 LOCAL_C_INCLUDES := \
 	system/core/include/utils \
@@ -102,5 +112,5 @@ json_list := jsonconfigs/colorcorrection.json jsonconfigs/kmscube1layer.json \
 
 $(foreach script,$(json_list),$(eval $(call script_to_copy,$(script))))
 
-#include $(LOCAL_PATH)/third_party/json-c/Android.mk
+include $(LOCAL_PATH)/../Android.static.mk
 endif

--- a/tests/third_party/json-c/Android.mk
+++ b/tests/third_party/json-c/Android.mk
@@ -54,4 +54,3 @@ LOCAL_ARM_MODE:=arm
 
 include $(BUILD_SHARED_LIBRARY)
 
-include $(LOCAL_PATH)/../../Android.mk


### PR DESCRIPTION
As Android build system doesn't recognize shared library name like
hwcomposer.xx.so, previously in order to build testlayers we have to
modify Android.mk to rename hwcomposer.xx.so to libhwcomposer.xx.so.
This patch provides an easy way to build testlayers without renaming
the library name back and forth.

Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>