### PR TITLE
Fix buffer init issue of logical and mosiac mode.

### DIFF
--- a/common/core/mosiacdisplay.h
+++ b/common/core/mosiacdisplay.h
@@ -122,7 +122,7 @@ class MosiacDisplay : public NativeDisplay {
   bool enable_vsync_ = false;
   bool connected_ = false;
   bool pending_vsync_ = false;
-  bool update_connected_displays_ = false;
+  bool update_connected_displays_ = true;
   SpinLock lock_;
 };
 

--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -701,6 +701,9 @@ int main(int argc, char *argv[]) {
   if (displays.empty())
     return 0;
 
+  callback->SetPowerMode(hwcomposer::kOn);
+  callback->SetActiveConfig(0);
+
   hwcomposer::NativeDisplay *primary = displays.at(0);
   for (size_t i = 1; i < displays.size(); i++) {
     hwcomposer::NativeDisplay *cloned = displays.at(i);


### PR DESCRIPTION
Add set active config and power mode functions before getting attr
of display to fix 0 width value which caused buffer creating issue

Change the update display default value to fix the no content in
display when in mosiac mode.

Jira: None.
Test: Enable logical mode or mosiac mode, the displays can show correct
      content and no error found from commands.

Signed-off-by: Fan, Yugang <yugang.fan@intel.com>