### PR TITLE
Remove vaSyncSurface

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -305,7 +305,6 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   ret = vaBeginPicture(va_display_, va_context, surface_out);
   ret |= vaRenderPicture(va_display_, va_context, &pipeline_buffer.buffer(), 1);
   ret |= vaEndPicture(va_display_, va_context);
-  ret |= vaSyncSurface(va_display_, surface_out);
 
   return ret == VA_STATUS_SUCCESS ? true : false;
 }


### PR DESCRIPTION
vaSyncSurface is not required on intel h/w and it's incompatible with
vpg's driver.

Change-Id: I47392fa972e2b3070be023f7283939496e3620e0
Tracked-On:
Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>