### PR TITLE
Fix build for Android

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -39,7 +39,8 @@ LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/../os \
         $(LOCAL_PATH)/../os/android \
         $(LOCAL_PATH)/../wsi \
-        $(LOCAL_PATH)/../wsi/drm
+        $(LOCAL_PATH)/../wsi/drm \
+        $(TARGET_OUT_HEADERS)/libva
 
 ifeq ($(strip $(BOARD_USES_LIBVA)), true)
 LOCAL_SHARED_LIBRARIES += \


### PR DESCRIPTION
This is needed to find VA header files in 1Android tree.

Change-Id: I0de7e387630b05c14c8772da6ed8c756ed21a96c
Tracked-On:
Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>