### PR TITLE
Add config handling for logical and mosiac.

### DIFF
--- a/hwc_display.ini
+++ b/hwc_display.ini
@@ -1,0 +1,34 @@
+# The switches of logical and mosiac mode.
+
+LOGICAL="false"
+MOSIAC="false"
+
+# Logical display definitions, with format "physical-display-number:split-number"
+# physical-display-number: start from 0, included all display ports(whatever connected or disconnected)
+# split-number: the sub display number you want to split
+
+LOGICAL_DISPLAY="0:3"
+LOGICAL_DISPLAY="1:2"
+
+# Mosiac display definitions, with format "sub-display-index+sub-display-index+sub-display-index....."
+# sub-display-index: start from 0, should be the available displays number, follow the order of the connected logical displays
+
+MOSIAC_DISPLAY="2+5"
+MOSIAC_DISPLAY="0+3+4"
+
+# ------------------------------------------------------------------------------------------------------------------------
+# A typical usages:
+#   there are 3 physical displays(ports? crtc? pipe?), the first one and third one are connected, the second one is disconnected
+#   use:
+#       LOGICAL_DISPLAY="0:3"
+#       LOGICAL_DISPLAY="1:2"
+#   to split the physical displays, the final logical displays number will be "0, 1, 2, 3, 4, 5", "3, 4" belongs to
+#   second physical display and is disconnected, so available displays number are "0, 1, 2, 5"
+#   use:
+#       MOSIAC_DISPLAY="2+5"
+#       MOSIAC_DISPLAY="0+3+4"
+#   the final mosiac display will be (keep the order by the smallest logical display num):
+#       MOSIAC_DISPLAY 0: includes 1 logical display(logical display 0) only
+#       MOSIAC_DISPLAY 1: includes 2 and 5 logical displays (5 is the third physical display without split displays)
+#   the logical display 1 is not used for mosiac display, will be second display of the final available display.
+# ------------------------------------------------------------------------------------------------------------------------

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -18,6 +18,9 @@
 #define PUBLIC_GPUDEVICE_H_
 
 #include <stdint.h>
+#include <fstream>
+#include <string>
+#include <sstream>
 
 #include "displaymanager.h"
 #include "logicaldisplaymanager.h"


### PR DESCRIPTION
The HWC will read the display config for logical and mosiac, the
config file will be pointed out by ENV var HWC_DISPLAY_CONFIG, and
use default path /etc/hwc_display.ini if no HWC_DISPLAY_CONFIG found.

Pls see comments of the config for detailed config format and usages.

Jira: None.
Test: Change the config file and connect some displays, the cube test
      can show logical and mosiac normally according to the config
      parameters.

Signed-off-by: Fan, Yugang <yugang.fan@intel.com>