### PR TITLE
Fix the issue that the HWCLock thread will not exit.

### DIFF
--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -130,6 +130,9 @@ bool DrmDisplayManager::Initialize() {
     return true;
   }
 
+  int flags = fcntl(hotplug_fd_, F_GETFL, 0);
+  fcntl(hotplug_fd_, F_SETFL, flags | O_NONBLOCK);
+
   fd_handler_.AddFd(hotplug_fd_);
 
   if (!InitWorker()) {


### PR DESCRIPTION
The displaymanager thread is blocked in "read" call,
so it will never get chance to disable HWClock.

As we already use "select" to receive the "POLL IN" event of
the fd, we had better to set the "Non Blocking" flag on.

Change-Id: I01bfd52e1c822421b76a1ad7e8b06f1b87ee5371
Signed-off-by: Zhongmin Wu <zhongmin.wu@intel.com>