### PR TITLE
Fix for crash during rotation

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -610,7 +610,9 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
   if (use_cursor_layer) {
     if (z_map.size()) {
       if (z_map.rbegin()->second->z_order() > cursor_z_order)
-        cursor_z_order = (z_map.rbegin()->second->z_order()) + 1;
+        cursor_z_order = z_map.rbegin()->second->z_order() + 1;
+      else if (client_z_order > cursor_z_order)
+        cursor_z_order = client_z_order + 1;
     }
     z_map.emplace(std::make_pair(cursor_z_order, cursor_layer));
   }


### PR DESCRIPTION
The cursor z_order is not the highest in one of the corner case,
so we end up with segmentation fault in cursor layer getbuffer becoz the
hwc implementation is based on the assumption that the cursor is always on the top.

Jira: None
Test: Able to rotate the screen without system reboot
Signed-off-by: Pallavi G <pallavi.g@intel.com>