### PR TITLE
Fix CPU busy caused by HWCLock thread

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -552,8 +552,8 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
 
   // Let Display handle any lazy initalizations.
   if (handle_display_initializations_) {
-    handle_display_initializations_ = false;
-    display_->HandleLazyInitialization();
+    if (display_->HandleLazyInitialization())
+      handle_display_initializations_ = false;
   }
 
   return true;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -708,8 +708,8 @@ void DrmDisplay::ForceRefresh() {
   display_queue_->ForceRefresh();
 }
 
-void DrmDisplay::HandleLazyInitialization() {
-  manager_->HandleLazyInitialization();
+bool DrmDisplay::HandleLazyInitialization() {
+  return manager_->HandleLazyInitialization();
 }
 
 void DrmDisplay::NotifyClientsOfDisplayChangeStatus() {

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -80,7 +80,7 @@ class DrmDisplay : public PhysicalDisplay {
 
   void ForceRefresh();
 
-  void HandleLazyInitialization() override;
+  bool HandleLazyInitialization() override;
 
  private:
   void ShutDownPipe();

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -396,14 +396,17 @@ void DrmDisplayManager::ForceRefresh() {
   spin_lock_.unlock();
 }
 
-void DrmDisplayManager::HandleLazyInitialization() {
+bool DrmDisplayManager::HandleLazyInitialization() {
+  bool dispatched = false;
   spin_lock_.lock();
   if (release_lock_ && hwc_lock_.get()) {
     hwc_lock_->DisableWatch();
     hwc_lock_.reset(nullptr);
     release_lock_ = false;
+    dispatched = true;
   }
   spin_lock_.unlock();
+  return dispatched;
 }
 
 DisplayManager *DisplayManager::CreateDisplayManager() {

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -58,7 +58,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void NotifyClientsOfDisplayChangeStatus();
 
-  void HandleLazyInitialization();
+  bool HandleLazyInitialization();
 
  protected:
   void HandleWait() override;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -194,7 +194,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   * API to handle any lazy initializations which need to be handled
   * during first present call.
   */
-  virtual void HandleLazyInitialization() {
+  virtual bool HandleLazyInitialization() {
+    return false;
   }
 
  private:


### PR DESCRIPTION
It will not exit due to release_lock false
This fix is to ensure HWCLock will exit

Jira: https://jira01.devtools.intel.com/browse/OAM-51903
Test: After install hwcompoper to DUT
use top to see the process CPU usage
Signed-off-by: Lin Johnson <johnson.lin@intel.com>