### PR TITLE
fix the screencap black screen issue

### DIFF
--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -504,10 +504,10 @@ bool PhysicalDisplay::GetDisplayAttribute(uint32_t /*config*/,
   // We always get the values from preferred mode config.
   switch (attribute) {
     case HWCDisplayAttribute::kWidth:
-      *value = 1;
+      *value = 1920;
       break;
     case HWCDisplayAttribute::kHeight:
-      *value = 1;
+      *value = 1080;
       break;
     case HWCDisplayAttribute::kRefreshRate:
       // in nanoseconds


### PR DESCRIPTION
When there is no display to connect device, the original HWC module
will create only 1*1 framebuffer.
So screencap will not works properly, it only can get a black screen.
This will block many test case.

In order to fix this issue, we make the default width and height to
1080p format for most HDMI device use this format.

JIRA: none
TEST: screencap can works well when don't connect any display device
Signed-off-by: Yang Shi <yang.a.shi@intel.com>