### PR TITLE
Fix for Flicker when unlock by pin/pattern

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -164,7 +164,6 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
 
     if (plane_state_render || plane.SurfaceRecycled()) {
       bool clear_surface = false;
-      bool alpha_damaged = false;
       bool content_changed = false;
       const std::vector<size_t>& source_layers = last_plane.source_layers();
       HwcRect<int> surface_damage = HwcRect<int>(0, 0, 0, 0);
@@ -197,11 +196,7 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
           // one layer having alpha = 255 and damaged.
           if (layer.GetBlending() == HWCBlending::kBlendingPremult &&
               layer.GetAlpha() == 255) {
-            if (alpha_damaged) {
               clear_surface = true;
-            } else {
-              alpha_damaged = true;
-            }
           }
         }
       }


### PR DESCRIPTION
Observed screen corruption and flicker when we unlock and go to homescreen.

When we try to do surafce damage optimization for the given layer with alpha
equal to 255(status bar in this case),there is a corruption & flicker.

Made clear_surface true if the layer alpha equal to 255 then no issues.

Jira: None
Test: Tested unlocking directly to the home screen using pin (and pattern).
       No flicker & corruption observed.
Signed-off-by: bshwetha <shwetha.b@intel.com>