### PR TITLE
Fix incorrect region width/height caculration

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -269,15 +269,15 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   HwcRect<float> source_crop = state.layer_->GetSourceCrop();
   surface_region.x = source_crop.left;
   surface_region.y = source_crop.top;
-  surface_region.width = source_crop.right;
-  surface_region.height = source_crop.bottom;
+  surface_region.width = source_crop.right - source_crop.left;
+  surface_region.height = source_crop.bottom - source_crop.top;
   param.surface_region = &surface_region;
 
   HwcRect<int> display_frame = state.layer_->GetDisplayFrame();
   output_region.x = display_frame.left;
   output_region.y = display_frame.top;
-  output_region.width = display_frame.right;
-  output_region.height = display_frame.bottom;
+  output_region.width = display_frame.right - display_frame.left;
+  output_region.height = display_frame.bottom - display_frame.top;
   param.output_region = &output_region;
 
   DUMPTRACE("surface_region: (%d, %d, %d, %d)\n",


### PR DESCRIPTION
in va renderer Draw function

Jira:https://jira01.devtools.intel.com/browse/OAM-52773
Tests: Video should be in the middle even if it does not scale
Signed-off-by: Lin Johnson <johnson.lin@intel.com>