### PR TITLE
Revert "Fix Primary display order issues on Android."

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -287,28 +287,7 @@ bool GpuDevice::Initialize() {
     }
   }
 
-  // Re-order displays based on connection status.
-  std::vector<NativeDisplay *> connected_displays;
-  std::vector<NativeDisplay *> un_connected_displays;
   size = displays.size();
-  for (size_t i = 0; i < size; i++) {
-    NativeDisplay *temp = displays.at(i);
-    if (temp->IsConnected()) {
-      connected_displays.emplace_back(temp);
-    } else {
-      un_connected_displays.emplace_back(temp);
-    }
-  }
-
-  displays.swap(connected_displays);
-
-  if (!un_connected_displays.empty()) {
-    size_t temp = un_connected_displays.size();
-    for (size_t i = 0; i < temp; i++) {
-      displays.emplace_back(un_connected_displays.at(i));
-    }
-  }
-
   for (size_t i = 0; i < size; i++) {
     displays.at(i)->SetDisplayOrder(i);
   }

--- a/hwc_display.ini
+++ b/hwc_display.ini
@@ -5,10 +5,7 @@ MOSAIC="false"
 CLONE="true"
 ROTATION="false"
 
-# The Order of Physical Displays. This along with connection status
-# will be used to determine the order. If display is first in this
-# list but is not connected than it will added to the last.The order
-# is preserved till the next reboot.
+# The Order of Physical Displays.
 PHYSICAL_DISPLAY="0:1:2"
 
 # Rotation of display, with format "physical-display-number:rotation".

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -146,10 +146,22 @@ HWC2::Error IAHWC2::Init() {
   }
 
   std::vector<NativeDisplay *> displays = device_.GetAllDisplays();
-  NativeDisplay *primary_display = displays.at(0);
+  size_t size = displays.size();
+  NativeDisplay *primary_display = NULL;
+  for (size_t i = 0; i < size; i++) {
+    hwcomposer::NativeDisplay *display = displays.at(i);
+    if (display->IsConnected()) {
+      primary_display = display;
+      break;
+    }
+  }
+
+  if (!primary_display) {
+    primary_display = displays.at(0);
+  }
+
   uint32_t external_display_id = 1;
   primary_display_.Init(primary_display, 0, disable_explicit_sync_);
-  size_t size = displays.size();
 
   // Add nested display which is expected to use the output of this display and
   // show it himself. Nested display can be implemented with real HW display.


### PR DESCRIPTION
This reverts commit 4ff7d579227cdfa3c53bb779a03850021359d253.

This patch creates regression of making one display blank when booted
with target connected to than one display

Jira: None
Test: Cold/Warm reboot with displays connected should not result in
        blank screen in any display

Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>