### PR TITLE
Fix Linux build

### DIFF
--- a/common/Makefile.sources
+++ b/common/Makefile.sources
@@ -10,6 +10,7 @@ common_SOURCES =              \
     core/logicaldisplay.cpp \
     core/logicaldisplaymanager.cpp \
     core/mosaicdisplay.cpp \
+    core/nesteddisplay.cpp \
     display/displayqueue.cpp \
     display/displayplanemanager.cpp \
     display/vblankeventhandler.cpp \


### PR DESCRIPTION
Seeing the following linker error on Linux since commit 674b37e8e6:
../.libs/libhwcomposer.so: undefined reference to `hwcomposer::NestedDisplay::NestedDisplay()'

Just need to add the new file to the Makefile

Jira: None
Test: Build passes on Linux

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>