### PR TITLE
Add P010 pixel format support in VARenderer

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -323,6 +323,8 @@ int VARenderer::DrmFormatToVAFormat(int format) {
       return VA_FOURCC_UYVY;
     case DRM_FORMAT_YUYV:
       return VA_FOURCC_YUY2;
+    case DRM_FORMAT_P010:
+      return VA_FOURCC_P010;
     case DRM_FORMAT_YVYU:
     case DRM_FORMAT_VYUY:
     case DRM_FORMAT_YUV444:
@@ -347,6 +349,8 @@ int VARenderer::DrmFormatToRTFormat(int format) {
       return VA_RT_FORMAT_YUV422;
     case DRM_FORMAT_YUV444:
       return VA_RT_FORMAT_YUV444;
+    case DRM_FORMAT_P010:
+      return VA_RT_FORMAT_YUV420_10BPP;
     default:
       break;
   }


### PR DESCRIPTION
p010 pixel format support in VARenderer is needed to support
playing back 10bits video

Change-Id: Ib7197a286ad9f37672da605ab1f98d4e4436943d
Jira: None
Test: Build passed on both Android & Linux and works as expected
Tracked-On:
Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>