### PR TITLE
Don't create VA context for each drawing

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -285,6 +285,11 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   param.filters = nullptr;
   param.filter_flags = VA_FRAME_PICTURE;
 
+  // currently rotation is only supported by VA on Android.
+#ifdef ANDROID
+  param.rotation_state = HWCTransformToVA(state.layer_->GetTransform());
+#endif
+
   VAProcFilterCapColorBalance vacaps[VAProcColorBalanceCount];
   uint32_t vacaps_num = VAProcColorBalanceCount;
 
@@ -424,6 +429,20 @@ void VARenderer::DestroyContext() {
     vaDestroyConfig(va_display_, va_config_);
     va_config_ = VA_INVALID_ID;
   }
+}
+
+uint32_t VARenderer::HWCTransformToVA(uint32_t transform) {
+  switch (transform) {
+    case kTransform270:
+      return VA_ROTATION_270;
+    case kTransform180:
+      return VA_ROTATION_180;
+    case kTransform90:
+      return VA_ROTATION_90;
+    default:
+      break;
+  }
+  return VA_ROTATION_NONE;
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -19,8 +19,6 @@
 
 #include <xf86drm.h>
 #include <drm_fourcc.h>
-#include <va/va.h>
-#include <va/va_vpp.h>
 #include <va/va_drmcommon.h>
 #ifdef ANDROID
 #include <va/va_android.h>
@@ -50,6 +48,7 @@ class ScopedVASurfaceID {
   }
 
   bool CreateSurface(int format, VASurfaceAttribExternalBuffers& external) {
+    CTRACE();
     VASurfaceAttrib attribs[2];
     attribs[0].flags = VA_SURFACE_ATTRIB_SETTABLE;
     attribs[0].type = VASurfaceAttribMemoryType;
@@ -79,69 +78,6 @@ class ScopedVASurfaceID {
   VASurfaceID surface_ = VA_INVALID_ID;
 };
 
-class ScopedVAConfigID {
- public:
-  ScopedVAConfigID(VADisplay display) : display_(display) {
-  }
-  ~ScopedVAConfigID() {
-    if (config_ != VA_INVALID_ID) {
-      vaDestroyConfig(display_, config_);
-    }
-  }
-
-  bool CreateConfig(int format) {
-    VAConfigAttrib config_attrib;
-    config_attrib.type = VAConfigAttribRTFormat;
-    config_attrib.value = format;
-    VAStatus ret =
-        vaCreateConfig(display_, VAProfileNone, VAEntrypointVideoProc,
-                       &config_attrib, 1, &config_);
-    return ret == VA_STATUS_SUCCESS ? true : false;
-  }
-
-  operator VAConfigID() const {
-    return config_;
-  }
-
-  VAConfigID config() const {
-    return config_;
-  }
-
- private:
-  VADisplay display_;
-  VAConfigID config_ = VA_INVALID_ID;
-};
-
-class ScopedVAContextID {
- public:
-  ScopedVAContextID(VADisplay display) : display_(display) {
-  }
-  ~ScopedVAContextID() {
-    if (context_ != VA_INVALID_ID) {
-      vaDestroyContext(display_, context_);
-    }
-  }
-
-  bool CreateContext(VAConfigID config, int width, int height,
-                     VASurfaceID render_target) {
-    VAStatus ret = vaCreateContext(display_, config, width, height, 0x00,
-                                   &render_target, 1, &context_);
-    return ret == VA_STATUS_SUCCESS ? true : false;
-  }
-
-  operator VAContextID() const {
-    return context_;
-  }
-
-  VAContextID context() const {
-    return context_;
-  }
-
- private:
-  VADisplay display_;
-  VAContextID context_ = VA_INVALID_ID;
-};
-
 class ScopedVABufferID {
  public:
   ScopedVABufferID(VADisplay display) : display_(display) {
@@ -153,6 +89,7 @@ class ScopedVABufferID {
 
   bool CreateBuffer(VAContextID context, VABufferType type, uint32_t size,
                     uint32_t num, void* data) {
+    CTRACE();
     VAStatus ret =
         vaCreateBuffer(display_, context, type, size, num, data, &buffer_);
     return ret == VA_STATUS_SUCCESS ? true : false;
@@ -176,6 +113,8 @@ class ScopedVABufferID {
 };
 
 VARenderer::~VARenderer() {
+  DestroyContext();
+
   if (va_display_) {
     vaTerminate(va_display_);
   }
@@ -253,6 +192,7 @@ bool VARenderer::SetVAProcFilterColorValue(HWCColorControl mode, float value) {
 }
 
 bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
+  CTRACE();
   VASurfaceAttribExternalBuffers external_in;
   memset(&external_in, 0, sizeof(external_in));
   const OverlayBuffer* buffer_in = state.layer_->GetBuffer();
@@ -304,15 +244,13 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
     return false;
   }
 
-  ScopedVAConfigID va_config(va_display_);
-  if (!va_config.CreateConfig(rt_format)) {
-    return false;
-  }
-
-  ScopedVAContextID va_context(va_display_);
-  if (!va_context.CreateContext(va_config, dest_width, dest_height,
-                                surface_out)) {
-    return false;
+  if (va_context_ == VA_INVALID_ID || render_target_format_ != rt_format) {
+    DTRACE("to create VA context\n");
+    render_target_format_ = rt_format;
+    if (!CreateContext()) {
+      ETRACE("Create VA context failed\n");
+      return false;
+    }
   }
 
   VAProcPipelineParameterBuffer param;
@@ -351,7 +289,7 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   uint32_t vacaps_num = VAProcColorBalanceCount;
 
   if (caps_.empty()) {
-    if (!QueryVAProcFilterCaps(va_context, VAProcFilterColorBalance, vacaps,
+    if (!QueryVAProcFilterCaps(va_context_, VAProcFilterColorBalance, vacaps,
                                &vacaps_num)) {
       return false;
     } else {
@@ -377,7 +315,7 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
       cbparam.value = itr->second.value;
       cbparam.attrib = itr->second.caps.type;
       if (!cb_elements[static_cast<int>(itr->first)].CreateBuffer(
-              va_context, VAProcFilterParameterBufferType,
+              va_context_, VAProcFilterParameterBufferType,
               sizeof(VAProcFilterParameterBufferColorBalance), 1, &cbparam)) {
         return false;
       }
@@ -392,15 +330,16 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
 
   ScopedVABufferID pipeline_buffer(va_display_);
   if (!pipeline_buffer.CreateBuffer(
-          va_context, VAProcPipelineParameterBufferType,
+          va_context_, VAProcPipelineParameterBufferType,
           sizeof(VAProcPipelineParameterBuffer), 1, &param)) {
     return false;
   }
 
   VAStatus ret = VA_STATUS_SUCCESS;
-  ret = vaBeginPicture(va_display_, va_context, surface_out);
-  ret |= vaRenderPicture(va_display_, va_context, &pipeline_buffer.buffer(), 1);
-  ret |= vaEndPicture(va_display_, va_context);
+  ret = vaBeginPicture(va_display_, va_context_, surface_out);
+  ret |=
+      vaRenderPicture(va_display_, va_context_, &pipeline_buffer.buffer(), 1);
+  ret |= vaEndPicture(va_display_, va_context_);
 
   return ret == VA_STATUS_SUCCESS ? true : false;
 }
@@ -451,6 +390,40 @@ int VARenderer::DrmFormatToRTFormat(int format) {
       break;
   }
   return 0;
+}
+
+bool VARenderer::CreateContext() {
+  DestroyContext();
+
+  VAConfigAttrib config_attrib;
+  config_attrib.type = VAConfigAttribRTFormat;
+  config_attrib.value = render_target_format_;
+  VAStatus ret =
+      vaCreateConfig(va_display_, VAProfileNone, VAEntrypointVideoProc,
+                     &config_attrib, 1, &va_config_);
+  if (ret != VA_STATUS_SUCCESS) {
+    ETRACE("Create VA Config failed\n");
+    return false;
+  }
+
+  // These parameters are not used in vaCreateContext so just set them to dummy
+  // values
+  int width = 1;
+  int height = 1;
+  ret = vaCreateContext(va_display_, va_config_, width, height, 0x00,
+                        nullptr, 0, &va_context_);
+  return ret == VA_STATUS_SUCCESS ? true : false;
+}
+
+void VARenderer::DestroyContext() {
+  if (va_context_ != VA_INVALID_ID) {
+    vaDestroyContext(va_display_, va_context_);
+    va_context_ = VA_INVALID_ID;
+  }
+  if (va_config_ != VA_INVALID_ID) {
+    vaDestroyConfig(va_display_, va_config_);
+    va_config_ = VA_INVALID_ID;
+  }
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -60,8 +60,9 @@ class VARenderer : public Renderer {
                                      VAProcColorBalanceType vamode);
   bool CreateContext();
   void DestroyContext();
+  uint32_t HWCTransformToVA(uint32_t transform);
 
-  void *va_display_ = nullptr;
+  void* va_display_ = nullptr;
   ColorBalanceCapMap caps_;
   int render_target_format_ = VA_RT_FORMAT_YUV420;
   VAContextID va_context_ = VA_INVALID_ID;

--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -18,10 +18,11 @@
 #define COMMON_COMPOSITOR_VA_VARENDERER_H_
 
 #include <map>
+#include <va/va.h>
+#include <va/va_vpp.h>
+
 #include "renderer.h"
 #include "hwcdefs.h"
-#include "va/va.h"
-#include "va/va_vpp.h"
 
 namespace hwcomposer {
 
@@ -57,9 +58,14 @@ class VARenderer : public Renderer {
   int DrmFormatToRTFormat(int format);
   bool MapVAProcFilterColorModetoHwc(HWCColorControl& vppmode,
                                      VAProcColorBalanceType vamode);
+  bool CreateContext();
+  void DestroyContext();
 
-  void* va_display_ = nullptr;
+  void *va_display_ = nullptr;
   ColorBalanceCapMap caps_;
+  int render_target_format_ = VA_RT_FORMAT_YUV420;
+  VAContextID va_context_ = VA_INVALID_ID;
+  VAConfigID va_config_ = VA_INVALID_ID;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
vaCreateContext takes long time to initialize video driver
so we don't create the context in each drawing.

Jira: OAM-54014
Test: Build passes on both Android & Linux and video playback works

Change-Id: I7814874e0414960116c91839d71d1af902077755
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-54014
Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>