### PR TITLE
Fix for external display hot plug/unplug

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -230,7 +230,9 @@ HWC2::Error IAHWC2::RegisterCallback(int32_t descriptor,
   switch (callback) {
     case HWC2::Callback::Hotplug: {
       primary_display_.RegisterHotPlugCallback(data, function);
+#ifdef NESTED_DISPLAY_SUPPORT
       nested_display_.RegisterHotPlugCallback(data, function);
+#endif
       for (size_t i = 0; i < size; ++i) {
         IAHWC2::HwcDisplay *display = extended_displays_.at(i).get();
         display->RegisterHotPlugCallback(data, function);


### PR DESCRIPTION
with current code the nested display is also having the display id of 0
and we are wrongly notifying the plug/unplug of the external display to
the primary display.

Looke like the nested display support is not completed,
So just moved the nested display hotplug notification under the
NESTED_DISPLAY_SUPPORT flag which is not defined

Jira: None
Test: External display Hot plug and unplug works fine
Signed-off-by: Pallavi G <pallavi.g@intel.com>