### PR TITLE
Remove the duplication of the function call

### DIFF
--- a/os/android/hwcservice.cpp
+++ b/os/android/hwcservice.cpp
@@ -55,9 +55,6 @@ bool HwcService::Start(IAHWC2 &hwc) {
     return true;
 
   mpHwc = &hwc;
-#ifdef USE_PROCESS_STATE
-  ProcessState::initWithDriver("/dev/vndbinder");
-#endif
   sp<IServiceManager> sm(defaultServiceManager());
   if (sm->addService(String16(IA_HWC_SERVICE_NAME), this, false)) {
     ALOGE("Failed to start %s service", IA_HWC_SERVICE_NAME);


### PR DESCRIPTION
Process State is already initialized at beginning of the process,
and again calling the same is duplication.

Jira: None
Test: GPA launching 3rd party App shouldn't cause any SIGSEGV
      & also HWC tests should PASS.
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>