### PR TITLE
hash_combine_hwc: get seed parameter as reference.

### DIFF
--- a/os/platformcommondefines.h
+++ b/os/platformcommondefines.h
@@ -34,7 +34,7 @@ VkFormat NativeToVkFormat(int native_format);
 // minigbm specific DRM_FORMAT_YVU420_ANDROID enum
 #define DRM_FORMAT_YVU420_ANDROID fourcc_code('9', '9', '9', '7')
 
-inline void hash_combine_hwc(size_t seed, size_t value) {
+inline void hash_combine_hwc(size_t& seed, size_t value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 


### PR DESCRIPTION
Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>