### PR TITLE
Added Support for 64bit RGB format

### DIFF
--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -57,6 +57,8 @@ static uint32_t GetDrmFormatFromHALFormat(int format) {
       return DRM_FORMAT_ARGB8888;
     case HAL_PIXEL_FORMAT_YV12:
       return DRM_FORMAT_YVU420;
+    case HAL_PIXEL_FORMAT_RGBA_FP16:
+      return DRM_FORMAT_XBGR161616;
     default:
       break;
   }
@@ -160,6 +162,8 @@ static uint32_t DrmFormatToHALFormat(int format) {
       return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
     case DRM_FORMAT_P010:
       return HAL_PIXEL_FORMAT_P010_INTEL;
+    case DRM_FORMAT_XBGR161616:
+      return HAL_PIXEL_FORMAT_RGBA_FP16;
     default:
       return 0;
       break;


### PR DESCRIPTION
One of the CTS test cases expects the support
to create Buffer of type HAL_PIXEL_FORMAT_RGBA_FP16

Jira: None
Tests: Buffer Created successfully.
       CTS command: run cts -m CtsHardwareTestCases

Signed-off-by: Poornima <poornima.y.n@intel.com>