### PR TITLE
NativeDisplay: Add GenerateLayerHash method

### DIFF
--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -181,15 +181,19 @@ class IAHWC2 : public hwc2_device_t {
       return layers_.at(layer);
     }
     hwcomposer::NativeDisplay *GetDisplay();
+    void SetVBlankTimestamp(uint64_t timestamp) {
+      timestamp_ = timestamp;
+    }
 
    private:
     hwcomposer::NativeDisplay *display_ = NULL;
     hwc2_display_t handle_;
     HWC2::DisplayType type_;
-    int layer_idx_ = 0;
+    uint64_t layer_idx_ = 0;
     std::map<hwc2_layer_t, Hwc2Layer> layers_;
     Hwc2Layer client_layer_;
     int32_t color_mode_;
+    uint64_t timestamp_ = 0;
 
     uint32_t frame_no_ = 0;
     // True after validateDisplay

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -304,6 +304,10 @@ class NativeDisplay {
   virtual void HotPlugUpdate(bool /*connected*/) {
   }
 
+  virtual uint64_t GenerateLayerHash(uint64_t addr) {
+    return 0;
+  };
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;
@@ -330,6 +334,7 @@ class NativeDisplay {
   // to individual layers shown by this display.
   virtual void RotateDisplay(HWCRotation /*rotation*/) {
   }
+
 };
 
 /**

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -38,7 +38,9 @@ PhysicalDisplay::PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id)
       width_(0),
       height_(0),
       gpu_fd_(gpu_fd),
-      power_mode_(kOn) {
+      power_mode_(kOn),
+      HashA_(1),
+      HashB_(0) {
 }
 
 PhysicalDisplay::~PhysicalDisplay() {
@@ -577,6 +579,12 @@ bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   *size = std::min<uint32_t>(static_cast<uint32_t>(length + 1), *size);
   strncpy(name, string.c_str(), *size);
   return true;
+}
+
+uint64_t PhysicalDisplay::GenerateLayerHash(uint64_t addr) {
+  (HashA_ > HashB_) ? HashB_++ : HashA_++;
+
+  return addr + HashA_ + HashB_ + pipe_;
 }
 
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -207,6 +207,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
+  uint64_t GenerateLayerHash(uint64_t addr) override;
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();
@@ -255,6 +257,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
+  uint64_t HashA_, HashB_;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
The generate layer hash can be used to generate unique hash values
for the layer id.

Jira: None.
Test:

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>
Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>