### PR TITLE
Layer Hash Generator

### DIFF
--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -186,7 +186,6 @@ class IAHWC2 : public hwc2_device_t {
     hwcomposer::NativeDisplay *display_ = NULL;
     hwc2_display_t handle_;
     HWC2::DisplayType type_;
-    int layer_idx_ = 0;
     std::map<hwc2_layer_t, Hwc2Layer> layers_;
     Hwc2Layer client_layer_;
     int32_t color_mode_;

--- a/os/platformcommondefines.h
+++ b/os/platformcommondefines.h
@@ -25,6 +25,7 @@ VkFormat NativeToVkFormat(int native_format);
 
 #include <hwcbuffer.h>
 
+#include <cmath>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -304,6 +304,20 @@ class NativeDisplay {
   virtual void HotPlugUpdate(bool /*connected*/) {
   }
 
+  virtual int InitializeLayerHashGenerator(int) {
+    return 0;
+  }
+
+  virtual uint64_t AcquireId() {
+    return 0;
+  }
+
+  virtual void ReleaseId(uint64_t) {
+  }
+
+  virtual void ResetLayerHashGenerator() {
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -579,4 +579,31 @@ bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+  int InitializeLayerHashGenerator(int size) {
+    LayerIds_.clear();
+    for (int i = 0; i < size; i++) {
+      LayerIds_.push_back(i);
+    }
+
+    current_max_layer_ids_ = size;
+    return 0;
+  }
+
+  uint64_t AcquireId() {
+    if (LayerIds_.empty())
+      return ++current_max_layer_ids;
+
+    uint64_t id = ids_.back();
+    ids_.pop_back();
+
+    return id;
+  }
+
+  void ReleaseId(uint64_t) {
+    LayerIds_.push_back(id);
+  }
+
+  void ResetLayerHashGenerator() {
+    return InitializeLayerHashGenerator(current_max_layer_ids_);
+  }
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -207,10 +207,20 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
+  int InitializeLayerHashGenerator(int) override;
+
+  uint64_t AcquireId() override;
+
+  void ReleaseId(uint64_t) override;
+
+  void ResetLayerHashGenerator() override;
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();
   void HandleClonedDisplays(std::vector<HwcLayer *> &source_layers);
+  std::vector<uint64_t> LayerIds_;
+  uint64_t current_max_layer_ids_;
 
  protected:
   enum DisplayConnectionStatus {


### PR DESCRIPTION
The LayerHashGenerator are a set of utility methods in NativeDisplay
which can be used to get layer ids. It maintains with a pool of ids whose
initial size is determined by the size parameter passed to
InitializeLayerHashGenerator. Call AcquireId when a new id is required
and release that id with ReleaseId. The size of the pool is variable
and increases when required.

Jira: None
Test:

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>