### PR TITLE
NativeDisplay: Layer Hash Generator

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -344,6 +344,8 @@ HWC2::Error IAHWC2::HwcDisplay::Init(hwcomposer::NativeDisplay *display,
   if (err != HWC2::Error::None)
     return err;
 
+  display_->InitializeLayerHashGenerator(32);
+
   return SetActiveConfig(default_config);
 }
 
@@ -395,10 +397,10 @@ HWC2::Error IAHWC2::HwcDisplay::AcceptDisplayChanges() {
 
 HWC2::Error IAHWC2::HwcDisplay::CreateLayer(hwc2_layer_t *layer) {
   supported(__func__);
-  layers_.emplace(static_cast<hwc2_layer_t>(layer_idx_), IAHWC2::Hwc2Layer());
-  layers_.at(layer_idx_).XTranslateCoordinates(display_->GetXTranslation());
-  *layer = static_cast<hwc2_layer_t>(layer_idx_);
-  ++layer_idx_;
+  uint64_t id = display_->AcquireId();
+  layers_.emplace(static_cast<hwc2_layer_t>(id), IAHWC2::Hwc2Layer());
+  layers_.at(id).XTranslateCoordinates(display_->GetXTranslation());
+  *layer = static_cast<hwc2_layer_t>(id);
   return HWC2::Error::None;
 }
 
@@ -407,7 +409,9 @@ HWC2::Error IAHWC2::HwcDisplay::DestroyLayer(hwc2_layer_t layer) {
   if (layers_.empty())
     return HWC2::Error::None;
 
-  layers_.erase(layer);
+  if (layers_.erase(layer))
+    display_->ReleaseId(layer);
+
   return HWC2::Error::None;
 }
 
@@ -415,8 +419,8 @@ void IAHWC2::HwcDisplay::FreeAllLayers() {
   if (layers_.empty())
     return;
 
+  display_->ResetLayerHashGenerator();
   std::map<hwc2_layer_t, Hwc2Layer>().swap(layers_);
-  layer_idx_ = 0;
 }
 
 HWC2::Error IAHWC2::HwcDisplay::GetActiveConfig(hwc2_config_t *config) {

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -186,7 +186,6 @@ class IAHWC2 : public hwc2_device_t {
     hwcomposer::NativeDisplay *display_ = NULL;
     hwc2_display_t handle_;
     HWC2::DisplayType type_;
-    int layer_idx_ = 0;
     std::map<hwc2_layer_t, Hwc2Layer> layers_;
     Hwc2Layer client_layer_;
     int32_t color_mode_;

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -304,6 +304,35 @@ class NativeDisplay {
   virtual void HotPlugUpdate(bool /*connected*/) {
   }
 
+  /**
+   * Use this method to initalize the display's pool of
+   * layer ids. The argument to the method is the
+   * initial size of the pool
+   */
+  virtual int InitializeLayerHashGenerator(int) {
+    return 0;
+  }
+
+  /**
+   * Once the id pool is initialzed, use this to acquire an
+   * unused id for the layer.
+   */
+  virtual uint64_t AcquireId() {
+    return 0;
+  }
+
+  /**
+   * Method to return a destroyed layer's id back into the pool
+   */
+  virtual void ReleaseId(uint64_t) {
+  }
+
+  /**
+   * Call this to reset the id pool back to its initial state.
+   */
+  virtual void ResetLayerHashGenerator() {
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -579,4 +579,31 @@ bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+int PhysicalDisplay::InitializeLayerHashGenerator(int size) {
+  LayerIds_.clear();
+  for (int i = 0; i < size; i++) {
+    LayerIds_.push_back(i);
+  }
+
+  current_max_layer_ids_ = size;
+  return 0;
+}
+
+uint64_t PhysicalDisplay::AcquireId() {
+  if (LayerIds_.empty())
+    return ++current_max_layer_ids_;
+
+  uint64_t id = LayerIds_.back();
+  LayerIds_.pop_back();
+
+  return id;
+}
+
+void PhysicalDisplay::ReleaseId(uint64_t id) {
+  LayerIds_.push_back(id);
+}
+
+void PhysicalDisplay::ResetLayerHashGenerator() {
+  InitializeLayerHashGenerator(current_max_layer_ids_);
+}
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -207,10 +207,20 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
+  int InitializeLayerHashGenerator(int) override;
+
+  uint64_t AcquireId() override;
+
+  void ReleaseId(uint64_t) override;
+
+  void ResetLayerHashGenerator() override;
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();
   void HandleClonedDisplays(std::vector<HwcLayer *> &source_layers);
+  std::vector<uint64_t> LayerIds_;
+  uint64_t current_max_layer_ids_;
 
  protected:
   enum DisplayConnectionStatus {


### PR DESCRIPTION
The LayerHashGenerator are a set of utility methods in NativeDisplay
which can be used to get layer ids. It maintains with a pool of ids whose
initial size is determined by the size parameter passed to
InitializeLayerHashGenerator. Call AcquireId when a new id is required
and release that id with ReleaseId. The size of the pool is variable
and increases when required.

Jira: None
Test:

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>