### PR TITLE
Correct video plane damage rect caculation

### DIFF
--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -202,7 +202,15 @@ void DisplayPlaneState::ResetLayers(const std::vector<OverlayLayer> &layers,
 
 void DisplayPlaneState::UpdateDisplayFrame(const HwcRect<int> &display_frame) {
   HwcRect<int> &target_display_frame = private_data_->display_frame_;
-  CalculateRect(display_frame, target_display_frame);
+  if (!IsVideoPlane())
+    CalculateRect(display_frame, target_display_frame);
+  else {
+    target_display_frame.bounds[0] = display_frame.bounds[0];
+    target_display_frame.bounds[1] = display_frame.bounds[1];
+    target_display_frame.bounds[2] = display_frame.bounds[2];
+    target_display_frame.bounds[3] = display_frame.bounds[3];
+  }
+
   private_data_->rect_updated_ = true;
 }
 


### PR DESCRIPTION
Video plane does not need combation of display
rects from layers. Instead it should use the
display rect of its source layer

Change-Id: I6c6e46f96175946b3285cd035cc7d94f9971df71
Jira: None
Test: Youtube