### PR TITLE
Add initial support for HDCP.

### DIFF
--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -67,6 +67,10 @@ bool LogicalDisplay::SetPowerMode(uint32_t power_mode) {
   return true;
 }
 
+void LogicalDisplay::SetHDCPState(HWCContentProtection state) {
+  logical_display_manager_->SetHDCPState(state);
+}
+
 bool LogicalDisplay::Present(std::vector<HwcLayer *> &source_layers,
                              int32_t *retire_fence, bool handle_constraints) {
   if (power_mode_ != kOn)

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -119,6 +119,8 @@ class LogicalDisplay : public NativeDisplay {
 
   void HotPlugUpdate(bool connected) override;
 
+  void SetHDCPState(HWCContentProtection state) override;
+
  private:
   LogicalDisplayManager *logical_display_manager_;
   NativeDisplay *physical_display_;

--- a/common/core/logicaldisplaymanager.cpp
+++ b/common/core/logicaldisplaymanager.cpp
@@ -219,4 +219,11 @@ void LogicalDisplayManager::GetLogicalDisplays(std::vector<LogicalDisplay*>& dis
     }
 }
 
+void LogicalDisplayManager::SetHDCPState(HWCContentProtection state) {
+  uint32_t size = displays_.size();
+  for (uint32_t i = 0; i < size; i++) {
+    displays_.at(i)->SetHDCPState(state);
+  }
+}
+
 }  // namespace hwcomposer

--- a/common/core/logicaldisplaymanager.h
+++ b/common/core/logicaldisplaymanager.h
@@ -52,6 +52,8 @@ class LogicalDisplayManager {
 
   void GetLogicalDisplays(std::vector<LogicalDisplay*>& displays);
 
+  void SetHDCPState(HWCContentProtection state);
+
  private:
   NativeDisplay* physical_display_;
   std::vector<std::unique_ptr<LogicalDisplay>> displays_;

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -504,4 +504,11 @@ bool MosaicDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+void MosaicDisplay::SetHDCPState(HWCContentProtection state) {
+  uint32_t size = physical_displays_.size();
+  for (uint32_t i = 0; i < size; i++) {
+    physical_displays_.at(i)->SetHDCPState(state);
+  }
+}
+
 }  // namespace hwcomposer

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -108,6 +108,8 @@ class MosaicDisplay : public NativeDisplay {
 
   void HotPlugUpdate(bool connected);
 
+  void SetHDCPState(HWCContentProtection state) override;
+
  private:
   std::vector<NativeDisplay *> physical_displays_;
   std::vector<NativeDisplay *> connected_displays_;

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -37,6 +37,12 @@ enum class HWCBlending : int32_t {
   kBlendingCoverage = 0x0405,
 };
 
+enum HWCContentProtection {
+  kUnSupported = 0,  // Content Protection is not supported.
+  kUnDesired = 1,    // Content Protection is not required.
+  kDesired = 2       // Content Protection is desired.
+};
+
 enum HWCTransform {
   kIdentity = 0,
   kReflectX = 1 << 0,

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -333,6 +333,14 @@ class NativeDisplay {
   virtual void ResetLayerHashGenerator() {
   }
 
+  /**
+   * Call this to set HDCP state for this display. This function
+   * tries to take advantage of any HDCP support advertised by
+   * the Kernel.
+   */
+  virtual void SetHDCPState(HWCContentProtection /*state*/) {
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -98,12 +98,33 @@ bool DrmDisplay::ConnectDisplay(const drmModeModeInfo &mode_info,
     return false;
   }
 
-  // GetDrmObjectProperty("DPMS", connector_props, &dpms_prop_);
+  int value = -1;
+  GetDrmHDCPObjectProperty("Content Protection", connector, connector_props,
+                           &hdcp_id_prop_, &value);
+
+  if (value >= 0) {
+    switch (value) {
+      case 0:
+        current_protection_support_ = HWCContentProtection::kUnDesired;
+        break;
+      case 1:
+        current_protection_support_ = HWCContentProtection::kDesired;
+        break;
+      default:
+        break;
+    }
+
+    if (desired_protection_support_ == HWCContentProtection::kUnSupported) {
+      desired_protection_support_ = current_protection_support_;
+    }
+  }
+
   GetDrmObjectProperty("CRTC_ID", connector_props, &crtc_prop_);
   GetDrmObjectProperty("Broadcast RGB", connector_props, &broadcastrgb_id_);
   GetDrmObjectProperty("DPMS", connector_props, &dpms_prop_);
 
   PhysicalDisplay::Connect();
+  SetHDCPState(desired_protection_support_);
 
   drmModePropertyPtr broadcastrgb_props =
       drmModeGetProperty(gpu_fd_, broadcastrgb_id_);
@@ -269,6 +290,29 @@ bool DrmDisplay::SetBroadcastRGB(const char *range_property) {
   return true;
 }
 
+void DrmDisplay::SetHDCPState(HWCContentProtection state) {
+  desired_protection_support_ = state;
+  if (desired_protection_support_ == current_protection_support_)
+    return;
+
+  if (hdcp_id_prop_ <= 0) {
+    ETRACE("Cannot set HDCP state as Connector property is not supported \n");
+    return;
+  }
+
+  if (!(connection_state_ & kConnected)) {
+    return;
+  }
+
+  current_protection_support_ = desired_protection_support_;
+  uint32_t value = 0;
+  if (current_protection_support_ == kDesired) {
+    value = 1;
+  }
+
+  drmModeConnectorSetProperty(gpu_fd_, connector_, hdcp_id_prop_, value);
+}
+
 bool DrmDisplay::Commit(
     const DisplayPlaneStateList &composition_planes,
     const DisplayPlaneStateList &previous_composition_planes,
@@ -372,6 +416,35 @@ void DrmDisplay::GetDrmObjectProperty(const char *name,
     ScopedDrmPropertyPtr property(drmModeGetProperty(gpu_fd_, props->props[i]));
     if (property && !strcmp(property->name, name)) {
       *id = property->prop_id;
+      break;
+    }
+  }
+  if (!(*id))
+    ETRACE("Could not find property %s", name);
+}
+
+void DrmDisplay::GetDrmHDCPObjectProperty(
+    const char *name, const drmModeConnector *connector,
+    const ScopedDrmObjectPropertyPtr &props, uint32_t *id, int *value) const {
+  uint32_t count_props = props->count_props;
+  for (uint32_t i = 0; i < count_props; i++) {
+    ScopedDrmPropertyPtr property(drmModeGetProperty(gpu_fd_, props->props[i]));
+    if (property && !strcmp(property->name, name)) {
+      *id = property->prop_id;
+      if (value) {
+        for (int prop_idx = 0; prop_idx < connector->count_props; ++prop_idx) {
+          if (connector->props[prop_idx] != property->prop_id)
+            continue;
+
+          for (int enum_idx = 0; enum_idx < property->count_enums; ++enum_idx) {
+            const drm_mode_property_enum &property_enum =
+                property->enums[enum_idx];
+            if (property_enum.value == connector->prop_values[prop_idx]) {
+              *value = property_enum.value;
+            }
+          }
+        }
+      }
       break;
     }
   }

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -48,6 +48,8 @@ class DrmDisplay : public PhysicalDisplay {
 
   bool SetBroadcastRGB(const char *range_property) override;
 
+  void SetHDCPState(HWCContentProtection state) override;
+
   bool InitializeDisplay() override;
   void PowerOn() override;
   void UpdateDisplayConfig() override;
@@ -92,6 +94,10 @@ class DrmDisplay : public PhysicalDisplay {
   void GetDrmObjectProperty(const char *name,
                             const ScopedDrmObjectPropertyPtr &props,
                             uint32_t *id) const;
+  void GetDrmHDCPObjectProperty(const char *name,
+                                const drmModeConnector *connector,
+                                const ScopedDrmObjectPropertyPtr &props,
+                                uint32_t *id, int *value = NULL) const;
   float TransformGamma(float value, float gamma) const;
   float TransformContrastBrightness(float value, float brightness,
                                     float contrast) const;
@@ -121,11 +127,16 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t old_blob_id_ = 0;
   uint32_t active_prop_ = 0;
   uint32_t mode_id_prop_ = 0;
+  uint32_t hdcp_id_prop_ = 0;
   uint32_t connector_ = 0;
   uint64_t lut_size_ = 0;
   int64_t broadcastrgb_full_ = -1;
   int64_t broadcastrgb_automatic_ = -1;
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
+  HWCContentProtection current_protection_support_ =
+      HWCContentProtection::kUnSupported;
+  HWCContentProtection desired_protection_support_ =
+      HWCContentProtection::kUnSupported;
   drmModeModeInfo current_mode_;
   std::vector<drmModeModeInfo> modes_;
   SpinLock display_lock_;


### PR DESCRIPTION
We try to program the pipe if kernel exposes "Content Protection"
property.

Jira: None.
Test: On KBL, we are able to print the property and supported values in
      logcat.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>