### PR TITLE
If the content has changed, don't assign previous plane regions

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -214,10 +214,12 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
         }
 
         if (!clear_surface) {
-          const std::vector<CompositionRegion>& comp_regions =
-              plane.GetCompositionRegion();
-          last_plane.GetCompositionRegion().assign(comp_regions.begin(),
-                                                   comp_regions.end());
+          if(!content_changed){
+            const std::vector<CompositionRegion>& comp_regions =
+                plane.GetCompositionRegion();
+            last_plane.GetCompositionRegion().assign(comp_regions.begin(),
+                                                    comp_regions.end());
+          }
         } else {
           content_changed = true;
         }


### PR DESCRIPTION
If the content has changed, don't assign the previous plane regions.

Jira: OAM-53768
Test: We don't see any incomplete/black region after turn on
      wifi in split screen.
Signed-off-by: Sami Uddin <sami.uddin.mohammad@intel.com>