### PR TITLE
VARenderer: add surface sync

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -70,9 +70,10 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
   std::shared_ptr<OverlayBuffer> buffer(NULL);
 
   // FIXME: Enable cache again.
-  /*if (resource_manager && register_buffer) {
+  if (resource_manager && register_buffer) {
     buffer = resource_manager->FindCachedBuffer(GETNATIVEBUFFER(handle));
-  }*/
+  }
+
 
   if (buffer == NULL) {
     buffer = OverlayBuffer::CreateOverlayBuffer();

--- a/common/core/resourcemanager.h
+++ b/common/core/resourcemanager.h
@@ -84,10 +84,12 @@ class ResourceManager {
   }
 
  private:
-#define BUFFER_CACHE_LENGTH 4
+  void RemoveAgedBuffer();
+
+#define BUFFER_AGE_LIMIT 6
   typedef std::unordered_map<HWCNativeBuffer, std::shared_ptr<OverlayBuffer>,
                              BufferHash, BufferEqual> BUFFER_MAP;
-  std::vector<BUFFER_MAP> cached_buffers_;
+  BUFFER_MAP cached_buffers_;
   // This should be used in same thread handling
   // Present in NativeDisplay.
   std::vector<ResourceHandle> purged_resources_;

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -62,7 +62,7 @@ struct BufferHash {
   size_t operator()(HWCNativeBuffer const& buffer) const {
     const native_handle_t & p = buffer.base;
     std::size_t seed = 0;
-    for (int i = 0; i < p.numFds + p.numInts; i++) {
+    for (int i = 0; i < p.numFds; i++) {
       hash_combine_hwc(seed, (const size_t)p.data[i]);
     }
     return seed;
@@ -71,17 +71,41 @@ struct BufferHash {
 
 struct BufferEqual {
   bool operator()(const HWCNativeBuffer& buffer1, const HWCNativeBuffer& buffer2) const {
+    //FIXME: to enable cache again. current it cause flicker
+	  return false;
+	/*
     const native_handle_t &p1 = buffer1.base;
     const native_handle_t &p2 = buffer2.base;
     bool equal = (p1.numFds == p2.numFds) && (p1.numInts ==  p2.numInts);
     if (equal) {
-      for (int i = 0; i < p1.numFds + p1.numInts; i++) {
+      for (int i = 0; i< p1.numFds; i++) {
+        equal = equal && (buffer1.fds[i] == buffer2.fds[i]);
+        if (!equal)
+          break;
+      }
+    }
+    if (equal) {
+      for (int i = 0; i< p1.numFds; i++) {
+        equal = equal && (buffer1.strides[i] == buffer2.strides[i]);
+		equal = equal && (buffer1.offsets[i] == buffer2.offsets[i]);
+	    equal = equal && (buffer1.sizes[i] == buffer2.sizes[i]);
+        if (!equal)
+          break;
+      }
+    }
+	if(equal)
+		equal = equal && (buffer1.width == buffer2.width) && (buffer1.height == buffer2.height) && (buffer1.format == buffer2.format);
+	*/
+	/*
+	if(equal) {
+	for (int i = 4; i < p1.numFds+p1.numInts; i++) {
         equal = equal && (p1.data[i] == p2.data[i]);
         if (!equal)
           break;
       }
     }
-    return equal;
+    */
+    //return equal;
   }
 };
 

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -74,6 +74,7 @@ void DrmBuffer::Initialize(const HwcBuffer& bo) {
   }
 
   total_planes_ = GetTotalPlanesForFormat(format_);
+  ResetAge();
 }
 
 void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
@@ -102,6 +103,7 @@ void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
 
   media_image_.handle_ = image_.handle_;
   Initialize(image_.handle_->meta_data_);
+  ResetAge();
 }
 
 void DrmBuffer::UpdateRawPixelBackingStore(void* addr) {
@@ -126,6 +128,7 @@ bool DrmBuffer::NeedsTextureUpload() const {
 
 const ResourceHandle& DrmBuffer::GetGpuResource(GpuDisplay egl_display,
                                                 bool external_import) {
+   ResetAge();
   if (image_.image_ == 0) {
 #ifdef USE_GL
     EGLImageKHR image = EGL_NO_IMAGE_KHR;
@@ -266,6 +269,8 @@ const ResourceHandle& DrmBuffer::GetGpuResource(GpuDisplay egl_display,
 const MediaResourceHandle& DrmBuffer::GetMediaResource(MediaDisplay display,
                                                        uint32_t width,
                                                        uint32_t height) {
+
+  ResetAge();
   if (media_image_.surface_ != VA_INVALID_ID) {
     if ((previous_width_ == width) && (previous_height_ == height)) {
       return media_image_;
@@ -318,6 +323,7 @@ const MediaResourceHandle& DrmBuffer::GetMediaResource(MediaDisplay display,
 }
 
 const ResourceHandle& DrmBuffer::GetGpuResource() {
+  ResetAge();
   return image_;
 }
 

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -59,7 +59,9 @@ class DrmBuffer : public OverlayBuffer {
     return usage_;
   }
 
-  uint32_t GetFb() const override {
+  const uint32_t GetFb()    override {
+    //ResetAge();
+    age_ = 0;
     return image_.drm_fd_;
   }
 
@@ -96,6 +98,14 @@ class DrmBuffer : public OverlayBuffer {
 
   void Dump() override;
 
+  void  const ResetAge() override {
+  	age_ =0;
+  }
+  uint32_t GetIncreasedAge() {
+    age_++;
+	return age_;
+  }
+
  private:
   void Initialize(const HwcBuffer& bo);
   uint32_t width_ = 0;
@@ -116,6 +126,7 @@ class DrmBuffer : public OverlayBuffer {
   MediaResourceHandle media_image_;
   std::unique_ptr<PixelBuffer> pixel_buffer_;
   void* data_;
+  uint32_t age_ = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -66,7 +66,7 @@ class OverlayBuffer {
 
   virtual HWCLayerType GetUsage() const = 0;
 
-  virtual uint32_t GetFb() const = 0;
+  virtual const uint32_t GetFb() = 0;
 
   virtual uint32_t GetPrimeFD() const = 0;
 
@@ -96,6 +96,9 @@ class OverlayBuffer {
   virtual bool CreateFrameBuffer(uint32_t gpu_fd) = 0;
 
   virtual void Dump() = 0;
+
+  virtual void const ResetAge() =0;
+  virtual uint32_t GetIncreasedAge() = 0;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
We rely on fence for GPU/display sync
But for varenderer, currently there is not fence mechanism
And vaEndPicture does not sync surface.
So Need to add sync at the end.

Change-Id: Ied562741b8ff7d7a9170969cdd2038befd99be6b
Jira:None
Tests:None