### PR TITLE
Ensure we dont allocate more than once for the plane in a given frame.

### DIFF
--- a/common/compositor/gl/glrenderer.cpp
+++ b/common/compositor/gl/glrenderer.cpp
@@ -84,7 +84,7 @@ bool GLRenderer::Init() {
 }
 
 bool GLRenderer::Draw(const std::vector<RenderState> &render_states,
-                      NativeSurface *surface) {
+		      NativeSurface *surface) {
   GLuint frame_width = surface->GetWidth();
   GLuint frame_height = surface->GetHeight();
   GLuint left = 0;
@@ -103,18 +103,26 @@ bool GLRenderer::Draw(const std::vector<RenderState> &render_states,
 
   glViewport(left, top, frame_width, frame_height);
 
-  if (partial_clear) {
-    const HwcRect<int> &damage = surface->GetSurfaceDamage();
-    GLuint clear_width = damage.right - damage.left;
-    GLuint clear_height = damage.bottom - damage.top;
+  if (partial_clear || clear_surface) {
+    GLuint clear_width = 0;
+    GLuint clear_height = 0;
+    GLuint vleft = 0;
+    GLuint vtop = 0;
+    if (partial_clear) {
+      const HwcRect<int> &damage = surface->GetSurfaceDamage();
+      clear_width = damage.right - damage.left;
+      clear_height = damage.bottom - damage.top;
+      vleft = damage.left;
+      vtop = damage.top;
+    } else {
+      const HwcRect<int> &display_rect = surface->GetLayer()->GetDisplayFrame();
+      clear_width = display_rect.right - display_rect.left;
+      clear_height = display_rect.bottom - display_rect.top;
+      vleft = display_rect.left;
+      vtop = display_rect.top;
+    }
     glEnable(GL_SCISSOR_TEST);
-    glScissor(damage.left, damage.top, clear_width, clear_height);
-  } else if (clear_surface) {
-    const HwcRect<int> &display_rect = surface->GetLayer()->GetDisplayFrame();
-    GLuint clear_width = display_rect.right - display_rect.left;
-    GLuint clear_height = display_rect.bottom - display_rect.top;
-    glEnable(GL_SCISSOR_TEST);
-    glScissor(display_rect.left, display_rect.top, clear_width, clear_height);
+    glScissor(vleft, vtop, clear_width, clear_height);
     glClear(GL_COLOR_BUFFER_BIT);
   } else {
     glEnable(GL_SCISSOR_TEST);

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -49,6 +49,9 @@ DisplayPlaneState::DisplayPlaneState(DisplayPlane *plane, OverlayLayer *layer,
 
 void DisplayPlaneState::CopyState(DisplayPlaneState &state) {
   private_data_ = state.private_data_;
+  if (private_data_->surfaces_.size() == 3)
+    needs_surface_allocation_ = false;
+
   // We don't copy recycled_surface_ state as this
   // should be determined in DisplayQueue for every frame.
 }
@@ -259,6 +262,7 @@ void DisplayPlaneState::SetOffScreenTarget(NativeSurface *target) {
   recycled_surface_ = false;
   surface_swapped_ = true;
   RefreshSurfaces(NativeSurface::kFullClear, true);
+  needs_surface_allocation_ = false;
 }
 
 NativeSurface *DisplayPlaneState::GetOffScreenTarget() const {
@@ -300,6 +304,7 @@ const std::vector<NativeSurface *> &DisplayPlaneState::GetSurfaces() const {
 
 void DisplayPlaneState::ReleaseSurfaces() {
   std::vector<NativeSurface *>().swap(private_data_->surfaces_);
+  needs_surface_allocation_ = true;
 }
 
 void DisplayPlaneState::RefreshSurfaces(NativeSurface::ClearType clear_surface,

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -205,12 +205,18 @@ class DisplayPlaneState {
 
   uint32_t GetDownScalingFactor() const;
 
- private:
-  void CalculateSourceCrop(HwcRect<float> &source_crop) const;
+  // Helper to check if we need to allocate
+  // an offscreen surface for this plane.
+  bool NeedsSurfaceAllocation() const {
+    return needs_surface_allocation_;
+  }
 
   // Put's current OffscreenSurface to back in the
   // list if not already done.
   void SwapSurfaceIfNeeded();
+
+ private:
+  void CalculateSourceCrop(HwcRect<float> &source_crop) const;
 
   class DisplayPlanePrivateState {
    public:
@@ -272,6 +278,7 @@ class DisplayPlaneState {
 
   bool recycled_surface_ = true;
   bool surface_swapped_ = false;
+  bool needs_surface_allocation_ = true;
   uint32_t re_validate_layer_ = ReValidationType::kNone;
   std::shared_ptr<DisplayPlanePrivateState> private_data_;
 };

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -296,26 +296,13 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
 
       if (full_reset || !surface_damage.empty() || update_rect ||
           update_source_rect || refresh_surfaces) {
-        if (last_plane.GetSurfaces().size() < 3) {
+        if (last_plane.NeedsSurfaceAllocation()) {
           display_plane_manager_->SetOffScreenPlaneTarget(last_plane);
         } else if (refresh_surfaces) {
-          last_plane.UpdateDamage(last_plane.GetDisplayFrame());
-          last_plane.ResetCompositionRegion();
-          if (update_rect || update_source_rect) {
-            // Make sure all rects are correct.
-            if (only_cursor_rect_changed) {
-              last_plane.UpdateDamage(surface_damage);
-            } else {
-              last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
-            }
-          }
+          last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
         } else if (update_rect || update_source_rect) {
           // Make sure all rects are correct.
-          if (only_cursor_rect_changed) {
-            last_plane.UpdateDamage(surface_damage);
-          } else {
-            last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
-          }
+          last_plane.UpdateDamage(surface_damage);
         } else if (!surface_damage.empty()) {
           last_plane.UpdateDamage(surface_damage);
         }
@@ -386,6 +373,17 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
 #endif
         const OverlayLayer* layer = &(layers.at(source_layers.at(0)));
         old_plane.AddLayer(layer);
+
+        // Let's allocate an offscreen surface if needed.
+        display_plane_manager_->SetOffScreenPlaneTarget(old_plane);
+
+        // If overlay has offscreen surfaces, discard
+        // them.
+        if (last_overlay.GetOffScreenTarget()) {
+          display_plane_manager_->MarkSurfacesForRecycling(
+              &last_overlay, surfaces_not_inuse_, false);
+        }
+
         last_overlay.GetDisplayPlane()->SetInUse(false);
         composition->erase(composition->begin() + (size - 1));
       }


### PR DESCRIPTION
As we can be doing incremental validation, we dont want to allocate
buffers if it has already been allocated during GetCachedLayers.

Jira: None.
Test: No garbage seen on APL when moving around views which are 3D composited.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>