### PR TITLE
Move LayerHashGenerator to Native display

### DIFF
--- a/common/compositor/gl/glrenderer.cpp
+++ b/common/compositor/gl/glrenderer.cpp
@@ -103,18 +103,19 @@ bool GLRenderer::Draw(const std::vector<RenderState> &render_states,
 
   glViewport(left, top, frame_width, frame_height);
 
-  if (clear_surface || partial_clear) {
+  if (partial_clear) {
     const HwcRect<int> &damage = surface->GetSurfaceDamage();
     GLuint clear_width = damage.right - damage.left;
     GLuint clear_height = damage.bottom - damage.top;
-    if ((frame_width != clear_width) || (frame_height != clear_height)) {
-      glEnable(GL_SCISSOR_TEST);
-      glScissor(damage.left, damage.top, clear_width, clear_height);
-      glClear(GL_COLOR_BUFFER_BIT);
-    } else {
-      glClear(GL_COLOR_BUFFER_BIT);
-      glEnable(GL_SCISSOR_TEST);
-    }
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(damage.left, damage.top, clear_width, clear_height);
+  } else if (clear_surface) {
+    const HwcRect<int> &display_rect = surface->GetLayer()->GetDisplayFrame();
+    GLuint clear_width = display_rect.right - display_rect.left;
+    GLuint clear_height = display_rect.bottom - display_rect.top;
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(display_rect.left, display_rect.top, clear_width, clear_height);
+    glClear(GL_COLOR_BUFFER_BIT);
   } else {
     glEnable(GL_SCISSOR_TEST);
   }

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -220,6 +220,10 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
             resource_manager, true);
 
+  if (!layer->IsValidated()) {
+    state_ |= kForceFullDraw;
+  }
+
   if (!handle_constraints) {
     if (previous_layer) {
       ValidatePreviousFrameState(previous_layer, layer);

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -208,6 +208,13 @@ struct OverlayLayer {
     return state_ & kRawPixelDataChanged;
   }
 
+  // Returns true if this layer is not
+  // validated and complete re-rendering
+  // of the plane needs to be forced.
+  bool NeedsFullDraw() const {
+    return state_ & kForceFullDraw;
+  }
+
   void Dump();
 
  private:
@@ -217,7 +224,8 @@ struct OverlayLayer {
     kInvisible = 1 << 2,
     kSourceRectChanged = 1 << 3,
     kNeedsReValidation = 1 << 4,
-    kRawPixelDataChanged = 1 << 5
+    kRawPixelDataChanged = 1 << 5,
+    kForceFullDraw = 1 << 6
   };
 
   struct ImportedBuffer {

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -246,8 +246,6 @@ bool DisplayPlaneManager::ValidateLayers(
               ResetPlaneTarget(last_plane, commit_planes.back());
               validate_final_layers = true;
             }
-
-            last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
           }
         }
       }
@@ -293,7 +291,6 @@ bool DisplayPlaneManager::ValidateLayers(
         }
 
         commit_planes.back().layer = last_plane.GetOverlayLayer();
-        last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
       }
     }
   }
@@ -360,8 +357,6 @@ void DisplayPlaneManager::PreparePlaneForCursor(
   if (!surface) {
     SetOffScreenPlaneTarget(*plane);
     *validate_final_layers = true;
-  } else {
-    plane->RefreshSurfaces(NativeSurface::kFullClear, true);
   }
 }
 
@@ -967,8 +962,7 @@ bool DisplayPlaneManager::ReValidatePlanes(
 
       if (old_type != new_type) {
         // Set new rotation type. Clear surfaces in case type has changed.
-        last_plane.SetRotationType(new_type, false);
-        last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
+        last_plane.SetRotationType(new_type, true);
       }
     }
 

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -201,7 +201,8 @@ void DisplayPlaneState::ResetLayers(const std::vector<OverlayLayer> &layers,
   RefreshSurfaces(NativeSurface::kFullClear, true);
 }
 
-void DisplayPlaneState::UpdateDisplayFrame(const HwcRect<int> &display_frame) {
+void DisplayPlaneState::UpdateDisplayFrame(const HwcRect<int> &display_frame,
+                                           bool full_clear) {
   HwcRect<int> &target_display_frame = private_data_->display_frame_;
   if (private_data_->source_layers_.size() == 1) {
     target_display_frame = display_frame;
@@ -210,10 +211,12 @@ void DisplayPlaneState::UpdateDisplayFrame(const HwcRect<int> &display_frame) {
   }
 
   private_data_->rect_updated_ = true;
-  RefreshSurfaces(NativeSurface::kPartialClear);
+  RefreshSurfaces(full_clear ? NativeSurface::kFullClear
+                             : NativeSurface::kPartialClear);
 }
 
-void DisplayPlaneState::UpdateSourceCrop(const HwcRect<float> &source_crop) {
+void DisplayPlaneState::UpdateSourceCrop(const HwcRect<float> &source_crop,
+                                         bool full_clear) {
   HwcRect<float> &target_source_crop = private_data_->source_crop_;
   if (private_data_->source_layers_.size() == 1) {
     target_source_crop = source_crop;
@@ -221,7 +224,8 @@ void DisplayPlaneState::UpdateSourceCrop(const HwcRect<float> &source_crop) {
     CalculateSourceRect(source_crop, target_source_crop);
   }
   private_data_->rect_updated_ = true;
-  RefreshSurfaces(NativeSurface::kPartialClear);
+  RefreshSurfaces(full_clear ? NativeSurface::kFullClear
+                             : NativeSurface::kPartialClear);
 }
 
 void DisplayPlaneState::ForceGPURendering() {

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -272,7 +272,6 @@ class DisplayPlaneState {
 
   bool recycled_surface_ = true;
   bool surface_swapped_ = false;
-  bool refresh_needed_ = false;
   uint32_t re_validate_layer_ = ReValidationType::kNone;
   std::shared_ptr<DisplayPlanePrivateState> private_data_;
 };

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -67,9 +67,9 @@ class DisplayPlaneState {
 
   // Updates Display frame rect of this plane to include
   // display_frame.
-  void UpdateDisplayFrame(const HwcRect<int> &display_frame);
+  void UpdateDisplayFrame(const HwcRect<int> &display_frame, bool full_clear);
 
-  void UpdateSourceCrop(const HwcRect<float> &source_crop);
+  void UpdateSourceCrop(const HwcRect<float> &source_crop, bool full_clear);
 
   // Forces GPU Rendering of content for this plane.
   void ForceGPURendering();

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -309,7 +309,13 @@ class NativeDisplay {
    * layer ids. The argument to the method is the
    * initial size of the pool
    */
-  virtual int InitializeLayerHashGenerator(int) {
+  virtual int InitializeLayerHashGenerator(int size) {
+    LayerIds_.clear();
+    for (int i = 0; i < size; i++) {
+      LayerIds_.push_back(i);
+    }
+
+    current_max_layer_ids_ = size;
     return 0;
   }
 
@@ -318,19 +324,27 @@ class NativeDisplay {
    * unused id for the layer.
    */
   virtual uint64_t AcquireId() {
-    return 0;
+    if (LayerIds_.empty())
+      return ++current_max_layer_ids_;
+
+    uint64_t id = LayerIds_.back();
+    LayerIds_.pop_back();
+
+    return id;
   }
 
   /**
    * Method to return a destroyed layer's id back into the pool
    */
-  virtual void ReleaseId(uint64_t) {
+  virtual void ReleaseId(uint64_t id) {
+    LayerIds_.push_back(id);
   }
 
   /**
    * Call this to reset the id pool back to its initial state.
    */
   virtual void ResetLayerHashGenerator() {
+    InitializeLayerHashGenerator(current_max_layer_ids_);
   }
 
   /**
@@ -367,6 +381,11 @@ class NativeDisplay {
   // to individual layers shown by this display.
   virtual void RotateDisplay(HWCRotation /*rotation*/) {
   }
+
+private:
+  std::vector<uint64_t> LayerIds_;
+  uint64_t current_max_layer_ids_;
+
 };
 
 /**

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -578,32 +578,4 @@ bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   strncpy(name, string.c_str(), *size);
   return true;
 }
-
-int PhysicalDisplay::InitializeLayerHashGenerator(int size) {
-  LayerIds_.clear();
-  for (int i = 0; i < size; i++) {
-    LayerIds_.push_back(i);
-  }
-
-  current_max_layer_ids_ = size;
-  return 0;
-}
-
-uint64_t PhysicalDisplay::AcquireId() {
-  if (LayerIds_.empty())
-    return ++current_max_layer_ids_;
-
-  uint64_t id = LayerIds_.back();
-  LayerIds_.pop_back();
-
-  return id;
-}
-
-void PhysicalDisplay::ReleaseId(uint64_t id) {
-  LayerIds_.push_back(id);
-}
-
-void PhysicalDisplay::ResetLayerHashGenerator() {
-  InitializeLayerHashGenerator(current_max_layer_ids_);
-}
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -207,20 +207,10 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
-  int InitializeLayerHashGenerator(int) override;
-
-  uint64_t AcquireId() override;
-
-  void ReleaseId(uint64_t) override;
-
-  void ResetLayerHashGenerator() override;
-
  private:
   bool UpdatePowerMode();
   void RefreshClones();
   void HandleClonedDisplays(std::vector<HwcLayer *> &source_layers);
-  std::vector<uint64_t> LayerIds_;
-  uint64_t current_max_layer_ids_;
 
  protected:
   enum DisplayConnectionStatus {


### PR DESCRIPTION
Moving the implementation of LayerHashGenerator form Physical
diplay to nativedisplay as other classes directly implement
nativedisplay.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>