### PR TITLE
Check for setting offscreen target when there is a fall back

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -188,7 +188,10 @@ bool DisplayPlaneManager::ValidateLayers(
 
       last_plane.AddLayer(i->GetZorder(), i->GetDisplayFrame(), false);
     }
-
+    if (!last_plane.GetOffScreenTarget() || last_plane.GetSurfaces().size() < 3) {
+    SetOffScreenPlaneTarget(last_plane);
+    }
+    last_plane.SwapSurfaceIfNeeded();
     if (last_plane.GetCompositionState() == DisplayPlaneState::State::kRender)
       render_layers = true;
   }


### PR DESCRIPTION
We need to check if the offscreen target is set properly for the plane, when we are handling more layers in it.

JIRA: OAM-54054

Test: No flicker when we touch/mouse click during video play back.

Signed-off-by: bshwetha <shwetha.b@intel.com>