### PR TITLE
Remove opengl, vulkan, va use for dummy compositor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ script:
 - make clean
 - ./autogen.sh --prefix=$WLD --disable-hotplug-support
 - make -j5
+- make clean
+- ./autogen.sh --prefix=$WLD --enable-dummy-compositor
+- make -j5
 
 # Test Weston plugin
 - export WLD=/tmp/wl-install
@@ -149,14 +152,6 @@ script:
 - git clean -xfd
 - ./autogen.sh --prefix=$WLD
 - make -j5 && make install
-- popd
-
-#Build hwcomposer with dummy compositor enabled
-- pushd .
-- cd /tmp/common
-- git clean -xfd
-- ./autogen.sh --prefix=$WLD --enable-dummy-compositor
-- make && make install
 - popd
 
 #Build weston and weston plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,14 @@ script:
 - make -j5 && make install
 - popd
 
+#Build hwcomposer with dummy compositor enabled
+- pushd .
+- cd /tmp/common
+- git clean -xfd
+- ./autogen.sh --prefix=$WLD --enable-dummy-compositor
+- make && make install
+- popd
+
 #Build weston and weston plugin
 - git clone https://anongit.freedesktop.org/git/wayland/weston.git /tmp/weston
 - os/linux/weston/build_script.sh --apply-patches --weston-dir=/tmp/weston --iahwc-dir=$(pwd) --build

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,9 @@ libhwcomposer_ladir = $(libdir)
 libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -shared
 libhwcomposer_la_LDFLAGS += -Wl,--no-as-needed,-lva,-lva-drm,--as-needed
 
+if ENABLE_DUMMY_COMPOSITOR
+AM_CPPFLAGS += -DUSE_DC
+else
 if ENABLE_VULKAN
 AM_CPP_INCLUDES += -Icommon/compositor/vk
 AM_CPPFLAGS += -Icommon/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
@@ -58,6 +61,7 @@ else
 AM_CPP_INCLUDES += -Icommon/compositor/gl
 AM_CPPFLAGS += -DUSE_GL
 libhwcomposer_la_LIBADD += $(GLES2_LIBS)
+endif
 endif
 
 if ENABLE_LINUX_FRONTEND

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -39,6 +39,9 @@ libhwcomposer_common_la_LIBADD = \
 
 noinst_LTLIBRARIES = libhwcomposer_common.la
 libhwcomposer_common_la_SOURCES = $(common_SOURCES)
+if ENABLE_DUMMY_COMPOSITOR
+AM_CPPFLAGS += -DUSE_DC
+else
 if ENABLE_VULKAN
 libhwcomposer_common_la_SOURCES += $(vk_SOURCES)
 AM_CPP_INCLUDES += -Icompositor/vk
@@ -53,6 +56,7 @@ endif
 
 libhwcomposer_common_la_SOURCES += $(va_SOURCES)
 AM_CPP_INCLUDES += -Icompositor/va
+endif
 
 libhwcomposer_common_ladir = $(libdir)
 libhwcomposer_common_la_LDFLAGS = -version-number 0:0:1 -no-undefined

--- a/common/compositor/compositordefs.h
+++ b/common/compositor/compositordefs.h
@@ -19,7 +19,10 @@
 
 #include <stdint.h>
 
-#ifdef USE_GL
+#ifdef USE_DC
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#elif USE_GL
 #include "shim.h"
 #elif USE_VK
 #include "vkshim.h"
@@ -42,7 +45,15 @@ static float TransformMatrices[] = {
 };
 // clang-format on
 
-#ifdef USE_GL
+#ifdef USE_DC
+typedef unsigned GpuResourceHandle;
+typedef struct gl_import {
+  EGLImageKHR image_ = 0;
+  HWCNativeHandle handle_ = 0;
+  uint32_t drm_fd_ = 0;
+} ResourceHandle;
+typedef EGLDisplay GpuDisplay;
+#elif USE_GL
 typedef unsigned GpuResourceHandle;
 typedef struct gl_import {
   EGLImageKHR image_ = 0;

--- a/common/compositor/compositordefs.h
+++ b/common/compositor/compositordefs.h
@@ -19,10 +19,7 @@
 
 #include <stdint.h>
 
-#ifdef USE_DC
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#elif USE_GL
+#if USE_GL
 #include "shim.h"
 #elif USE_VK
 #include "vkshim.h"
@@ -48,11 +45,11 @@ static float TransformMatrices[] = {
 #ifdef USE_DC
 typedef unsigned GpuResourceHandle;
 typedef struct gl_import {
-  EGLImageKHR image_ = 0;
+  void* image_ = 0;
   HWCNativeHandle handle_ = 0;
   uint32_t drm_fd_ = 0;
 } ResourceHandle;
-typedef EGLDisplay GpuDisplay;
+typedef void* GpuDisplay;
 #elif USE_GL
 typedef unsigned GpuResourceHandle;
 typedef struct gl_import {

--- a/common/compositor/factory.cpp
+++ b/common/compositor/factory.cpp
@@ -17,7 +17,9 @@
 #include "factory.h"
 #include "platformdefines.h"
 
-#ifdef USE_GL
+#ifdef USE_DC
+#include "nativesurface.h"
+#elif USE_GL
 #include "glrenderer.h"
 #include "glsurface.h"
 #include "nativeglresource.h"

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -666,7 +666,7 @@ bool DisplayPlaneState::CanUseGPUDownScaling() const {
         ceilf(target_src_rect.right - target_src_rect.left));
     uint32_t source_crop_height = static_cast<uint32_t>(
         ceilf(target_src_rect.bottom - target_src_rect.top));
-    if (display_frame_width < 500 || display_frame_height < 500) {
+    if (display_frame_width < 500) {
       // Ignore < 500 pixels.
       value = false;
     } else if ((display_frame_width == source_crop_width) &&

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,17 @@ AC_PROG_LIBTOOL
 
 AC_SUBST(ASSEMBLER_WARN_CFLAGS)
 
+# For splash screen dummy compositor
+AC_ARG_ENABLE(dummy-compositor,
+  AS_HELP_STRING([--enable-dummy-compositor],
+    [Enable the dummy compositor (EXPERIMENTAL)]),
+[if test x$enableval = xyes; then
+  enable_dummy_compositor=yes
+  AC_DEFINE(ENABLE_DUMMY_COMPOSITOR, 1, [Enable Dummy_Compositor])
+fi])
+
+AM_CONDITIONAL([ENABLE_DUMMY_COMPOSITOR], [test "x$enable_dummy_compositor" = "xyes"])
+
 # For vulkan
 AC_ARG_ENABLE(vulkan,
   AS_HELP_STRING([--enable-vulkan],
@@ -216,6 +227,7 @@ AC_OUTPUT
 echo -e """\nEnabled options """
 
 AC_MSG_RESULT([
+     Dummy compositor         $enable_dummy_compositor
      Vulkan                   $enable_vulkan
      Linux frontend           $enable_linux_frontend
      GBM                      $enable_gbm

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,9 @@
 #  SOFTWARE.
 #
 
+if ENABLE_DUMMY_COMPOSITOR
+    AM_CPPFLAGS = -DUSE_DC
+else
 bin_PROGRAMS = testlayers \
 	       linux_test
 
@@ -94,3 +97,4 @@ linux_test_SOURCES = \
     ./common/esTransform.cpp \
     ./common/jsonhandlers.cpp \
     ./apps/linux_frontend_test.cpp
+endif


### PR DESCRIPTION
Adjust makefiles in order to build without certain functionality that we won't need enabled in the splash screen with dummy compositor flag set. 

Jira: None.
Test: Build passes when using dummy compositor flag
Signed-off-by: Richard Avelar richard.avelar@intel.com