### PR TITLE
Handle layer transform in VARenderer

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -299,6 +299,11 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
     return false;
   }
 
+  // currently rotation is only supported by VA on Android.
+#ifdef DISABLE_CURSOR_PLANE
+  param_.rotation_state = HWCTransformToVA(state.layer_->GetTransform());
+#endif
+
   ScopedVABufferID pipeline_buffer(va_display_);
   if (!pipeline_buffer.CreateBuffer(
           va_context_, VAProcPipelineParameterBufferType,
@@ -485,6 +490,20 @@ bool VARenderer::UpdateCaps() {
   }
 
   return true;
+}
+
+uint32_t VARenderer::HWCTransformToVA(uint32_t transform) {
+    switch (transform) {
+        case kTransform270:
+            return VA_ROTATION_270;
+        case kTransform180:
+            return VA_ROTATION_180;
+        case kTransform90:
+            return VA_ROTATION_90;
+        default:
+            break;
+    }
+    return VA_ROTATION_NONE;
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -110,6 +110,7 @@ class VARenderer : public Renderer {
   bool CreateContext();
   void DestroyContext();
   bool UpdateCaps();
+  uint32_t HWCTransformToVA(uint32_t transform);
 
   bool update_caps_ = false;
   void* va_display_ = nullptr;


### PR DESCRIPTION
VA only support 90/180/270 rotation so we only handle these transforms
in VARenderer.

Jira: None.
Test: Video rotation should work
Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>