### PR TITLE
Use buffer handle to identify buffer

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -24,6 +24,7 @@
 #include "hwcutils.h"
 
 #include "resourcemanager.h"
+#include "nativebufferhandler.h"
 
 namespace hwcomposer {
 
@@ -74,8 +75,13 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
                              bool register_buffer, HwcLayer* layer) {
   std::shared_ptr<OverlayBuffer> buffer(NULL);
 
+  uint32_t id;
+  uint32_t gpu_fd = resource_manager->GetNativeBufferHandler()->GetFd();
+
+  id = GetNativeBuffer(gpu_fd, handle);
+  
   if (resource_manager && register_buffer) {
-    buffer = resource_manager->FindCachedBuffer(GETNATIVEBUFFER(handle));
+    buffer = resource_manager->FindCachedBuffer(id);
   }
 
   if (buffer == NULL) {
@@ -87,7 +93,7 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
     buffer->InitializeFromNativeHandle(handle, resource_manager,
                                        is_cursor_layer);
     if (register_buffer) {
-      resource_manager->RegisterBuffer(GETNATIVEBUFFER(handle), buffer);
+      resource_manager->RegisterBuffer(id, buffer);
     }
   }
 
@@ -229,7 +235,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
 
   surface_damage_ = layer->GetLayerDamage();
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
-            resource_manager, false, layer);
+            resource_manager, true, layer);
 
   if (!handle_constraints) {
     if (previous_layer) {

--- a/common/core/resourcemanager.cpp
+++ b/common/core/resourcemanager.cpp
@@ -50,7 +50,7 @@ void ResourceManager::Dump() {
 }
 
 std::shared_ptr<OverlayBuffer>& ResourceManager::FindCachedBuffer(
-    const HWCNativeBuffer& native_buffer) {
+    const uint32_t& native_buffer) {
   BUFFER_MAP& first_map = cached_buffers_[0];
   static std::shared_ptr<OverlayBuffer> pBufNull = nullptr;
   for (auto& map : cached_buffers_) {
@@ -82,7 +82,7 @@ std::shared_ptr<OverlayBuffer>& ResourceManager::FindCachedBuffer(
   return pBufNull;
 }
 
-void ResourceManager::RegisterBuffer(const HWCNativeBuffer& native_buffer,
+void ResourceManager::RegisterBuffer(const uint32_t& native_buffer,
                                      std::shared_ptr<OverlayBuffer>& pBuffer) {
   BUFFER_MAP& first_map = cached_buffers_[0];
   first_map.emplace(std::make_pair(native_buffer, pBuffer));

--- a/common/core/resourcemanager.h
+++ b/common/core/resourcemanager.h
@@ -61,8 +61,8 @@ class ResourceManager {
   ~ResourceManager();
   void Dump();
   std::shared_ptr<OverlayBuffer>& FindCachedBuffer(
-      const HWCNativeBuffer& native_buffer);
-  void RegisterBuffer(const HWCNativeBuffer& native_buffer,
+      const uint32_t& native_buffer);
+  void RegisterBuffer(const uint32_t& native_buffer,
                       std::shared_ptr<OverlayBuffer>& pBuffer);
   void MarkResourceForDeletion(const ResourceHandle& handle,
                                bool has_valid_gpu_resources);
@@ -85,8 +85,7 @@ class ResourceManager {
 
  private:
 #define BUFFER_CACHE_LENGTH 4
-  typedef std::unordered_map<HWCNativeBuffer, std::shared_ptr<OverlayBuffer>,
-                             BufferHash, BufferEqual> BUFFER_MAP;
+  typedef std::unordered_map<uint32_t, std::shared_ptr<OverlayBuffer>> BUFFER_MAP;
   std::vector<BUFFER_MAP> cached_buffers_;
   // This should be used in same thread handling
   // Present in NativeDisplay.

--- a/os/android/gralloc1bufferhandler.h
+++ b/os/android/gralloc1bufferhandler.h
@@ -47,6 +47,10 @@ class Gralloc1BufferHandler : public NativeBufferHandler {
             size_t plane) const override;
   int32_t UnMap(HWCNativeHandle handle, void *map_data) const override;
 
+  uint32_t GetFd( ) const override {
+  	return fd_;
+  }
+
  private:
   uint32_t ConvertHalFormatToDrm(uint32_t hal_format);
   uint32_t fd_;

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -33,6 +33,7 @@
 #include "platformcommondefines.h"
 #include <cros_gralloc_handle.h>
 
+
 #define DRV_I915 1
 #include <i915_private_android_types.h>
 
@@ -54,37 +55,6 @@ struct gralloc_handle {
 };
 
 typedef struct gralloc_handle* HWCNativeHandle;
-typedef struct cros_gralloc_handle HWCNativeBuffer;
-#define GETNATIVEBUFFER(handle) (*(cros_gralloc_handle*)(handle->handle_))
-
-
-struct BufferHash {
-  size_t operator()(HWCNativeBuffer const& buffer) const {
-    const native_handle_t & p = buffer.base;
-    std::size_t seed = 0;
-    for (int i = 0; i < p.numFds + p.numInts; i++) {
-      hash_combine_hwc(seed, (const size_t)p.data[i]);
-    }
-    return seed;
-  }
-};
-
-struct BufferEqual {
-  bool operator()(const HWCNativeBuffer& buffer1, const HWCNativeBuffer& buffer2) const {
-    const native_handle_t &p1 = buffer1.base;
-    const native_handle_t &p2 = buffer2.base;
-    bool equal = (p1.numFds == p2.numFds) && (p1.numInts ==  p2.numInts);
-    if (equal) {
-      for (int i = 0; i < p1.numFds + p1.numInts; i++) {
-        equal = equal && (p1.data[i] == p2.data[i]);
-        if (!equal)
-          break;
-      }
-    }
-    return equal;
-  }
-};
-
 
 #define VTRACE(fmt, ...) ALOGV("%s: " fmt, __func__, ##__VA_ARGS__)
 #define DTRACE(fmt, ...) ALOGD("%s: " fmt, __func__, ##__VA_ARGS__)
@@ -92,6 +62,17 @@ struct BufferEqual {
 #define WTRACE(fmt, ...) ALOGW("%s: " fmt, __func__, ##__VA_ARGS__)
 #define ETRACE(fmt, ...) ALOGE("%s: " fmt, __func__, ##__VA_ARGS__)
 #define STRACE() ATRACE_CALL()
+
+inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle)
+{
+  uint32_t id = 0;
+  uint32_t prime_fd = handle->handle_->data[0];  
+  if (drmPrimeFDToHandle(gpu_fd, prime_fd, &id)) {
+  	ETRACE("Error generate handle from prime fd %d", prime_fd);
+  }
+  return id;
+}
+
 // _cplusplus
 #ifdef _cplusplus
 }

--- a/os/linux/gbmbufferhandler.h
+++ b/os/linux/gbmbufferhandler.h
@@ -44,6 +44,9 @@ class GbmBufferHandler : public NativeBufferHandler {
             uint32_t height, uint32_t *stride, void **map_data,
             size_t plane) const override;
   int32_t UnMap(HWCNativeHandle handle, void *map_data) const override;
+  uint32_t GetFd( ) const override {
+  	return fd_;
+  }
 
  private:
   uint32_t fd_;

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -52,64 +52,6 @@ struct gbm_handle {
 };
 
 typedef struct gbm_handle* HWCNativeHandle;
-#define GETNATIVEBUFFER(handle) (handle->import_data)
-
-#ifdef USE_MINIGBM
-typedef gbm_import_fd_planar_data HWCNativeBuffer;
-struct BufferHash {
-  size_t operator()(gbm_import_fd_planar_data const& p) const {
-    std::size_t seed = 0;
-    for (int i = 0; i < GBM_MAX_PLANES; i++) {
-      hash_combine_hwc(seed, (const size_t)p.fds[i]);
-    }
-    // avoid to consider next information?
-    hash_combine_hwc(seed, p.width);
-    hash_combine_hwc(seed, p.height);
-    hash_combine_hwc(seed, p.format);
-    return seed;
-  }
-};
-
-struct BufferEqual {
-  bool operator()(const gbm_import_fd_planar_data& p1,
-                  const gbm_import_fd_planar_data& p2) const {
-    bool equal = true;
-    for (int i = 0; i < GBM_MAX_PLANES; i++) {
-      equal = equal && (p1.fds[i] == p2.fds[i]);
-      if (!equal)
-        break;
-    }
-    if (equal)
-      equal = equal && (p1.width == p2.width) && (p1.height == p2.height) &&
-              (p1.format == p2.format);
-    return equal;
-  }
-};
-#else
-
-typedef gbm_import_fd_data HWCNativeBuffer;
-struct BufferHash {
-  size_t operator()(gbm_import_fd_data const& p) const {
-    std::size_t seed = 0;
-    hash_combine_hwc(seed, p.fd);
-    hash_combine_hwc(seed, p.width);
-    hash_combine_hwc(seed, p.height);
-    hash_combine_hwc(seed, p.stride);
-    hash_combine_hwc(seed, p.format);
-    return seed;
-  }
-};
-struct BufferEqual {
-  bool operator()(const gbm_import_fd_data& p1,
-                  const gbm_import_fd_data& p2) const {
-    bool equal = (p1.fd == p2.fd) && (p1.width == p2.width) &&
-                 (p1.height == p2.height) && (p1.stride == p2.stride) &&
-                 (p1.format == p2.format);
-    return equal;
-  }
-};
-
-#endif
 
 #ifdef _cplusplus
 extern "C" {
@@ -121,6 +63,29 @@ extern "C" {
 #define WTRACE(fmt, ...) fprintf(stderr, "%s: \n" fmt, __func__, ##__VA_ARGS__)
 #define ETRACE(fmt, ...) fprintf(stderr, "%s: \n" fmt, __func__, ##__VA_ARGS__)
 #define STRACE() ((void)0)
+
+#ifdef USE_MINIGBM
+inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle)
+{
+  uint32_t id = 0;
+  uint32_t prime_fd = handle->import_data.fds[0];  
+  if (drmPrimeFDToHandle(gpu_fd, prime_fd, &id)) {
+  	ETRACE("Error generate handle from prime fd %d", prime_fd;
+  }
+  return id;
+}
+#else
+inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle)
+{
+  uint32_t id = 0;
+  uint32_t prime_fd = handle->import_data.fd;  
+  if (drmPrimeFDToHandle(gpu_fd, prime_fd, &id)) {
+  	ETRACE("Error generate handle from prime fd %d", prime_fd);
+  }
+  return id;
+}
+#endif
+
 // _cplusplus
 #ifdef _cplusplus
 }

--- a/public/nativebufferhandler.h
+++ b/public/nativebufferhandler.h
@@ -51,6 +51,8 @@ class NativeBufferHandler {
                     void **map_data, size_t plane) const = 0;
 
   virtual int32_t UnMap(HWCNativeHandle handle, void *map_data) const = 0;
+
+  virtual uint32_t GetFd( ) const; 
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -38,8 +38,6 @@ DrmBuffer::~DrmBuffer() {
     resource_manager_->MarkResourceForDeletion(image_, image_.texture_ > 0);
   } else {
     if (image_.texture_ > 0) {
-      image_.handle_ = 0;
-      image_.drm_fd_ = 0;
       resource_manager_->MarkResourceForDeletion(image_, true);
     }
 


### PR DESCRIPTION
Instead of using fd since fds are dynamical
Reenable cache again

Change-Id: Ic3bcc53ef813ec9eb9056ce316b2e1a51e76b952
Jira:None
Tests: No UI flicker on OneA, and video is good
Signed-off-by: Lin Johnson <johnson.lin@intel.com>