### PR TITLE
videoeffect: Query vpp caps before use it

### DIFF
--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -109,6 +109,7 @@ class VARenderer : public Renderer {
   bool GetVAProcDeinterlaceFlagFromVideo(HWCDeinterlaceFlag flag);
   bool CreateContext();
   void DestroyContext();
+  bool LoadCaps();
   bool UpdateCaps();
   uint32_t HWCTransformToVA(uint32_t transform);
 


### PR DESCRIPTION
two things fixed here:
1. We query caps on UpdateCaps, but we use the caps in SetVAProcFilterDeinterlaceMode.
But SetVAProcFilterDeinterlaceMode call before UpdateCaps, this makes
SetVAProcFilterDeinterlaceMode use a invalid value.
2. when we changed the video effect, we mmeset the param_, it will make
the param_.surface_region and param_.output_region useless

Change-Id: I75a1f30b06fb76c7af37310c947dd9b99837bc90
Jira: None.
Test: 1. Video playback works fine.
2. adb shell hwcservice_test -b 100, you see the video turn bright on screen