### PR TITLE
Remove dead code in RenderState

### DIFF
--- a/common/compositor/renderstate.cpp
+++ b/common/compositor/renderstate.cpp
@@ -68,16 +68,8 @@ void RenderState::ConstructState(std::vector<OverlayLayer> &layers,
       }
       case HWCTransform::kTransform90: {
         swap_xy = true;
-        if (transform & HWCTransform::kReflectX) {
-          flip_xy[0] = true;
-          flip_xy[1] = true;
-        } else if (transform & HWCTransform::kReflectY) {
-          flip_xy[0] = false;
-          flip_xy[1] = false;
-        } else {
-          flip_xy[0] = false;
-          flip_xy[1] = true;
-        }
+        flip_xy[0] = false;
+        flip_xy[1] = true;
         break;
       }
       default: {


### PR DESCRIPTION
This code has never been reachable since its introduction in the initial
code import. Simply drop it for now, making room for someone to correctly
add whatever transform case it was originally designed to cover.

Jira: None
Test: Build and run testlayers

Fixes-coverity-id: 1465620
Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>