### PR TITLE
Remove opengl, vulkan, va use for dummy compositor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ script:
 - make clean
 - ./autogen.sh --prefix=$WLD --disable-hotplug-support
 - make -j5
+- make clean
+- ./autogen.sh --prefix=$WLD --enable-dummy-compositor
+- make -j5
 
 # Test Weston plugin
 - export WLD=/tmp/wl-install

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,9 @@ libhwcomposer_ladir = $(libdir)
 libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -shared
 libhwcomposer_la_LDFLAGS += -Wl,--no-as-needed,-lva,-lva-drm,--as-needed
 
+if ENABLE_DUMMY_COMPOSITOR
+AM_CPPFLAGS += -DUSE_DC
+else
 if ENABLE_VULKAN
 AM_CPP_INCLUDES += -Icommon/compositor/vk
 AM_CPPFLAGS += -Icommon/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
@@ -58,6 +61,7 @@ else
 AM_CPP_INCLUDES += -Icommon/compositor/gl
 AM_CPPFLAGS += -DUSE_GL
 libhwcomposer_la_LIBADD += $(GLES2_LIBS)
+endif
 endif
 
 if ENABLE_LINUX_FRONTEND

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -39,6 +39,9 @@ libhwcomposer_common_la_LIBADD = \
 
 noinst_LTLIBRARIES = libhwcomposer_common.la
 libhwcomposer_common_la_SOURCES = $(common_SOURCES)
+if ENABLE_DUMMY_COMPOSITOR
+AM_CPPFLAGS += -DUSE_DC
+else
 if ENABLE_VULKAN
 libhwcomposer_common_la_SOURCES += $(vk_SOURCES)
 AM_CPP_INCLUDES += -Icompositor/vk
@@ -53,6 +56,7 @@ endif
 
 libhwcomposer_common_la_SOURCES += $(va_SOURCES)
 AM_CPP_INCLUDES += -Icompositor/va
+endif
 
 libhwcomposer_common_ladir = $(libdir)
 libhwcomposer_common_la_LDFLAGS = -version-number 0:0:1 -no-undefined

--- a/common/compositor/compositordefs.h
+++ b/common/compositor/compositordefs.h
@@ -42,7 +42,14 @@ static float TransformMatrices[] = {
 };
 // clang-format on
 
-#ifdef USE_GL
+#ifdef USE_DC
+typedef unsigned GpuResourceHandle;
+typedef struct dc_import {
+  HWCNativeHandle handle_ = 0;
+  uint32_t drm_fd_ = 0;
+} ResourceHandle;
+typedef void* GpuDisplay;
+#elif USE_GL
 typedef unsigned GpuResourceHandle;
 typedef struct gl_import {
   EGLImageKHR image_ = 0;

--- a/common/compositor/factory.cpp
+++ b/common/compositor/factory.cpp
@@ -17,7 +17,9 @@
 #include "factory.h"
 #include "platformdefines.h"
 
-#ifdef USE_GL
+#ifdef USE_DC
+#include "nativesurface.h"
+#elif USE_GL
 #include "glrenderer.h"
 #include "glsurface.h"
 #include "nativeglresource.h"
@@ -56,7 +58,11 @@ Renderer* Create3DRenderer() {
 }
 
 Renderer* CreateMediaRenderer() {
+#ifdef USE_DC
+  return NULL;
+#else
   return new VARenderer();
+#endif
 }
 
 NativeGpuResource* CreateNativeGpuResourceHandler() {

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,17 @@ AC_PROG_LIBTOOL
 
 AC_SUBST(ASSEMBLER_WARN_CFLAGS)
 
+# For splash screen dummy compositor
+AC_ARG_ENABLE(dummy-compositor,
+  AS_HELP_STRING([--enable-dummy-compositor],
+    [Enable the dummy compositor (EXPERIMENTAL)]),
+[if test x$enableval = xyes; then
+  enable_dummy_compositor=yes
+  AC_DEFINE(ENABLE_DUMMY_COMPOSITOR, 1, [Enable Dummy_Compositor])
+fi])
+
+AM_CONDITIONAL([ENABLE_DUMMY_COMPOSITOR], [test "x$enable_dummy_compositor" = "xyes"])
+
 # For vulkan
 AC_ARG_ENABLE(vulkan,
   AS_HELP_STRING([--enable-vulkan],
@@ -216,8 +227,20 @@ AC_OUTPUT
 echo -e """\nEnabled options """
 
 AC_MSG_RESULT([
+     Dummy compositor         $enable_dummy_compositor
      Vulkan                   $enable_vulkan
      Linux frontend           $enable_linux_frontend
      GBM                      $enable_gbm
      Hotplug Support          $disable_hotplug_support
 ])
+
+# Test both compositors aren't enabled.
+if [[ ! -z $enable_dummy_compositor ]] && [[ ! -z $enable_vulkan ]];
+then
+    if test $enable_dummy_compositor = yes && test $enable_vulkan = yes; then
+        echo "Error:"
+        echo -e "\tOnly up to one compositor may be enabled at a time." 1>&2
+        exit 1
+    fi
+fi
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,9 @@
 #  SOFTWARE.
 #
 
+if ENABLE_DUMMY_COMPOSITOR
+    AM_CPPFLAGS = -DUSE_DC
+else
 bin_PROGRAMS = testlayers \
 	       linux_test
 
@@ -94,3 +97,4 @@ linux_test_SOURCES = \
     ./common/esTransform.cpp \
     ./common/jsonhandlers.cpp \
     ./apps/linux_frontend_test.cpp
+endif


### PR DESCRIPTION
Adjust makefiles in order to build without certain functionality that
we won't need enabled in the splash screen with dummy compositor flag set.

Jira: None.
Test: Build passes when using dummy compositor flag
Signed-off-by: Richard Avelar richard.avelar@intel.com