### PR TITLE
Fix warnings when building hwc

### DIFF
--- a/os/linux/iahwc.h
+++ b/os/linux/iahwc.h
@@ -113,10 +113,10 @@ enum iahwc_layer_transform {
 };
 
 typedef struct iahwc_rect {
-  int left;
-  int top;
-  int right;
-  int bottom;
+  uint32_t left;
+  uint32_t top;
+  uint32_t right;
+  uint32_t bottom;
 } iahwc_rect_t;
 
 typedef struct iahwc_region {


### PR DESCRIPTION
Adjust casting and include gaurds to silence redefined and narrow conversion
warnings.

Jira: None.
Test: Build passes without warnings
Signed-off-by: Richard Avelar richard.avelar@intel.com