### PR TITLE
Use global cache for KMS resources

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -76,6 +76,7 @@ LOCAL_SRC_FILES := \
         core/gpudevice.cpp \
         core/hwclayer.cpp \
 	core/resourcemanager.cpp \
+  core/framebuffermanager.cpp \
 	core/logicaldisplay.cpp \
 	core/logicaldisplaymanager.cpp \
 	core/mosaicdisplay.cpp \

--- a/common/core/framebuffermanager.cpp
+++ b/common/core/framebuffermanager.cpp
@@ -1,0 +1,94 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "framebuffermanager.h"
+
+namespace hwcomposer {
+
+FrameBufferManager *FrameBufferManager::pInstance = NULL;
+
+FrameBufferManager *FrameBufferManager::GetInstance() {
+  if (pInstance == NULL)
+    pInstance = new FrameBufferManager();
+  return pInstance;
+}
+
+uint32_t FrameBufferManager::FindFB(const FBKey &key) {
+  lock_.lock();
+  auto it = fb_map_.find(key);
+  if (it != fb_map_.end()) {
+    it->second.fb_ref++;
+    lock_.unlock();
+    return it->second.fb_id;
+  } else {
+    uint32_t fb_id = 0;
+    int ret = drmModeAddFB2(key.gpu_fd, key.width, key.height,
+                            key.frame_buffer_format, key.gem_handles,
+                            key.pitches, key.offsets, &fb_id, 0);
+
+    if (ret) {
+      ETRACE("drmModeAddFB2 error (%dx%d, %c%c%c%c, handle %d pitch %d) (%s)",
+             key.width, key.height, key.frame_buffer_format,
+             key.frame_buffer_format >> 8, key.frame_buffer_format >> 16,
+             key.frame_buffer_format >> 24, key.gem_handles[0], key.pitches[0],
+             strerror(-ret));
+      lock_.unlock();
+      return fb_id;
+    }
+    FBValue value;
+    value.fb_id = fb_id;
+    value.fb_ref = 1;
+    fb_map_.emplace(std::make_pair(key, value));
+    lock_.unlock();
+    return fb_id;
+  }
+}
+
+int FrameBufferManager::RemoveFB(const int32_t fb, bool &real_moved) {
+  lock_.lock();
+  auto it = fb_map_.begin();
+  int ret = 0;
+  real_moved = false;
+
+  while (it != fb_map_.end()) {
+    if (it->second.fb_id == fb) {
+      it->second.fb_ref -= 1;
+      if (it->second.fb_ref == 0) {
+        ret = drmModeRmFB(it->first.gpu_fd, fb);
+        fb_map_.erase(it);
+        real_moved = true;
+      }
+      break;
+    }
+    it++;
+  }
+
+  lock_.unlock();
+  return ret;
+}
+
+void FrameBufferManager::PurgeAllFBs() {
+
+  lock_.lock();
+  auto it = fb_map_.begin();
+
+  while (it != fb_map_.end()) {
+    drmModeRmFB(it->first.gpu_fd, it->second.fb_id);
+  }
+  lock_.unlock();
+}
+
+} // namespace hwcomposer

--- a/common/core/framebuffermanager.h
+++ b/common/core/framebuffermanager.h
@@ -1,0 +1,122 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+/*
+Design of ResourceManager:
+The purpose is to add cache magagement to external buffer owned by hwcLayer
+to avoid import buffer and glimage/texture generation overhead
+
+1: the ResourceManager is owned per display, as each display has a
+separate
+GL context
+2: ResourceManager stores a refernce of external buffers in a vector
+   cached_buffers, each vector member is hash map.
+   The vector stores history buffer in this way, vector[0] is for the current
+   frame buffers, vector[1] is for last frame (-1) buffers, vector[2] is -2
+   frames buffers etc. A constant (currently 4) frames of buffers is stored.
+   When a buffer refernce is stored in vector[3] and it is not used in the
+   current frame present, it will go out of scope and be released.
+   If a buffer is fetched from map, it will always re-registered in vector[0]
+map.
+3. By this way, drm_buffer now owns eglImage and gltexture and they
+   can be resued.
+*/
+
+#ifndef COMMON_CORE_FRAMEBUFFER_MANAGER_H_
+#define COMMON_CORE_FRAMEBUFFER_MANAGER_H_
+
+#include <hwcdefs.h>
+#include <platformdefines.h>
+#include <hwctrace.h>
+
+#include <memory>
+#include <unordered_map>
+
+#include <spinlock.h>
+
+namespace hwcomposer {
+
+struct HwcLayer;
+class OverlayBuffer;
+class NativeBufferHandler;
+
+typedef struct FBKey {
+  uint32_t gpu_fd;
+  uint32_t width;
+  uint32_t height;
+  uint32_t frame_buffer_format;
+  uint32_t gem_handles[4];
+  uint32_t pitches[4];
+  uint32_t offsets[4];
+
+  FBKey(const uint32_t &igpu_fd, const uint32_t &iwidth,
+        const uint32_t &iheight, const uint32_t &iframe_buffer_format,
+        const uint32_t (&igem_handles)[4], const uint32_t (&ipitches)[4],
+        const uint32_t (&ioffsets)[4]) {
+    gpu_fd = igpu_fd;
+    width = iwidth;
+    height = iheight;
+    frame_buffer_format = iframe_buffer_format;
+    gem_handles[0] = igem_handles[0];
+    gem_handles[1] = igem_handles[1];
+    gem_handles[2] = igem_handles[2];
+    gem_handles[3] = igem_handles[3];
+    pitches[0] = ipitches[0];
+    pitches[1] = ipitches[1];
+    pitches[2] = ipitches[2];
+    pitches[3] = ipitches[3];
+    offsets[0] = ioffsets[0];
+    offsets[1] = ioffsets[1];
+    offsets[2] = ioffsets[2];
+    offsets[3] = ioffsets[3];
+  }
+} FBKey;
+
+typedef struct {
+  uint32_t fb_id;
+  uint32_t fb_ref;
+} FBValue;
+
+struct FBHash {
+  size_t operator()(FBKey const &key) const { return key.gem_handles[0]; }
+};
+
+struct FBEqual {
+  bool operator()(const FBKey &p1, const FBKey &p2) const {
+    bool equal = (p1.gem_handles[0] == p2.gem_handles[0]) && (p1.gem_handles[1] == p2.gem_handles[1])
+                 && (p1.gem_handles[2] == p2.gem_handles[2]) && (p1.gem_handles[3] == p2.gem_handles[3]);
+    return equal;
+  }
+};
+
+class FrameBufferManager {
+public:
+  static FrameBufferManager *GetInstance();
+  uint32_t FindFB(const FBKey &key);
+  int RemoveFB(const int32_t fb, bool &real_moved);
+
+private:
+  static FrameBufferManager *pInstance;
+  SpinLock lock_;
+  void PurgeAllFBs();
+  FrameBufferManager() {}
+  ~FrameBufferManager() { PurgeAllFBs(); }
+
+  std::unordered_map<FBKey, FBValue, FBHash, FBEqual> fb_map_;
+};
+
+} // namespace hwcomposer
+#endif // COMMON_CORE_RESOURCE_MANAGER_H_

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -237,6 +237,15 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   }
 
   surface_damage_ = layer->GetLayerDamage();
+  // In case of layer using blening we need to force partial clear. Otherwise
+  // we see content not getting updated correctly. For example:
+  // on Android enable, settings put system user_rotation 1 and
+  // navigate to settings on Android.
+  if (((blending_ != HWCBlending::kBlendingNone) && !surface_damage_.empty())) {
+    state_ |= kForcePartialClear;
+    surface_damage_ = layer->GetDisplayFrame();
+  }
+
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
             resource_manager, true, layer);
 

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -930,6 +930,7 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
 }
 
 void DisplayQueue::PresentClonedCommit(DisplayQueue* queue) {
+
   const DisplayPlaneStateList& source_planes =
       queue->GetCurrentCompositionPlanes();
   if (source_planes.empty()) {

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -170,14 +170,15 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
   return true;
 }
 
-bool Gralloc1BufferHandler::ReleaseBuffer(HWCNativeHandle handle) const {
+bool Gralloc1BufferHandler::ReleaseBuffer(HWCNativeHandle handle,
+                                          bool releasehandle) const {
   gralloc1_device_t *gralloc1_dvc =
       reinterpret_cast<gralloc1_device_t *>(device_);
 
   if (handle->hwc_buffer_) {
     release_(gralloc1_dvc, handle->handle_);
   } else if (handle->imported_handle_) {
-    ReleaseGraphicsBuffer(handle, fd_);
+    ReleaseGraphicsBuffer(handle, fd_, releasehandle);
     release_(gralloc1_dvc, handle->imported_handle_);
   }
 

--- a/os/android/gralloc1bufferhandler.h
+++ b/os/android/gralloc1bufferhandler.h
@@ -36,7 +36,7 @@ class Gralloc1BufferHandler : public NativeBufferHandler {
 
   bool CreateBuffer(uint32_t w, uint32_t h, int format, HWCNativeHandle *handle,
                     uint32_t layer_type) const override;
-  bool ReleaseBuffer(HWCNativeHandle handle) const override;
+  bool ReleaseBuffer(HWCNativeHandle handle, bool releasehandle) const override;
   void DestroyHandle(HWCNativeHandle handle) const override;
   bool ImportBuffer(HWCNativeHandle handle) const override;
   void CopyHandle(HWCNativeHandle source,

--- a/os/android/platformdefines.cpp
+++ b/os/android/platformdefines.cpp
@@ -68,5 +68,7 @@ VkFormat NativeToVkFormat(int native_format) {
 #endif
 
 int ReleaseFrameBuffer(uint32_t gpu_fd, uint32_t fd) {
-  return drmModeRmFB(gpu_fd, fd);
+  // return drmModeRmFB(gpu_fd, fd);
+
+  return 0;
 }

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -223,7 +223,8 @@ static void DestroyBufferHandle(HWCNativeHandle handle) {
   handle = NULL;
 }
 
-static bool ReleaseGraphicsBuffer(HWCNativeHandle handle, int fd) {
+static bool ReleaseGraphicsBuffer(HWCNativeHandle handle, int fd,
+                                  bool releasehandle) {
   if (!handle)
     return false;
 
@@ -243,13 +244,15 @@ static bool ReleaseGraphicsBuffer(HWCNativeHandle handle, int fd) {
     last_gem_handle = current_gem_handle;
     gem_close.handle = current_gem_handle;
 
-    ret = drmIoctl(fd, DRM_IOCTL_GEM_CLOSE, &gem_close);
-    if (ret) {
-      ETRACE(
-          "Failed to close gem handle ErrorCode: %d PrimeFD: %d HWCBuffer: %d "
-          "GemHandle: %d  \n",
-          ret, handle->meta_data_.prime_fds_[plane], handle->hwc_buffer_,
-          current_gem_handle);
+    if (releasehandle) {
+      ret = drmIoctl(fd, DRM_IOCTL_GEM_CLOSE, &gem_close);
+      if (ret) {
+        ETRACE("Failed to close gem handle ErrorCode: %d PrimeFD: %d "
+               "HWCBuffer: %d "
+               "GemHandle: %d  \n",
+               ret, handle->meta_data_.prime_fds_[plane], handle->hwc_buffer_,
+               current_gem_handle);
+      }
     }
   }
 

--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -150,7 +150,8 @@ bool GbmBufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
   return true;
 }
 
-bool GbmBufferHandler::ReleaseBuffer(HWCNativeHandle handle) const {
+bool GbmBufferHandler::ReleaseBuffer(HWCNativeHandle handle,
+                                     bool releasehandle) const {
   if (handle->bo || handle->imported_bo) {
     if (handle->bo && handle->hwc_buffer_) {
       gbm_bo_destroy(handle->bo);

--- a/os/linux/gbmbufferhandler.h
+++ b/os/linux/gbmbufferhandler.h
@@ -34,7 +34,7 @@ class GbmBufferHandler : public NativeBufferHandler {
 
   bool CreateBuffer(uint32_t w, uint32_t h, int format, HWCNativeHandle *handle,
                     uint32_t layer_type) const override;
-  bool ReleaseBuffer(HWCNativeHandle handle) const override;
+  bool ReleaseBuffer(HWCNativeHandle handle, bool releasehandle) const override;
   void DestroyHandle(HWCNativeHandle handle) const override;
   void CopyHandle(HWCNativeHandle source,
                   HWCNativeHandle *target) const override;

--- a/public/nativebufferhandler.h
+++ b/public/nativebufferhandler.h
@@ -35,7 +35,8 @@ class NativeBufferHandler {
                             HWCNativeHandle *handle = NULL,
                             uint32_t layer_type = kLayerNormal) const = 0;
 
-  virtual bool ReleaseBuffer(HWCNativeHandle handle) const = 0;
+  virtual bool ReleaseBuffer(HWCNativeHandle handle,
+                             bool releasehandle = true) const = 0;
 
   virtual void DestroyHandle(HWCNativeHandle handle) const = 0;
 

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -27,6 +27,7 @@
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "resourcemanager.h"
+#include "framebuffermanager.h"
 #include "vautils.h"
 
 #include <va/va_drmcommon.h>
@@ -123,6 +124,7 @@ bool DrmBuffer::NeedsTextureUpload() const {
 
 const ResourceHandle& DrmBuffer::GetGpuResource(GpuDisplay egl_display,
                                                 bool external_import) {
+
   if (image_.image_ == 0) {
 #ifdef USE_GL
     EGLImageKHR image = EGL_NO_IMAGE_KHR;
@@ -295,6 +297,7 @@ const ResourceHandle& DrmBuffer::GetGpuResource(GpuDisplay egl_display,
 const MediaResourceHandle& DrmBuffer::GetMediaResource(MediaDisplay display,
                                                        uint32_t width,
                                                        uint32_t height) {
+
   if (media_image_.surface_ != VA_INVALID_ID) {
     if ((previous_width_ == width) && (previous_height_ == height)) {
       return media_image_;
@@ -360,18 +363,10 @@ bool DrmBuffer::CreateFrameBuffer(uint32_t gpu_fd) {
   image_.drm_fd_ = 0;
   media_image_.drm_fd_ = 0;
 
-  int ret = drmModeAddFB2(gpu_fd, width_, height_, frame_buffer_format_,
-                          gem_handles_, pitches_, offsets_, &image_.drm_fd_, 0);
+  FBKey key(gpu_fd, width_, height_, frame_buffer_format_, gem_handles_,
+            pitches_, offsets_);
 
-  if (ret) {
-    ETRACE("drmModeAddFB2 error (%dx%d, %c%c%c%c, handle %d pitch %d) (%s)",
-           width_, height_, frame_buffer_format_, frame_buffer_format_ >> 8,
-           frame_buffer_format_ >> 16, frame_buffer_format_ >> 24,
-           gem_handles_[0], pitches_[0], strerror(-ret));
-
-    image_.drm_fd_ = 0;
-    return false;
-  }
+  image_.drm_fd_ = FrameBufferManager::GetInstance()->FindFB(key);
 
   media_image_.drm_fd_ = image_.drm_fd_;
   return true;


### PR DESCRIPTION
KMS Reousrces include framebuffers and gem handles
should be process widely shared
Do not close gem handle when other
drmbuffer are still refernce it

Change-Id: I880e88194333d36d3ae3df79c017b500de41449c
Jira: None
Tests: Extend mode, video playback
Signed-off-by: Lin Johnson <johnson.lin@intel.com>