### PR TITLE
Fix warnings generated in common core hwc

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -578,7 +578,7 @@ void GpuDevice::HandleHWCSettings() {
       int index = float_display_indices.at(i);
 
       // Ignore float index if out of range of connected displays
-      if (index < num_displays) {
+      if ((size_t) index < num_displays) {
         const HwcRect<int32_t> &rect = float_displays.at(i);
         ret = total_displays_.at(index)->SetCustomResolution(rect);
       }

--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -190,7 +190,9 @@ bool NestedDisplay::SetPowerMode(uint32_t /*power_mode*/) {
 bool NestedDisplay::Present(std::vector<HwcLayer *> &source_layers,
                             int32_t * /*retire_fence*/,
                             bool /*handle_constraints*/) {
-#ifdef NESTED_DISPLAY_SUPPORT
+#ifndef NESTED_DISPLAY_SUPPORT
+  return true;
+#else
   int ret = 0;
   size_t size = source_layers.size();
   const uint32_t *pitches;
@@ -284,8 +286,8 @@ bool NestedDisplay::Present(std::vector<HwcLayer *> &source_layers,
     } while (rc != msg_size && rc >= 0);
   }
   memset(buf, 0, METADATA_BUFFER_SIZE);
-#endif
   return true;
+#endif
 }
 
 bool NestedDisplay::PresentClone(NativeDisplay * /*display*/) {


### PR DESCRIPTION
Adjust casting for coversion warnings and adjust ifdef gaurd which
causes a param unused warning for source_layers.

Jira: None.
Test: Build passes without warnings
Signed-off-by: Richard Avelar richard.avelar@intel.com