### PR TITLE
Refine VA module.

### DIFF
--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -109,6 +109,7 @@ class VARenderer : public Renderer {
   bool GetVAProcDeinterlaceFlagFromVideo(HWCDeinterlaceFlag flag);
   bool CreateContext();
   void DestroyContext();
+  bool LoadCaps();
   bool UpdateCaps();
   uint32_t HWCTransformToVA(uint32_t transform);
 

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -140,7 +140,7 @@ HWC2::Error IAHWC2::Init() {
   else
     ALOGI("EXPLICIT SYNC support is enabled");
 
-  property_get("board.hwc.scaling.mode", value, "0");
+  property_get("board.hwc.scaling.mode", value, "2");
   scaling_mode_ = atoi(value);
   switch (scaling_mode_) {
     case 1:
@@ -150,7 +150,7 @@ HWC2::Error IAHWC2::Init() {
       ALOGI("HWC Scaling Mode High Quality");
       break;
     default:
-      ALOGI("HWC Scaling Mode None");
+      ALOGI("Unsupport HWC Scaling Mode");
       break;
   }
 
@@ -337,6 +337,7 @@ HWC2::Error IAHWC2::HwcDisplay::Init(hwcomposer::NativeDisplay *display,
   handle_ = display_index;
 
   disable_explicit_sync_ = disable_explicit_sync;
+  scaling_mode_ = scaling_mode;
   display_->SetExplicitSyncSupport(disable_explicit_sync_);
   display_->SetVideoScalingMode(scaling_mode_);
 


### PR DESCRIPTION
1. Ensure HSBC/Sharp/Deinterlace/Scaling mode can be set to libva
correctly.
2. Integrate Hue/Satation/Brightness/Contrast into one filter.
3. Do memset before quary from libva.
4. Set default csc scaling mode as High Quality mode.

Jira: None.
Test: Set/Restore color works as expected.

Signed-off-by: Wang,Fei <fei.w.wang@intel.com>