### PR TITLE
Should also release handle if native buffer

### DIFF
--- a/common/core/framebuffermanager.cpp
+++ b/common/core/framebuffermanager.cpp
@@ -78,7 +78,12 @@ int FrameBufferManager::RemoveFB(const uint32_t &fb, bool release_gem_handles) {
     it++;
   }
 
+  if(it == fb_map_.end()) {
+    ETRACE("RemoveFB not meet!");
+  }
+
   lock_.unlock();
+
   return ret;
 }
 

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -172,7 +172,7 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
 
 bool Gralloc1BufferHandler::CanReleaseGemHandles(HWCNativeHandle handle) const {
   if (handle->hwc_buffer_) {
-    return false;
+    return true;
   }
 
   if (handle->imported_handle_) {


### PR DESCRIPTION
Otherwise it will cause memory leak

Tests: app switch in Android IVI no memory grow
Jira: None
Signed-off-by: Lin Johnson <johnson.lin@intel.com>