### PR TITLE
Custom position for float display

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -82,15 +82,17 @@ void HwcLayer::SetSourceCrop(const HwcRect<float>& source_crop) {
 }
 
 void HwcLayer::SetDisplayFrame(const HwcRect<int>& display_frame,
-                               int translate_x_pos) {
+                               int translate_x_pos, int translate_y_pos) {
   if (((display_frame.left + translate_x_pos) != display_frame_.left) ||
       ((display_frame.right + translate_x_pos) != display_frame_.right) ||
-      (display_frame.top != display_frame_.top) ||
-      (display_frame.bottom != display_frame_.bottom)) {
+      ((display_frame.top + translate_y_pos) != display_frame_.top) ||
+      ((display_frame.bottom + translate_y_pos) != display_frame_.bottom)) {
     layer_cache_ |= kDisplayFrameRectChanged;
     HwcRect<int> frame = display_frame;
     frame.left += translate_x_pos;
     frame.right += translate_x_pos;
+    frame.top += translate_y_pos;
+    frame.bottom += translate_y_pos;
     UpdateRenderingDamage(display_frame_, frame, false);
 
     display_frame_ = frame;

--- a/hwc_display.ini
+++ b/hwc_display.ini
@@ -31,7 +31,7 @@ MOSAIC_DISPLAY="0+1+2"
 # in other words, default resolution is replaced by current definition.
 # sub-display-index: start from 0, should be the available displays number, follow the order of the connected logical displays
 # left, top, right and bottom specify the frame rectangle to be displayed as floating on a display with sub-display-index
-FLOAT_DISPLAY="0:0+0+1280+720"
+FLOAT_DISPLAY="0:320+180+1600+900"
 
 # Clone display definitions, with format "physical-display-number:cloned-physical-display-number". This
 # setting is ignored if LOGICAL or MOSAIC is set to true.

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -413,6 +413,7 @@ HWC2::Error IAHWC2::HwcDisplay::CreateLayer(hwc2_layer_t *layer) {
   uint64_t id = display_->AcquireId();
   layers_.emplace(static_cast<hwc2_layer_t>(id), IAHWC2::Hwc2Layer());
   layers_.at(id).XTranslateCoordinates(display_->GetXTranslation());
+  layers_.at(id).YTranslateCoordinates(display_->GetYTranslation());
   *layer = static_cast<hwc2_layer_t>(id);
   return HWC2::Error::None;
 }
@@ -912,7 +913,7 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerDisplayFrame(hwc_rect_t frame) {
   hwc_layer_.SetDisplayFrame(
       hwcomposer::HwcRect<int>(frame.left, frame.top, frame.right,
                                frame.bottom),
-      x_translation_);
+      x_translation_, y_translation_);
   return HWC2::Error::None;
 }
 

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -87,6 +87,10 @@ class IAHWC2 : public hwc2_device_t {
       x_translation_ = x_translation;
     }
 
+    void YTranslateCoordinates(uint32_t y_translation) {
+      y_translation_ = y_translation;
+    }
+
     void set_acquire_fence(int acquire_fence) {
       if (acquire_fence > 0)
         hwc_layer_.SetAcquireFence(acquire_fence);
@@ -125,6 +129,7 @@ class IAHWC2 : public hwc2_device_t {
     hwcomposer::HwcLayer hwc_layer_;
     struct gralloc_handle native_handle_;
     uint32_t x_translation_ = 0;
+    uint32_t y_translation_ = 0;
   };
 
   class HwcDisplay {

--- a/os/linux/linux_frontend.cpp
+++ b/os/linux/linux_frontend.cpp
@@ -403,7 +403,7 @@ int IAHWC::IAHWCLayer::SetLayerSourceCrop(iahwc_rect_t rect) {
 int IAHWC::IAHWCLayer::SetLayerDisplayFrame(iahwc_rect_t rect) {
   iahwc_layer_.SetDisplayFrame(
       hwcomposer::HwcRect<float>(rect.left, rect.top, rect.right, rect.bottom),
-      0);
+      0, 0);
 
   return IAHWC_ERROR_NONE;
 }

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -59,7 +59,9 @@ struct HwcLayer {
     return source_crop_;
   }
 
-  void SetDisplayFrame(const HwcRect<int>& display_frame, int translate_x_pos);
+  void SetDisplayFrame(const HwcRect<int>& display_frame,
+                       int translate_x_pos, int translate_y_pos);
+
   const HwcRect<int>& GetDisplayFrame() const {
     return display_frame_;
   }

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -309,6 +309,15 @@ class NativeDisplay {
     return 0;
   }
 
+  /**
+   * This is to position the composition to non-zero coordinates in display.
+   * When using float mode, the composition resolution is custom configured
+   * and it can be positioned as required.
+   */
+  virtual uint32_t GetYTranslation() {
+    return 0;
+  }
+
   virtual uint32_t GetLogicalIndex() const {
     return 0;
   }

--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -594,7 +594,7 @@ static void fill_hwclayer(hwcomposer::HwcLayer *pHwcLayer,
       pParameter->source_crop_width, pParameter->source_crop_height));
   pHwcLayer->SetDisplayFrame(hwcomposer::HwcRect<int>(
       pParameter->frame_x, pParameter->frame_y, pParameter->frame_width,
-      pParameter->frame_height), 0);
+      pParameter->frame_height), 0, 0);
   pHwcLayer->SetNativeHandle(pRenderer->GetNativeBoHandle());
 }
 

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -119,6 +119,24 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  /**
+   * API for composition to non-zero X coordinate.
+   * This is applicable when float mode is enabled.
+   * Parameters are read from config file.
+   */
+  uint32_t GetXTranslation() override {
+    return rect_.left;
+  }
+
+  /**
+   * API for composition to non-zero Y coordinate.
+   * This is applicable when float mode is enabled.
+   * Parameters are read from config file.
+   */
+  uint32_t GetYTranslation() override {
+    return rect_.top;
+  }
+
   void OwnPresentation(NativeDisplay *clone) override;
 
   void DisOwnPresentation(NativeDisplay *clone) override;


### PR DESCRIPTION
By default HWC sets the display hardware config mode as the resolution
and position it to 0,0 for top left. The additional mechanism of
setting the top left position to non-zero in case of float display enabled.
The float display resolution could be smaller than display resolution.

Jira: #302

Test: When float mode is set, config changes to set custom resolution
at custom position for the required pipe to be working as desired.
If not enabled, it should continue to work as before.