### PR TITLE
Should always reset plane targes when new DiplayPlaneState

### DIFF
--- a/common/core/framebuffermanager.cpp
+++ b/common/core/framebuffermanager.cpp
@@ -62,7 +62,7 @@ uint32_t FrameBufferManager::FindFB(const uint32_t &iwidth,
   auto it = fb_map_.find(key);
   if (it != fb_map_.end()) {
     if (it->second.fb_created) {
-      it->second.fb_ref++;
+      //it->second.fb_ref++;
     } else {
       it->second.fb_created = true;
       CreateFrameBuffer(iwidth, iheight, iframe_buffer_format, igem_handles,

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -215,6 +215,9 @@ bool DisplayPlaneManager::ValidateLayers(
 
             ResetPlaneTarget(last_plane, commit_planes.back());
           }
+          else if (last_plane.NeedsSurfaceAllocation()) {
+            SetOffScreenPlaneTarget(last_plane);
+          }
 
           break;
         } else {


### PR DESCRIPTION
Otherwise it will flicker due to not enough target surfaces

Jira: https://jira01.devtools.intel.com/browse/OAM-55851
Tests: Playback video 10 times thers is no flicker at beginnng
Signed-off-by: Lin Johnson <johnson.lin@intel.com>