### PR TITLE
FrameBufferManager Instance owned by GPUDevice

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -40,11 +40,12 @@ Compositor::Compositor() {
 Compositor::~Compositor() {
 }
 
-void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd) {
+void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd,
+                      FrameBufferManager *frame_buffer_manager) {
   if (!thread_)
     thread_.reset(new CompositorThread());
 
-  thread_->Initialize(resource_manager, gpu_fd);
+  thread_->Initialize(resource_manager, gpu_fd, frame_buffer_manager);
 }
 
 void Compositor::BeginFrame(bool disable_explicit_sync) {

--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -39,7 +39,8 @@ class Compositor {
   Compositor();
   ~Compositor();
 
-  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd);
+  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd,
+            FrameBufferManager *frame_buffer_manager);
   void Reset();
 
   Compositor(const Compositor &) = delete;

--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -41,7 +41,9 @@ CompositorThread::~CompositorThread() {
 }
 
 void CompositorThread::Initialize(ResourceManager *resource_manager,
-                                  uint32_t gpu_fd) {
+                                  uint32_t gpu_fd,
+                                  FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   tasks_lock_.lock();
   if (!gpu_resource_handler_)
     gpu_resource_handler_.reset(CreateNativeGpuResourceHandler());
@@ -159,8 +161,6 @@ void CompositorThread::HandleReleaseRequest() {
       purged_gl_resources, purged_media_resources, &has_gpu_resource);
   size_t purged_size = purged_gl_resources.size();
 
-  FrameBufferManager *pFBManager = FrameBufferManager::GetInstance();
-
   if (purged_size != 0) {
     if (has_gpu_resource) {
       Ensure3DRenderer();
@@ -176,8 +176,8 @@ void CompositorThread::HandleReleaseRequest() {
         continue;
       }
 
-      pFBManager->RemoveFB(handle.handle_->meta_data_.num_planes_,
-                           handle.handle_->meta_data_.gem_handles_);
+      fb_manager_->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                            handle.handle_->meta_data_.gem_handles_);
 
       handler->ReleaseBuffer(handle.handle_);
       handler->DestroyHandle(handle.handle_);
@@ -199,8 +199,8 @@ void CompositorThread::HandleReleaseRequest() {
         continue;
       }
 
-      pFBManager->RemoveFB(handle.handle_->meta_data_.num_planes_,
-                           handle.handle_->meta_data_.gem_handles_);
+      fb_manager_->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                            handle.handle_->meta_data_.gem_handles_);
       handler->ReleaseBuffer(handle.handle_);
       handler->DestroyHandle(handle.handle_);
     }

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -36,13 +36,15 @@ class OverlayBuffer;
 class DisplayPlaneManager;
 class ResourceManager;
 class NativeBufferHandler;
+class FrameBufferManager;
 
 class CompositorThread : public HWCThread {
  public:
   CompositorThread();
   ~CompositorThread() override;
 
-  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd);
+  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd,
+                  FrameBufferManager* frame_buffer_manager);
 
   bool Draw(std::vector<DrawState>& states,
             std::vector<DrawState>& media_states,
@@ -85,6 +87,7 @@ class CompositorThread : public HWCThread {
   uint32_t gpu_fd_ = 0;
   FDHandler fd_chandler_;
   HWCEvent cevent_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/compositor/nativesurface.h
+++ b/common/compositor/nativesurface.h
@@ -43,7 +43,8 @@ class NativeSurface {
   virtual ~NativeSurface();
 
   bool Init(ResourceManager* resource_manager, uint32_t format, uint32_t usage,
-            uint64_t modifier, bool* modifier_succeeded);
+            uint64_t modifier, bool* modifier_succeeded,
+            FrameBufferManager* frame_buffer_manager);
 
   bool InitializeForOffScreenRendering(HWCNativeHandle native_handle,
                                        ResourceManager* resource_manager);
@@ -145,6 +146,7 @@ class NativeSurface {
   HwcRect<int> surface_damage_;
   HwcRect<int> previous_damage_;
   HwcRect<int> previous_nc_damage_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/core/framebuffermanager.cpp
+++ b/common/core/framebuffermanager.cpp
@@ -20,17 +20,6 @@
 
 namespace hwcomposer {
 
-FrameBufferManager *FrameBufferManager::pInstance = NULL;
-
-FrameBufferManager *FrameBufferManager::GetInstance() {
-  return pInstance;
-}
-
-void FrameBufferManager::CreateInstance(uint32_t gpu_fd) {
-  if (pInstance == NULL)
-    pInstance = new FrameBufferManager(gpu_fd);
-}
-
 void FrameBufferManager::RegisterGemHandles(const uint32_t &num_planes,
                                             const uint32_t (&igem_handles)[4]) {
   lock_.lock();

--- a/common/core/framebuffermanager.h
+++ b/common/core/framebuffermanager.h
@@ -77,8 +77,11 @@ struct FBEqual {
 
 class FrameBufferManager {
  public:
-  static FrameBufferManager *GetInstance();
-  static void CreateInstance(uint32_t gpu_fd);
+  FrameBufferManager(uint32_t gpu_fd) : gpu_fd_(gpu_fd) {
+  }
+  ~FrameBufferManager() {
+    PurgeAllFBs();
+  }
   void RegisterGemHandles(const uint32_t &num_planes,
                           const uint32_t (&igem_handles)[4]);
   uint32_t FindFB(const uint32_t &iwidth, const uint32_t &iheight,
@@ -89,14 +92,8 @@ class FrameBufferManager {
   int RemoveFB(uint32_t num_planes, const uint32_t (&igem_handles)[4]);
 
  private:
-  static FrameBufferManager *pInstance;
   SpinLock lock_;
   void PurgeAllFBs();
-  FrameBufferManager(uint32_t gpu_fd) : gpu_fd_(gpu_fd) {
-  }
-  ~FrameBufferManager() {
-    PurgeAllFBs();
-  }
 
   std::unordered_map<FBKey, FBValue, FBHash, FBEqual> fb_map_;
   uint32_t gpu_fd_ = 0;

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -60,6 +60,8 @@ bool GpuDevice::Initialize() {
 
   thread_stage_lock_.unlock();
   HandleHWCSettings();
+  frame_buffer_manager_.reset(
+      new FrameBufferManager(display_manager_->GetFD()));
   InitializeHotPlugEvents(false);
 
   initialization_state_ |= kInitialized;
@@ -650,7 +652,7 @@ void GpuDevice::InitializeHotPlugEvents(bool take_lock) {
     // Take a lock to ensure displaymanager is all initialized.
     thread_stage_lock_.lock();
   }
-  display_manager_->InitializeDisplayResources();
+  display_manager_->InitializeDisplayResources(frame_buffer_manager_.get());
   display_manager_->StartHotPlugMonitor();
   if (take_lock)
     thread_stage_lock_.unlock();

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -35,7 +35,8 @@ LogicalDisplay::LogicalDisplay(LogicalDisplayManager *display_manager,
 LogicalDisplay::~LogicalDisplay() {
 }
 
-bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                                FrameBufferManager * /*frame_buffer_manager*/) {
   return true;
 }
 

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -35,7 +35,8 @@ class LogicalDisplay : public NativeDisplay {
                  uint32_t index);
   ~LogicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager * /*frame_buffer_manager*/) override;
 
   DisplayType Type() const override {
     return DisplayType::kLogical;

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -76,7 +76,8 @@ MosaicDisplay::MosaicDisplay(const std::vector<NativeDisplay *> &displays)
 MosaicDisplay::~MosaicDisplay() {
 }
 
-bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                               FrameBufferManager * /*frame_buffer_manager*/) {
   return true;
 }
 

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -32,7 +32,8 @@ class MosaicDisplay : public NativeDisplay {
   MosaicDisplay(const std::vector<NativeDisplay *> &displays);
   ~MosaicDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager * /*frame_buffer_manager*/) override;
 
   DisplayType Type() const override {
     return DisplayType::kMosaic;

--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -158,7 +158,9 @@ void NestedDisplay::InitNestedDisplay(uint32_t width, uint32_t height,
 #endif
 }
 
-bool NestedDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool NestedDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                               FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   return true;
 }
 
@@ -216,7 +218,8 @@ bool NestedDisplay::Present(std::vector<HwcLayer *> &source_layers,
     if (search == mHyperDmaExportedBuffers.end()) {
       std::shared_ptr<OverlayBuffer> buffer(NULL);
       buffer = OverlayBuffer::CreateOverlayBuffer();
-      buffer->InitializeFromNativeHandle(sf_handle, resource_manager_.get());
+      buffer->InitializeFromNativeHandle(sf_handle, resource_manager_.get(),
+                                         fb_manager_);
 
       if (mHyperDmaBuf_Fd > 0 && buffer->GetPrimeFD() > 0) {
         struct ioctl_hyper_dmabuf_export_remote msg;

--- a/common/core/nesteddisplay.h
+++ b/common/core/nesteddisplay.h
@@ -102,7 +102,8 @@ class NestedDisplay : public NativeDisplay {
   void InitNestedDisplay(uint32_t width, uint32_t height,
                          uint32_t port) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager *frame_buffer_manager) override;
 
   DisplayType Type() const override {
     return DisplayType::kNested;
@@ -187,6 +188,7 @@ class NestedDisplay : public NativeDisplay {
   uint32_t port_ = 0;
   bool enable_vsync_ = false;
   uint32_t config_ = 1;
+  FrameBufferManager *fb_manager_ = NULL;
 
 #ifdef NESTED_DISPLAY_SUPPORT
   int mHyperDmaBuf_Fd = -1;

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -72,7 +72,8 @@ std::shared_ptr<OverlayBuffer>& OverlayLayer::GetSharedBuffer() const {
 
 void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
                              ResourceManager* resource_manager,
-                             bool register_buffer) {
+                             bool register_buffer,
+                             FrameBufferManager* frame_buffer_manager) {
   std::shared_ptr<OverlayBuffer> buffer(NULL);
 
   uint32_t id;
@@ -85,7 +86,8 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
 
   if (buffer == NULL) {
     buffer = OverlayBuffer::CreateOverlayBuffer();
-    buffer->InitializeFromNativeHandle(handle, resource_manager);
+    buffer->InitializeFromNativeHandle(handle, resource_manager,
+                                       frame_buffer_manager);
     if (resource_manager && register_buffer) {
       resource_manager->RegisterBuffer(id, buffer);
     }
@@ -203,7 +205,8 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
                                    OverlayLayer* previous_layer,
                                    uint32_t z_order, uint32_t layer_index,
                                    uint32_t max_height, uint32_t rotation,
-                                   bool handle_constraints) {
+                                   bool handle_constraints,
+                                   FrameBufferManager* frame_buffer_manager) {
   transform_ = layer->GetTransform();
   if (rotation != kRotateNone) {
     ValidateTransform(layer->GetTransform(), rotation);
@@ -239,7 +242,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   }
 
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
-            resource_manager, true);
+            resource_manager, true, frame_buffer_manager);
 
   if (!surface_damage_.empty()) {
     if (type_ == kLayerCursor) {
@@ -371,22 +374,25 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
 void OverlayLayer::InitializeFromHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
-    uint32_t max_height, uint32_t rotation, bool handle_constraints) {
+    uint32_t max_height, uint32_t rotation, bool handle_constraints,
+    FrameBufferManager* frame_buffer_manager) {
   display_frame_width_ = layer->GetDisplayFrameWidth();
   display_frame_height_ = layer->GetDisplayFrameHeight();
   display_frame_ = layer->GetDisplayFrame();
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints);
+                  max_height, rotation, handle_constraints,
+                  frame_buffer_manager);
 }
 
 void OverlayLayer::InitializeFromScaledHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
     const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
-    bool handle_constraints) {
+    bool handle_constraints, FrameBufferManager* frame_buffer_manager) {
   SetDisplayFrame(display_frame);
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints);
+                  max_height, rotation, handle_constraints,
+                  frame_buffer_manager);
 }
 
 void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
@@ -481,7 +487,8 @@ void OverlayLayer::ValidateForOverlayUsage() {
 void OverlayLayer::CloneLayer(const OverlayLayer* layer,
                               const HwcRect<int>& display_frame,
                               ResourceManager* resource_manager,
-                              uint32_t z_order) {
+                              uint32_t z_order,
+                              FrameBufferManager* frame_buffer_manager) {
   int32_t fence = layer->GetAcquireFence();
   int32_t aquire_fence = 0;
   if (fence > 0) {
@@ -490,7 +497,7 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   SetDisplayFrame(display_frame);
   SetSourceCrop(layer->GetSourceCrop());
   SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
-            resource_manager, true);
+            resource_manager, true, frame_buffer_manager);
   ValidateForOverlayUsage();
   surface_damage_ = display_frame;
   transform_ = layer->transform_;

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -49,15 +49,14 @@ struct OverlayLayer {
   void InitializeFromHwcLayer(HwcLayer* layer, ResourceManager* buffer_manager,
                               OverlayLayer* previous_layer, uint32_t z_order,
                               uint32_t layer_index, uint32_t max_height,
-                              uint32_t rotation, bool handle_constraints);
+                              uint32_t rotation, bool handle_constraints,
+                              FrameBufferManager* frame_buffer_manager);
 
-  void InitializeFromScaledHwcLayer(HwcLayer* layer,
-                                    ResourceManager* buffer_manager,
-                                    OverlayLayer* previous_layer,
-                                    uint32_t z_order, uint32_t layer_index,
-                                    const HwcRect<int>& display_frame,
-                                    uint32_t max_height, uint32_t rotation,
-                                    bool handle_constraints);
+  void InitializeFromScaledHwcLayer(
+      HwcLayer* layer, ResourceManager* buffer_manager,
+      OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
+      const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
+      bool handle_constraints, FrameBufferManager* frame_buffer_manager);
   // Get z order of this layer.
   uint32_t GetZorder() const {
     return z_order_;
@@ -101,7 +100,8 @@ struct OverlayLayer {
   OverlayBuffer* GetBuffer() const;
 
   void SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
-                 ResourceManager* buffer_manager, bool register_buffer);
+                 ResourceManager* buffer_manager, bool register_buffer,
+                 FrameBufferManager* frame_buffer_manager);
 
   std::shared_ptr<OverlayBuffer>& GetSharedBuffer() const;
 
@@ -207,7 +207,8 @@ struct OverlayLayer {
   }
 
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
-                  ResourceManager* resource_manager, uint32_t z_order);
+                  ResourceManager* resource_manager, uint32_t z_order,
+                  FrameBufferManager* frame_buffer_manager);
 
   void Dump();
 
@@ -244,7 +245,8 @@ struct OverlayLayer {
   void InitializeState(HwcLayer* layer, ResourceManager* buffer_manager,
                        OverlayLayer* previous_layer, uint32_t z_order,
                        uint32_t layer_index, uint32_t max_height,
-                       uint32_t rotation, bool handle_constraints);
+                       uint32_t rotation, bool handle_constraints,
+                       FrameBufferManager* frame_buffer_manager);
 
   uint32_t transform_ = 0;
   uint32_t plane_transform_ = 0;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -41,7 +41,9 @@ DisplayPlaneManager::DisplayPlaneManager(DisplayPlaneHandler *plane_handler,
 DisplayPlaneManager::~DisplayPlaneManager() {
 }
 
-bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height) {
+bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height,
+                                     FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   width_ = width;
   height_ = height;
   bool status = plane_handler_->PopulatePlanes(overlay_planes_);
@@ -712,7 +714,7 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 
     bool modifer_succeeded = false;
     new_surface->Init(resource_manager_, preferred_format, usage, modifier,
-                      &modifer_succeeded);
+                      &modifer_succeeded, fb_manager_);
 
     if (modifer_succeeded) {
       plane.GetDisplayPlane()->PreferredFormatModifierValidated();
@@ -759,7 +761,7 @@ bool DisplayPlaneManager::FallbacktoGPU(
     return true;
 
   if (layer->GetBuffer()->GetFb() == 0) {
-    if (!layer->GetBuffer()->CreateFrameBuffer()) {
+    if (!layer->GetBuffer()->CreateFrameBuffer(fb_manager_)) {
       return true;
     }
   }

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -40,7 +40,8 @@ class DisplayPlaneManager {
 
   virtual ~DisplayPlaneManager();
 
-  bool Initialize(uint32_t width, uint32_t height);
+  bool Initialize(uint32_t width, uint32_t height,
+                  FrameBufferManager *frame_buffer_manager);
 
   bool ValidateLayers(std::vector<OverlayLayer> &layers, int add_index,
                       bool disable_overlay, bool *commit_checked,
@@ -176,6 +177,7 @@ class DisplayPlaneManager {
   uint32_t total_overlays_;
   uint32_t display_transform_;
   bool release_surfaces_;
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -61,6 +61,7 @@ class DisplayQueue {
   ~DisplayQueue();
 
   bool Initialize(uint32_t pipe, uint32_t width, uint32_t height,
+                  FrameBufferManager* frame_buffer_manager,
                   DisplayPlaneHandler* plane_manager);
 
   bool QueueUpdate(std::vector<HwcLayer*>& source_layers, int32_t* retire_fence,
@@ -356,6 +357,7 @@ class DisplayQueue {
   bool clone_mode_ = false;
   // Set to true if this queue needs to render the offscreen surfaces.
   bool clone_rendered_ = false;
+  FrameBufferManager* fb_manager_ = NULL;
   // Surfaces to be marked as not in use. These
   // are surfaces which are added to surfaces_not_inuse_
   // below.

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -33,14 +33,15 @@ namespace hwcomposer {
 
 VirtualDisplay::VirtualDisplay(uint32_t gpu_fd,
                                NativeBufferHandler *buffer_handler,
-                               uint32_t /*pipe_id*/, uint32_t /*crtc_id*/)
+                               uint32_t /*pipe_id*/, uint32_t /*crtc_id*/,
+                               FrameBufferManager *frame_buffer_manager)
     : output_handle_(0), acquire_fence_(-1), width_(0), height_(0) {
   resource_manager_.reset(new ResourceManager(buffer_handler));
   if (!resource_manager_) {
     ETRACE("Failed to construct hwc layer buffer manager");
   }
 
-  compositor_.Init(resource_manager_.get(), gpu_fd);
+  compositor_.Init(resource_manager_.get(), gpu_fd, frame_buffer_manager);
 }
 
 VirtualDisplay::~VirtualDisplay() {
@@ -110,7 +111,7 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
     overlay_layer.InitializeFromHwcLayer(
         layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-        height_, kIdentity, handle_constraints);
+        height_, kIdentity, handle_constraints, fb_manager_);
     index.emplace_back(z_order);
     layers_rects.emplace_back(layer->GetDisplayFrame());
     z_order++;
@@ -196,7 +197,9 @@ void VirtualDisplay::SetOutputBuffer(HWCNativeHandle buffer,
   }
 }
 
-bool VirtualDisplay::Initialize(NativeBufferHandler * /*buffer_manager*/) {
+bool VirtualDisplay::Initialize(NativeBufferHandler * /*buffer_manager*/,
+                                FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   return true;
 }
 

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -32,7 +32,8 @@ class NativeBufferHandler;
 class VirtualDisplay : public NativeDisplay {
  public:
   VirtualDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
-                 uint32_t pipe_id, uint32_t crtc_id);
+                 uint32_t pipe_id, uint32_t crtc_id,
+                 FrameBufferManager *frame_buffer_manager);
   ~VirtualDisplay() override;
 
   void InitVirtualDisplay(uint32_t width, uint32_t height) override;
@@ -47,7 +48,8 @@ class VirtualDisplay : public NativeDisplay {
 
   void SetOutputBuffer(HWCNativeHandle buffer, int32_t acquire_fence) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager *frame_buffer_manager) override;
 
   DisplayType Type() const override {
     return DisplayType::kVirtual;
@@ -89,6 +91,7 @@ class VirtualDisplay : public NativeDisplay {
   std::vector<OverlayLayer> in_flight_layers_;
   HWCNativeHandle handle_ = 0;
   std::unique_ptr<ResourceManager> resource_manager_;
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "displaymanager.h"
+#include "framebuffermanager.h"
 #include "hwcthread.h"
 #include "logicaldisplaymanager.h"
 #include "nativedisplay.h"
@@ -100,6 +101,7 @@ class GpuDevice : public HWCThread {
   void HandleRoutine() override;
   void HandleWait() override;
   std::unique_ptr<DisplayManager> display_manager_;
+  std::unique_ptr<FrameBufferManager> frame_buffer_manager_;
   std::vector<std::unique_ptr<LogicalDisplayManager>> logical_display_manager_;
   std::vector<std::unique_ptr<NativeDisplay>> mosaic_displays_;
   std::vector<NativeDisplay*> total_displays_;

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -32,6 +32,7 @@ namespace hwcomposer {
 struct HwcLayer;
 class GpuDevice;
 class NativeBufferHandler;
+class FrameBufferManager;
 
 class VsyncCallback {
  public:
@@ -71,7 +72,8 @@ class NativeDisplay {
   NativeDisplay(const NativeDisplay &rhs) = delete;
   NativeDisplay &operator=(const NativeDisplay &rhs) = delete;
 
-  virtual bool Initialize(NativeBufferHandler *buffer_handler) = 0;
+  virtual bool Initialize(NativeBufferHandler *buffer_handler,
+                          FrameBufferManager *frame_buffer_manager) = 0;
 
   virtual DisplayType Type() const = 0;
 

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -24,6 +24,7 @@
 namespace hwcomposer {
 
 class GpuDevice;
+class FrameBufferManager;
 class DisplayManager {
  public:
   static DisplayManager *CreateDisplayManager(GpuDevice *device);
@@ -40,7 +41,8 @@ class DisplayManager {
 
   // GetAllDisplays is expected to return set
   // of correct displays after this call is done.
-  virtual void InitializeDisplayResources() = 0;
+  virtual void InitializeDisplayResources(
+      FrameBufferManager *frame_buffer_manager) = 0;
 
   // Display Manager should initialize resources to start monitoring
   // for Hotplug events.

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -23,6 +23,7 @@
 namespace hwcomposer {
 
 class NativeBufferHandler;
+class FrameBufferManager;
 
 class DrmBuffer : public OverlayBuffer {
  public:
@@ -33,8 +34,9 @@ class DrmBuffer : public OverlayBuffer {
 
   ~DrmBuffer() override;
 
-  void InitializeFromNativeHandle(HWCNativeHandle handle,
-                                  ResourceManager* buffer_manager) override;
+  void InitializeFromNativeHandle(
+      HWCNativeHandle handle, ResourceManager* buffer_manager,
+      FrameBufferManager* frame_buffer_manager) override;
 
   uint32_t GetWidth() const override {
     return width_;
@@ -81,9 +83,10 @@ class DrmBuffer : public OverlayBuffer {
                                               uint32_t width,
                                               uint32_t height) override;
 
-  bool CreateFrameBuffer() override;
+  bool CreateFrameBuffer(FrameBufferManager* frame_buffer_manager) override;
 
-  bool CreateFrameBufferWithModifier(uint64_t modifier) override;
+  bool CreateFrameBufferWithModifier(
+      uint64_t modifier, FrameBufferManager* frame_buffer_manager) override;
 
   HWCNativeHandle GetOriginalHandle() const override {
     return original_handle_;
@@ -94,7 +97,8 @@ class DrmBuffer : public OverlayBuffer {
   void Dump() override;
 
  private:
-  void Initialize(const HwcBuffer& bo);
+  void Initialize(const HwcBuffer& bo,
+                  FrameBufferManager* frame_buffer_manager);
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint32_t format_ = 0;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -36,8 +36,6 @@
 
 #include <nativebufferhandler.h>
 
-#include "framebuffermanager.h"
-
 namespace hwcomposer {
 
 DrmDisplayManager::DrmDisplayManager(GpuDevice *device)
@@ -168,10 +166,9 @@ void DrmDisplayManager::HandleWait() {
   }
 }
 
-void DrmDisplayManager::InitializeDisplayResources() {
+void DrmDisplayManager::InitializeDisplayResources(
+    FrameBufferManager *frame_buffer_manager) {
   buffer_handler_.reset(NativeBufferHandler::CreateInstance(fd_));
-  // FIXME: Remove this once #303 is fixed.
-  FrameBufferManager::CreateInstance(fd_);
   if (!buffer_handler_) {
     ETRACE("Failed to create native buffer handler instance");
     return;
@@ -179,12 +176,14 @@ void DrmDisplayManager::InitializeDisplayResources() {
 
   int size = displays_.size();
   for (int i = 0; i < size; ++i) {
-    if (!displays_.at(i)->Initialize(buffer_handler_.get())) {
+    if (!displays_.at(i)->Initialize(buffer_handler_.get(),
+                                     frame_buffer_manager)) {
       ETRACE("Failed to Initialize Display %d", i);
     }
   }
 
-  virtual_display_.reset(new VirtualDisplay(fd_, buffer_handler_.get(), 0, 0));
+  virtual_display_.reset(new VirtualDisplay(fd_, buffer_handler_.get(), 0, 0,
+                                            frame_buffer_manager));
   nested_display_.reset(new NestedDisplay(fd_, buffer_handler_.get()));
 }
 

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -39,6 +39,7 @@ namespace hwcomposer {
 #define DRM_HOTPLUG_EVENT_SIZE 256
 
 class NativeDisplay;
+class FrameBufferManager;
 
 class DrmDisplayManager : public HWCThread, public DisplayManager {
  public:
@@ -47,7 +48,8 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   bool Initialize() override;
 
-  void InitializeDisplayResources() override;
+  void InitializeDisplayResources(
+      FrameBufferManager *frame_buffer_manager) override;
 
   void StartHotPlugMonitor() override;
 

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -22,6 +22,8 @@
 
 #include "compositordefs.h"
 
+#include "framebuffermanager.h"
+
 #include "hwcdefs.h"
 
 namespace hwcomposer {
@@ -40,8 +42,9 @@ class OverlayBuffer {
   virtual ~OverlayBuffer() {
   }
 
-  virtual void InitializeFromNativeHandle(HWCNativeHandle handle,
-                                          ResourceManager* buffer_manager) = 0;
+  virtual void InitializeFromNativeHandle(
+      HWCNativeHandle handle, ResourceManager* buffer_manager,
+      FrameBufferManager* frame_buffer_manager) = 0;
 
   virtual uint32_t GetWidth() const = 0;
 
@@ -76,10 +79,11 @@ class OverlayBuffer {
                                                       uint32_t width,
                                                       uint32_t height) = 0;
 
-  virtual bool CreateFrameBuffer() = 0;
+  virtual bool CreateFrameBuffer(FrameBufferManager* frame_buffer_manager) = 0;
 
   // Creates Framebuffer taking into account any Modifiers.
-  virtual bool CreateFrameBufferWithModifier(uint64_t modifier) = 0;
+  virtual bool CreateFrameBufferWithModifier(
+      uint64_t modifier, FrameBufferManager* frame_buffer_manager) = 0;
 
   virtual HWCNativeHandle GetOriginalHandle() const = 0;
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -45,7 +45,9 @@ PhysicalDisplay::PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id)
 PhysicalDisplay::~PhysicalDisplay() {
 }
 
-bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler) {
+bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler,
+                                 FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   display_queue_.reset(new DisplayQueue(gpu_fd_, false, buffer_handler, this));
   InitializeDisplay();
   return true;
@@ -162,7 +164,7 @@ void PhysicalDisplay::Connect() {
   display_state_ |= kNotifyClient;
   IHOTPLUGEVENTTRACE("PhysicalDisplay::Connect recieved. %p \n", this);
 
-  if (!display_queue_->Initialize(pipe_, width_, height_, this)) {
+  if (!display_queue_->Initialize(pipe_, width_, height_, fb_manager_, this)) {
     ETRACE("Failed to initialize Display Queue.");
   } else {
     display_state_ |= kInitialized;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -43,7 +43,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id);
   ~PhysicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager *frame_buffer_manager) override;
 
   DisplayType Type() const override {
     return DisplayType::kInternal;
@@ -288,6 +289,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
This patch addresses issue #303 and has the GpuDevice take ownership
of the FrameBufferManager Instance which then gets passed to all
displays on initialization to pass to the drmbuffer and the
compositorthread as needed in place of calling the instances from
FrameBufferManager directly.

Jira: None
Test: HWC build passes without errors
Signed-off-by: Richard Avelar richard.avelar@intel.com