### PR TITLE
update for fix compile warning -W#warnings -Wunused-parameter

### DIFF
--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -191,6 +191,7 @@ bool NestedDisplay::Present(std::vector<HwcLayer *> &source_layers,
                             int32_t * /*retire_fence*/,
                             bool /*handle_constraints*/) {
 #ifndef NESTED_DISPLAY_SUPPORT
+  (void)source_layers;
   return true;
 #else
   int ret = 0;

--- a/os/android/iahwc1.cpp
+++ b/os/android/iahwc1.cpp
@@ -18,7 +18,7 @@
 
 #include <inttypes.h>
 
-#include <cutils/log.h>
+#include <android/log.h>
 #include <cutils/properties.h>
 #include <sw_sync.h>
 #include <sync/sync.h>

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -81,6 +81,7 @@ void DrmBuffer::Initialize(const HwcBuffer& bo) {
 void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
                                            ResourceManager* resource_manager,
                                            bool is_cursor_buffer) {
+  (void)is_cursor_buffer; /* for avoid unused parameter warning*/
   resource_manager_ = resource_manager;
   const NativeBufferHandler* handler =
       resource_manager_->GetNativeBufferHandler();


### PR DESCRIPTION
    update for fix compile warning : "Deprecated: don't include cutils/log.h, use either android/log.h or log/log.h" [-W#warnings]
    update for fix compile warning : unused parameter 'source_layers' [-Wunused-parameter]

    Jira: GSE-1411
    Tests: compilation with warning clean