### PR TITLE
Keep the code of layers force GPU to fix black screen when do UI switch.

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -221,6 +221,7 @@ bool DisplayPlaneManager::ValidateLayers(
 
           break;
         } else {
+          bool force_all_layers = true;
           if (composition.empty()) {
             composition.emplace_back(plane, layer, this, layer->GetZorder(),
                                      display_transform_);
@@ -247,11 +248,18 @@ bool DisplayPlaneManager::ValidateLayers(
                   last_plane.SetRotationType(
                       DisplayPlaneState::RotationType::kGPURotation, true);
                 } else {
+                  force_all_layers = false;
                   validate_final_layers = false;
                 }
               }
             }
-
+            if (force_all_layers) {
+              ForceGpuForAllLayers(commit_planes, composition, layers,
+                                   mark_later, false);
+              *re_validation_needed = false;
+              *commit_checked = true;
+              return true;
+            }
             break;
           } else {
             commit_planes.pop_back();


### PR DESCRIPTION
The 3rd display may show black screen when remove the layers force GPU
for removed/added layers, so keep those code to fic the black screen
issue.

Jira: None.
Test: Switch UI with remove/add layers to check if there are black screen.

Signed-off-by: Fan Yugang <yugang.fan@intel.com>

@kalyankondapally i tried the original PR in latest master and met crash, so i just did the rebase and submit new PR here. pls noticed that we can't revert this file to original commit as the revert around "if (composition.empty()) " will cause the crash of hwc.