### PR TITLE
Fix incomplete display  after 90/270 degree rotation

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -250,9 +250,14 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
       switch (plane_transform_) {
         case HWCTransform::kTransform270:
         case HWCTransform::kTransform90: {
-          std::swap(surface_damage_.left, surface_damage_.top);
-          std::swap(surface_damage_.right, surface_damage_.bottom);
-          break;
+	   bool swap = true;
+	   if (surface_damage_ == display_frame_) {
+	     swap = false;
+	   }
+           if(swap){
+	     std::swap(surface_damage_.right, surface_damage_.bottom);
+	   }
+           break;
         }
         default:
           break;


### PR DESCRIPTION
After 90/270 degree rotation is done,the source layer dimensions are already updated, so swap is not required
here.

Jira: 59439
Test: Rendering works fine when displays are rotated 90/270

Signed-off-by: samiuddi sami.uddin.mohammad@intel.com