### PR TITLE
Fix incomplete Display after swipe up the screen to main menu when layer transformed to 90/270 degree

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -250,12 +250,17 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
       switch (plane_transform_) {
         case HWCTransform::kTransform270:
         case HWCTransform::kTransform90: {
-          std::swap(surface_damage_.left, surface_damage_.top);
-          std::swap(surface_damage_.right, surface_damage_.bottom);
-          break;
-        }
-        default:
-          break;
+         bool swap = true;
+	if (surface_damage_ == display_frame_) {
+	swap = false;
+	} 
+   	 if (swap) {
+         std::swap(surface_damage_.right, surface_damage_.bottom);
+        }
+       break;
+     }
+     default:  
+       break;
       }
     }
   }


### PR DESCRIPTION
Fix incomplete Display after swipe up the screen to main menu in Portrait Mode

Jira: 59439
Test: Rendering works fine when display is rotated 90/270 degrees.
Signed-off-by: reddyr3x <rakeshx.reddy@intel.com>