### PR TITLE
Adjust formatting in core files

### DIFF
--- a/common/core/framebuffermanager.h
+++ b/common/core/framebuffermanager.h
@@ -39,8 +39,8 @@ map.
 #define COMMON_CORE_FRAMEBUFFER_MANAGER_H_
 
 #include <hwcdefs.h>
-#include <platformdefines.h>
 #include <hwctrace.h>
+#include <platformdefines.h>
 
 #include <memory>
 #include <unordered_map>

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -609,8 +609,8 @@ void GpuDevice::EnableHDCPSessionForDisplay(uint32_t display,
 void GpuDevice::EnableHDCPSessionForAllDisplays(HWCContentType content_type) {
   size_t size = total_displays_.size();
   for (size_t i = 0; i < size; i++) {
-    total_displays_.at(i)
-        ->SetHDCPState(HWCContentProtection::kDesired, content_type);
+    total_displays_.at(i)->SetHDCPState(HWCContentProtection::kDesired,
+                                        content_type);
   }
 }
 

--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -274,7 +274,7 @@ int32_t HwcLayer::GetLeftConstraint() {
   if (total == 1)
     return left_constraint_.at(0);
 
-    std::vector<int32_t> temp;
+  std::vector<int32_t> temp;
   for (size_t i = 1; i < total; i++) {
     temp.emplace_back(left_constraint_.at(i));
   }
@@ -285,21 +285,21 @@ int32_t HwcLayer::GetLeftConstraint() {
 }
 
 int32_t HwcLayer::GetRightConstraint() {
-    size_t total = right_constraint_.size();
-    if (total == 0)
-      return -1;
+  size_t total = right_constraint_.size();
+  if (total == 0)
+    return -1;
 
-    if (total == 1)
-      return right_constraint_.at(0);
+  if (total == 1)
+    return right_constraint_.at(0);
 
-      std::vector<int32_t> temp;
-    for (size_t i = 1; i < total; i++) {
-      temp.emplace_back(right_constraint_.at(i));
-    }
+  std::vector<int32_t> temp;
+  for (size_t i = 1; i < total; i++) {
+    temp.emplace_back(right_constraint_.at(i));
+  }
 
-    uint32_t value = right_constraint_.at(0);
-    right_constraint_.swap(temp);
-    return value;
+  uint32_t value = right_constraint_.at(0);
+  right_constraint_.swap(temp);
+  return value;
 }
 
 void HwcLayer::SetLeftSourceConstraint(int32_t left_constraint) {

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -16,8 +16,8 @@
 
 #include "logicaldisplay.h"
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "logicaldisplaymanager.h"
 
@@ -53,8 +53,8 @@ int LogicalDisplay::GetDisplayPipe() {
 
 bool LogicalDisplay::SetActiveConfig(uint32_t config) {
   bool success = physical_display_->SetActiveConfig(config);
-    width_ = (physical_display_->Width()) / total_divisions_;
-    return success;
+  width_ = (physical_display_->Width()) / total_divisions_;
+  return success;
 }
 
 bool LogicalDisplay::GetActiveConfig(uint32_t *config) {

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -17,8 +17,8 @@
 #ifndef WSI_LOGICALDISPLAY_H_
 #define WSI_LOGICALDISPLAY_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <memory>
 
@@ -80,8 +80,8 @@ class LogicalDisplay : public NativeDisplay {
   void SetVideoColor(HWCColorControl color, float value) override;
   void GetVideoColor(HWCColorControl color, float *value, float *start,
                      float *end) override;
-  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
-                      uint16_t blue, uint16_t alpha) override;
+  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green, uint16_t blue,
+                      uint16_t alpha) override;
   void RestoreVideoDefaultColor(HWCColorControl color) override;
   void SetVideoDeinterlace(HWCDeinterlaceFlag flag,
                            HWCDeinterlaceControl mode) override;

--- a/common/core/logicaldisplaymanager.cpp
+++ b/common/core/logicaldisplaymanager.cpp
@@ -16,8 +16,8 @@
 
 #include "logicaldisplaymanager.h"
 
-#include "logicaldisplay.h"
 #include <hwclayer.h>
+#include "logicaldisplay.h"
 
 namespace hwcomposer {
 
@@ -78,10 +78,12 @@ void LogicalDisplayManager::InitializeLogicalDisplays(uint32_t total) {
   }
 
   auto r_callback = std::make_shared<LDMRefreshCallback>(this);
-  physical_display_->RegisterRefreshCallback(r_callback, physical_display_->GetDisplayPipe());
+  physical_display_->RegisterRefreshCallback(
+      r_callback, physical_display_->GetDisplayPipe());
 
   auto v_callback = std::make_shared<LDMVsyncCallback>(this);
-  physical_display_->RegisterVsyncCallback(v_callback, physical_display_->GetDisplayPipe());
+  physical_display_->RegisterVsyncCallback(v_callback,
+                                           physical_display_->GetDisplayPipe());
 }
 
 void LogicalDisplayManager::UpdatePowerMode() {
@@ -213,11 +215,12 @@ void LogicalDisplayManager::HotPlugCallback(bool connected) {
   }
 }
 
-void LogicalDisplayManager::GetLogicalDisplays(std::vector<LogicalDisplay*>& displays) {
-    uint32_t size = displays_.size();
-    for (uint32_t i = 0; i < size; i++) {
-      displays.emplace_back(displays_.at(i).get());
-    }
+void LogicalDisplayManager::GetLogicalDisplays(
+    std::vector<LogicalDisplay*>& displays) {
+  uint32_t size = displays_.size();
+  for (uint32_t i = 0; i < size; i++) {
+    displays.emplace_back(displays_.at(i).get());
+  }
 }
 
 void LogicalDisplayManager::SetHDCPState(HWCContentProtection state,

--- a/common/core/logicaldisplaymanager.h
+++ b/common/core/logicaldisplaymanager.h
@@ -17,8 +17,8 @@
 #ifndef WSI_LOGICALDISPLAY_MANAGER_H_
 #define WSI_LOGICALDISPLAY_MANAGER_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <nativedisplay.h>
 #include "logicaldisplay.h"

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -16,8 +16,8 @@
 
 #include "mosaicdisplay.h"
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include <hwclayer.h>
 
@@ -126,10 +126,10 @@ bool MosaicDisplay::SetActiveConfig(uint32_t config) {
     int32_t refresh = 0;
     height_ = std::max(height_, physical_displays_.at(i)->Height());
     width_ += physical_displays_.at(i)->Width();
-    physical_displays_.at(i)
-        ->GetDisplayAttribute(config_, HWCDisplayAttribute::kDpiX, &dpix);
-    physical_displays_.at(i)
-        ->GetDisplayAttribute(config_, HWCDisplayAttribute::kDpiY, &dpiy);
+    physical_displays_.at(i)->GetDisplayAttribute(
+        config_, HWCDisplayAttribute::kDpiX, &dpix);
+    physical_displays_.at(i)->GetDisplayAttribute(
+        config_, HWCDisplayAttribute::kDpiY, &dpiy);
     physical_displays_.at(i)->GetDisplayAttribute(
         config_, HWCDisplayAttribute::kRefreshRate, &refresh);
     dpix_ += dpix;
@@ -183,13 +183,13 @@ bool MosaicDisplay::Present(std::vector<HwcLayer *> &source_layers,
     for (uint32_t i = 0; i < size; i++) {
       if (physical_displays_.at(i)->IsConnected()) {
         connected_displays_.emplace_back(physical_displays_.at(i));
-	for (uint32_t i = 0; i < size; i++) {
-	  int32_t refresh = 0;
-	  physical_displays_.at(i)->GetDisplayAttribute(
-	      config_, HWCDisplayAttribute::kRefreshRate, &refresh);
-	  if (previous_refresh < refresh)
-	    preferred_display_index_ = i;
-	}
+        for (uint32_t i = 0; i < size; i++) {
+          int32_t refresh = 0;
+          physical_displays_.at(i)->GetDisplayAttribute(
+              config_, HWCDisplayAttribute::kRefreshRate, &refresh);
+          if (previous_refresh < refresh)
+            preferred_display_index_ = i;
+        }
       }
     }
     update_connected_displays_ = false;

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -17,8 +17,8 @@
 #ifndef WSI_MOSAICDISPLAY_H_
 #define WSI_MOSAICDISPLAY_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <memory>
 

--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -18,11 +18,11 @@
 
 #include <nativebufferhandler.h>
 
-#include <string>
 #include <sstream>
+#include <string>
 
-#include <hwctrace.h>
 #include <hwclayer.h>
+#include <hwctrace.h>
 
 namespace hwcomposer {
 #ifdef NESTED_DISPLAY_SUPPORT

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -23,8 +23,8 @@
 
 #include "hwcutils.h"
 
-#include "resourcemanager.h"
 #include "nativebufferhandler.h"
+#include "resourcemanager.h"
 
 namespace hwcomposer {
 
@@ -239,7 +239,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   }
 
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
-	    resource_manager, true);
+            resource_manager, true);
 
   if (!surface_damage_.empty()) {
     if (type_ == kLayerCursor) {
@@ -315,7 +315,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
     display_frame_height_ = display_frame_.bottom - display_frame_.top;
 
     if ((surface_damage_.left < display_frame_.left) &&
-	(surface_damage_.right > display_frame_.left)) {
+        (surface_damage_.right > display_frame_.left)) {
       surface_damage_.left = display_frame_.left;
     }
 

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -20,8 +20,8 @@
 #include <hwcdefs.h>
 #include <platformdefines.h>
 
-#include <memory>
 #include <hwclayer.h>
+#include <memory>
 
 #include "overlaybuffer.h"
 

--- a/common/core/resourcemanager.h
+++ b/common/core/resourcemanager.h
@@ -39,8 +39,8 @@ map.
 #define COMMON_CORE_RESOURCE_MANAGER_H_
 
 #include <hwcdefs.h>
-#include <platformdefines.h>
 #include <hwctrace.h>
+#include <platformdefines.h>
 
 #include <memory>
 #include <unordered_map>


### PR DESCRIPTION
In order to fix some of the formatting conventions in headers and indention that caused code to appear to be in another scope, I adjusted some of the lines in the core folder.

Jira: None
Test: Builds without error
Signed-off-by: Richard Avelar richard.avelar@intel.com