### PR TITLE
Fix bug where assignment has no effect

### DIFF
--- a/os/linux/pixeluploader.cpp
+++ b/os/linux/pixeluploader.cpp
@@ -209,7 +209,6 @@ void PixelUploader::Unmap(uint32_t prime_fd, void* addr, size_t size) {
     sync_start.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_RW;
     ioctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync_start);
     munmap(addr, size);
-    addr = nullptr;
   }
 }
 


### PR DESCRIPTION
Currently we pass in addr and use it to check the condition. Once inside we assign a nullptr to addr. However, the assignment of function parameter has no effect outside the function. 

Jira: None
Test: Build passes without error
Signed-off-by: Richard Avelar richard.avelar@intel.com