### PR TITLE
Pixel_uploader: Upload only damaged region.

### DIFF
--- a/os/linux/linux_frontend.cpp
+++ b/os/linux/linux_frontend.cpp
@@ -555,19 +555,16 @@ int IAHWC::IAHWCLayer::SetRawPixelData(iahwc_raw_pixel_data bo) {
       return -1;
     }
 
+    orig_width_ = bo.width;
     orig_height_ = bo.height;
     orig_stride_ = bo.stride;
-    upload_in_progress_ = true;
-    raw_data_uploader_->UpdateLayerPixelData(pixel_buffer_, orig_height_,
-                                             orig_stride_, bo.callback_data,
-                                             (uint8_t*)bo.buffer, this);
     iahwc_layer_.SetNativeHandle(pixel_buffer_);
-  } else {
-    upload_in_progress_ = true;
-    raw_data_uploader_->UpdateLayerPixelData(pixel_buffer_, orig_height_,
-                                             orig_stride_, bo.callback_data,
-                                             (uint8_t*)bo.buffer, this);
   }
+
+  upload_in_progress_ = true;
+  raw_data_uploader_->UpdateLayerPixelData(
+      pixel_buffer_, orig_width_, orig_height_, orig_stride_, bo.callback_data,
+      (uint8_t*)bo.buffer, this, iahwc_layer_.GetSurfaceDamage());
 
   return IAHWC_ERROR_NONE;
 }

--- a/os/linux/linux_frontend.h
+++ b/os/linux/linux_frontend.h
@@ -66,6 +66,7 @@ class IAHWC : public iahwc_device {
     hwcomposer::HwcLayer iahwc_layer_;
     struct gbm_handle hwc_handle_;
     HWCNativeHandle pixel_buffer_ = NULL;
+    uint32_t orig_width_ = 0;
     uint32_t orig_height_ = 0;
     uint32_t orig_stride_ = 0;
     PixelUploader* raw_data_uploader_ = NULL;

--- a/os/linux/pixeluploader.h
+++ b/os/linux/pixeluploader.h
@@ -57,10 +57,11 @@ class PixelUploader : public HWCThread {
   void RegisterPixelUploaderCallback(
       std::shared_ptr<RawPixelUploadCallback> callback);
 
-  void UpdateLayerPixelData(HWCNativeHandle handle, uint32_t original_height,
-                            uint32_t original_stride, void* callback_data,
-                            uint8_t* byteaddr,
-                            PixelUploaderLayerCallback* layer_callback);
+  void UpdateLayerPixelData(HWCNativeHandle handle, uint32_t original_width,
+                            uint32_t original_height, uint32_t original_stride,
+                            void* callback_data, uint8_t* byteaddr,
+                            PixelUploaderLayerCallback* layer_callback,
+                            HwcRect<int> surfaceDamage);
 
   const NativeBufferHandler* GetNativeBufferHandler() const {
     return buffer_handler_;
@@ -81,11 +82,13 @@ class PixelUploader : public HWCThread {
 
   struct PixelData {
     HWCNativeHandle handle_;
+    uint32_t original_width_ = 0;
     uint32_t original_height_ = 0;
     uint32_t original_stride_ = 0;
     void* callback_data_ = 0;
     uint8_t* data_ = NULL;
     PixelUploaderLayerCallback* layer_callback_ = NULL;
+    HwcRect<int> surfaceDamage;
   };
 
   void HandleRawPixelUpdate();


### PR DESCRIPTION
Take the surface damage into account when uploading shm
memory. This patch also reorders the layer's state setting
so that the damage, layer usage properties are set before
setting the damage.

Jira: None
Test: Weston-simple-damage still renders correctly

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>