### PR TITLE
Remove various dead code

### DIFF
--- a/os/alios/utils_alios.h
+++ b/os/alios/utils_alios.h
@@ -259,7 +259,6 @@ static void DestroyBufferHandle(HWCNativeHandle handle) {
     free_buffer_handle(handle->imported_target_);
 
   delete handle;
-  handle = NULL;
 }
 
 static struct yalloc_drm_handle_t AttrData2YallocHandle(

--- a/os/alios/yallocbufferhandler.h
+++ b/os/alios/yallocbufferhandler.h
@@ -53,7 +53,6 @@ class YallocBufferHandler : public NativeBufferHandler {
  private:
   uint32_t fd_;
   struct yalloc_device_t *device_;
-  fb_device_t *mFbDevice;
 };
 
 }  // namespace hwcomposer

--- a/os/android/gralloc1bufferhandler.h
+++ b/os/android/gralloc1bufferhandler.h
@@ -57,7 +57,6 @@ class Gralloc1BufferHandler : public NativeBufferHandler {
   uint32_t ConvertHalFormatToDrm(uint32_t hal_format);
   uint32_t fd_;
   const hw_module_t *gralloc_;
-  hw_device_t *device_;
   GRALLOC1_PFN_RETAIN register_;
   GRALLOC1_PFN_RELEASE release_;
   GRALLOC1_PFN_GET_DIMENSIONS dimensions_;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -725,7 +725,9 @@ HWC2::Error IAHWC2::HwcDisplay::SetClientTarget(buffer_handle_t target,
 
 HWC2::Error IAHWC2::HwcDisplay::SetColorMode(int32_t mode) {
   supported(__func__);
-  color_mode_ = mode;
+  // TODO: Use the parameter mode to set the color mode for the display to be
+  // used.
+
   return HWC2::Error::None;
 }
 

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -202,7 +202,6 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::DisplayType type_;
     std::map<hwc2_layer_t, Hwc2Layer> layers_;
     Hwc2Layer client_layer_;
-    int32_t color_mode_;
 
     uint32_t frame_no_ = 0;
     // True after validateDisplay

--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -157,6 +157,8 @@ bool GbmBufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
   }
 
   struct gbm_handle *temp = new struct gbm_handle();
+  // FIXME: If USE_MINIGBM is not set then an unitialized variable is used in
+  // line 191 to initialize modifier_high
   uint64_t mod;
 #if USE_MINIGBM
   size_t total_planes = gbm_bo_get_num_planes(bo);


### PR DESCRIPTION
utils_alios.h had an unnecessary assignment

yallocbufferhandler.h had an unused member

gralloc1bufferhandler.h had an unused member

iahwc2.cpp and .h had a color_mode_ that was not used anywhere

gbmbufferhandler.cpp needs a fixme note since I am not sure why
the mod variable is being used outside of the if statement when it
isn't initialized to begin with.

Jira: None
Test: HWC build passes without errors
Signed-off-by: Richard Avelar richard.avelar@intel.com