### PR TITLE
Reformat files with clang-format

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -22,13 +22,13 @@
 
 #include "disjoint_layers.h"
 #include "displayplanestate.h"
+#include "hwcdefs.h"
 #include "hwctrace.h"
+#include "hwcutils.h"
 #include "nativegpuresource.h"
 #include "nativesurface.h"
 #include "overlaylayer.h"
 #include "renderer.h"
-#include "hwcutils.h"
-#include "hwcdefs.h"
 
 namespace hwcomposer {
 
@@ -316,8 +316,8 @@ void Compositor::SeparateLayers(const std::vector<size_t> &dedicated_layers,
       [=](size_t layer_index) { return display_frame[layer_index]; });
   std::transform(source_layers.begin(), source_layers.end(),
                  layer_rects.begin() + layer_offset, [=](size_t layer_index) {
-    return display_frame[layer_index];
-  });
+                   return display_frame[layer_index];
+                 });
 
   std::vector<RectSet<int>> separate_regions;
   get_draw_regions(layer_rects, damage_region, &separate_regions);

--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -23,10 +23,10 @@
 #include <vector>
 
 #include "compositionregion.h"
-#include "displayplanestate.h"
-#include "renderstate.h"
 #include "compositorthread.h"
+#include "displayplanestate.h"
 #include "factory.h"
+#include "renderstate.h"
 
 namespace hwcomposer {
 

--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -16,15 +16,15 @@
 
 #include "compositorthread.h"
 
-#include "hwcutils.h"
+#include "displayplanemanager.h"
+#include "framebuffermanager.h"
 #include "hwctrace.h"
+#include "hwcutils.h"
 #include "nativegpuresource.h"
+#include "nativesurface.h"
 #include "overlaylayer.h"
 #include "renderer.h"
 #include "resourcemanager.h"
-#include "framebuffermanager.h"
-#include "displayplanemanager.h"
-#include "nativesurface.h"
 
 #include <nativebufferhandler.h>
 

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -17,15 +17,15 @@
 #ifndef COMMON_COMPOSITOR_COMPOSITORTHREAD_H_
 #define COMMON_COMPOSITOR_COMPOSITORTHREAD_H_
 
-#include <spinlock.h>
 #include <platformdefines.h>
+#include <spinlock.h>
 
 #include <memory>
 #include <vector>
 
-#include "renderstate.h"
 #include "factory.h"
 #include "hwcthread.h"
+#include "renderstate.h"
 
 #include "fdhandler.h"
 #include "hwcevent.h"

--- a/common/compositor/renderer.h
+++ b/common/compositor/renderer.h
@@ -17,8 +17,8 @@
 #ifndef COMMON_COMPOSITOR_RENDERER_H_
 #define COMMON_COMPOSITOR_RENDERER_H_
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <vector>
 

--- a/common/compositor/renderstate.h
+++ b/common/compositor/renderstate.h
@@ -19,8 +19,8 @@
 
 #include <vector>
 
-#include <unistd.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include "compositordefs.h"
 #include "hwcdefs.h"

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -188,7 +188,7 @@ void GpuDevice::HandleHWCSettings() {
           if (!value.compare(enable_str)) {
             rotate_display = true;
           }
-	  // Got float switch
+          // Got float switch
         } else if (!key.compare(key_float)) {
           if (!value.compare(enable_str)) {
             use_float = true;
@@ -346,8 +346,8 @@ void GpuDevice::HandleHWCSettings() {
 
           // Got display index
           std::getline(i_value, index_str, ':');
-          if (index_str.empty() || index_str.find_first_not_of("0123456789") !=
-            std::string::npos) {
+          if (index_str.empty() ||
+              index_str.find_first_not_of("0123456789") != std::string::npos) {
             continue;
           }
 
@@ -582,7 +582,7 @@ void GpuDevice::HandleHWCSettings() {
       int index = float_display_indices.at(i);
 
       // Ignore float index if out of range of connected displays
-      if ((size_t) index < num_displays) {
+      if ((size_t)index < num_displays) {
         const HwcRect<int32_t> &rect = float_displays.at(i);
         ret = total_displays_.at(index)->SetCustomResolution(rect);
       }

--- a/common/core/nesteddisplay.h
+++ b/common/core/nesteddisplay.h
@@ -17,22 +17,22 @@
 #ifndef COMMON_CORE_NESTEDDISPLAY_H_
 #define COMMON_CORE_NESTEDDISPLAY_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
-#include <memory>
-#include <nativedisplay.h>
 #include <drm_fourcc.h>
+#include <nativedisplay.h>
+#include <memory>
 #ifdef NESTED_DISPLAY_SUPPORT
 #include <linux/hyper_dmabuf.h>
-#include <map>
-#include "drmbuffer.h"
-#include <utils/threads.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
+#include <utils/threads.h>
+#include <map>
+#include "compositor.h"
+#include "drmbuffer.h"
 #include "hwcthread.h"
 #include "hwctrace.h"
-#include "compositor.h"
 #include "resourcemanager.h"
 
 #define SURFACE_NAME_LENGTH 64

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -17,13 +17,13 @@
 #ifndef COMMON_DISPLAY_DISPLAYPLANEMANAGER_H_
 #define COMMON_DISPLAY_DISPLAYPLANEMANAGER_H_
 
-#include <memory>
 #include <map>
-#include <vector>
+#include <memory>
 #include <tuple>
+#include <vector>
 
-#include "displayplanestate.h"
 #include "displayplanehandler.h"
+#include "displayplanestate.h"
 
 namespace hwcomposer {
 

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -19,7 +19,7 @@
 #include "hwctrace.h"
 #include "hwcutils.h"
 
-#include<math.h>
+#include <math.h>
 
 namespace hwcomposer {
 

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -16,18 +16,18 @@
 
 #include "displayqueue.h"
 
-#include <math.h>
 #include <hwcdefs.h>
 #include <hwclayer.h>
+#include <math.h>
 
 #include <vector>
 
 #include "displayplanemanager.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
+#include "nativesurface.h"
 #include "overlaylayer.h"
 #include "vblankeventhandler.h"
-#include "nativesurface.h"
 
 #include "physicaldisplay.h"
 #include "renderer.h"
@@ -1288,7 +1288,8 @@ void DisplayQueue::SetGamma(float red, float green, float blue) {
   state_ |= kNeedsColorCorrection;
 }
 
-void DisplayQueue::SetColorTransform(const float *matrix, HWCColorTransform hint) {
+void DisplayQueue::SetColorTransform(const float* matrix,
+                                     HWCColorTransform hint) {
   color_transform_hint_ = hint;
 
   if (hint == HWCColorTransform::kArbitraryMatrix) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -19,11 +19,11 @@
 
 #include <spinlock.h>
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
-#include <queue>
 #include <memory>
+#include <queue>
 #include <vector>
 
 #include "compositor.h"
@@ -69,7 +69,7 @@ class DisplayQueue {
   bool SetPowerMode(uint32_t power_mode);
   bool CheckPlaneFormat(uint32_t format);
   void SetGamma(float red, float green, float blue);
-  void SetColorTransform(const float *matrix, HWCColorTransform hint);
+  void SetColorTransform(const float* matrix, HWCColorTransform hint);
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue);
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue);
   void SetExplicitSyncSupport(bool disable_explicit_sync);
@@ -77,8 +77,8 @@ class DisplayQueue {
   void SetVideoColor(HWCColorControl color, float value);
   void GetVideoColor(HWCColorControl color, float* value, float* start,
                      float* end);
-  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
-                      uint16_t blue, uint16_t alpha);
+  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green, uint16_t blue,
+                      uint16_t alpha);
   void RestoreVideoDefaultColor(HWCColorControl color);
   void SetVideoDeinterlace(HWCDeinterlaceFlag flag, HWCDeinterlaceControl mode);
   void RestoreVideoDefaultDeinterlace();
@@ -341,7 +341,8 @@ class DisplayQueue {
   int state_ = kConfigurationChanged;
   PhysicalDisplay* display_ = NULL;
   SpinLock power_mode_lock_;
-  bool handle_display_initializations_ = true;  // to disable hwclock monitoring.
+  // to disable hwclock monitoring.
+  bool handle_display_initializations_ = true;
   uint32_t plane_transform_ = kIdentity;
   SpinLock video_lock_;
   bool requested_video_effect_ = false;

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -21,8 +21,8 @@
 #include <hwclayer.h>
 #include <nativebufferhandler.h>
 
-#include <vector>
 #include <sstream>
+#include <vector>
 
 #include "hwctrace.h"
 #include "overlaylayer.h"
@@ -102,8 +102,8 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
       continue;
 
     layers.emplace_back();
-    OverlayLayer& overlay_layer = layers.back();
-    OverlayLayer* previous_layer = NULL;
+    OverlayLayer &overlay_layer = layers.back();
+    OverlayLayer *previous_layer = NULL;
     if (previous_size > z_order) {
       previous_layer = &(in_flight_layers_.at(z_order));
     }
@@ -120,8 +120,7 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
       continue;
     }
 
-    if (!previous_layer ||
-        overlay_layer.HasLayerContentChanged() ||
+    if (!previous_layer || overlay_layer.HasLayerContentChanged() ||
         overlay_layer.HasDimensionsChanged()) {
       layers_changed = true;
     }
@@ -152,14 +151,14 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
   if (fence > 0) {
     for (size_t layer_index = 0; layer_index < size; layer_index++) {
-      HwcLayer* layer = source_layers.at(layer_index);
+      HwcLayer *layer = source_layers.at(layer_index);
       layer->SetReleaseFence(dup(fence));
     }
   } else {
     for (size_t layer_index = 0; layer_index < size; layer_index++) {
-      const OverlayLayer& overlay_layer =
+      const OverlayLayer &overlay_layer =
           in_flight_layers_.at(index.at(layer_index));
-      HwcLayer* layer = source_layers.at(overlay_layer.GetLayerIndex());
+      HwcLayer *layer = source_layers.at(overlay_layer.GetLayerIndex());
       layer->SetReleaseFence(overlay_layer.ReleaseAcquireFence());
     }
   }

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -19,13 +19,13 @@
 
 #include <stdint.h>
 #include <fstream>
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "displaymanager.h"
+#include "hwcthread.h"
 #include "logicaldisplaymanager.h"
 #include "nativedisplay.h"
-#include "hwcthread.h"
 
 namespace hwcomposer {
 

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -21,8 +21,8 @@
 
 #include <hwcrect.h>
 
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace hwcomposer {
 
@@ -104,8 +104,10 @@ enum DisplayPowerMode {
 };
 
 enum HWCColorTransform {
-  kIdentical = 0,       // Applies no transform to the output color
-  kArbitraryMatrix = 1  // Applies an arbitrary transform defined by a 4x4 affine matrix
+  // Applies no transform to the output color
+  kIdentical = 0,
+  // Applies an arbitrary transform defined by a 4x4 affine matrix
+  kArbitraryMatrix = 1
 };
 
 enum class HWCColorControl : int32_t {

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -59,8 +59,8 @@ struct HwcLayer {
     return source_crop_;
   }
 
-  void SetDisplayFrame(const HwcRect<int>& display_frame,
-                       int translate_x_pos, int translate_y_pos);
+  void SetDisplayFrame(const HwcRect<int>& display_frame, int translate_x_pos,
+                       int translate_y_pos);
 
   const HwcRect<int>& GetDisplayFrame() const {
     return display_frame_;

--- a/public/nativebufferhandler.h
+++ b/public/nativebufferhandler.h
@@ -19,8 +19,8 @@
 
 #include <stdint.h>
 
-#include <platformdefines.h>
 #include <hwcdefs.h>
+#include <platformdefines.h>
 
 namespace hwcomposer {
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -171,9 +171,11 @@ class NativeDisplay {
   * |b.r b.g b.b 0|
   * |Tr  Tg  Tb  1|
   *
-  * This matrix will be provided in row-major form: {r.r, r.g, r.b, 0, g.r, ...}.
+  * This matrix will be provided in row-major form: {r.r, r.g, r.b, 0, g.r,
+  * ...}.
   *
-  * Given a matrix of this form and an input color [R_in, G_in, B_in], the output
+  * Given a matrix of this form and an input color [R_in, G_in, B_in], the
+  * output
   * color [R_out, G_out, B_out] will be:
   *
   * R_out = R_in * r.r + G_in * g.r + B_in * b.r + Tr
@@ -181,10 +183,12 @@ class NativeDisplay {
   * B_out = R_in * r.b + G_in * g.b + B_in * b.b + Tb
   *
   * @param matrix a 4x4 transform matrix (16 floats) as described above
-  * @param hint a hint value to specify the transform type, applying no transform
+  * @param hint a hint value to specify the transform type, applying no
+  * transform
   *        or applying transform defined by given matrix
   */
-  virtual void SetColorTransform(const float * /*matrix*/, HWCColorTransform /*hint*/) {
+  virtual void SetColorTransform(const float * /*matrix*/,
+                                 HWCColorTransform /*hint*/) {
   }
 
   /**
@@ -206,9 +210,9 @@ class NativeDisplay {
                              uint32_t /*blue*/) {
   }
 
- /**
-  * API for setting video color in HWC
-  */
+  /**
+   * API for setting video color in HWC
+   */
   virtual void SetVideoColor(HWCColorControl /*color*/, float /*value*/) {
   }
 
@@ -446,7 +450,7 @@ class DisplayHotPlugEventCallback {
  public:
   virtual ~DisplayHotPlugEventCallback() {
   }
-  virtual void Callback(std::vector<NativeDisplay*> connected_displays) = 0;
+  virtual void Callback(std::vector<NativeDisplay *> connected_displays) = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/displayplane.h
+++ b/wsi/displayplane.h
@@ -17,8 +17,8 @@
 #ifndef WSI_DISPLAYPLANE_H_
 #define WSI_DISPLAYPLANE_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 namespace hwcomposer {
 

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -24,10 +24,10 @@
 #include <hwcdefs.h>
 #include <nativebufferhandler.h>
 
+#include "framebuffermanager.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "resourcemanager.h"
-#include "framebuffermanager.h"
 #include "vautils.h"
 
 #include <va/va_drmcommon.h>
@@ -295,7 +295,6 @@ const ResourceHandle& DrmBuffer::GetGpuResource(GpuDisplay egl_display,
 
   glBindTexture(target, image_.texture_);
   glEGLImageTargetTexture2DOES(target, (GLeglImageOES)image_.image_);
-
 
   glBindTexture(target, 0);
 

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -17,19 +17,19 @@
 #include "drmdisplay.h"
 
 #include <cmath>
-#include <set>
 #include <limits>
+#include <set>
 
 #include <hwcdefs.h>
 #include <hwclayer.h>
 #include <hwctrace.h>
 
 #include <algorithm>
-#include <string>
 #include <sstream>
+#include <string>
 
-#include "displayqueue.h"
 #include "displayplanemanager.h"
+#include "displayqueue.h"
 #include "drmdisplaymanager.h"
 #include "wsi_utils.h"
 
@@ -62,7 +62,8 @@ bool DrmDisplay::InitializeDisplay() {
   GetDrmObjectProperty("ACTIVE", crtc_props, &active_prop_);
   GetDrmObjectProperty("MODE_ID", crtc_props, &mode_id_prop_);
   GetDrmObjectProperty("CTM", crtc_props, &ctm_id_prop_);
-  GetDrmObjectProperty("CTM_POST_OFFSET", crtc_props, &ctm_post_offset_id_prop_);
+  GetDrmObjectProperty("CTM_POST_OFFSET", crtc_props,
+                       &ctm_post_offset_id_prop_);
   GetDrmObjectProperty("GAMMA_LUT", crtc_props, &lut_id_prop_);
   GetDrmObjectPropertyValue("GAMMA_LUT_SIZE", crtc_props, &lut_size_);
   GetDrmObjectProperty("OUT_FENCE_PTR", crtc_props, &out_fence_ptr_prop_);
@@ -185,10 +186,10 @@ bool DrmDisplay::GetDisplayAttribute(uint32_t config /*config*/,
     case HWCDisplayAttribute::kRefreshRate:
       if (!custom_resolution_) {
         refresh = (modes_[config].clock * 1000.0f) /
-                (modes_[config].htotal * modes_[config].vtotal);
+                  (modes_[config].htotal * modes_[config].vtotal);
       } else {
         refresh = (modes_[config].clock * 1000.0f) /
-                ((rect_.right - rect_.left) * (rect_.bottom - rect_.top));
+                  ((rect_.right - rect_.left) * (rect_.bottom - rect_.top));
       }
 
       if (modes_[config].flags & DRM_MODE_FLAG_INTERLACE)
@@ -220,7 +221,7 @@ bool DrmDisplay::GetDisplayAttribute(uint32_t config /*config*/,
           mmHeight_ ? (modes_[config].vdisplay * kUmPerInch) / mmHeight_ : -1;
       } else {
         *value =
-          mmHeight_ ? ((rect_.bottom - rect_.top) * kUmPerInch) / mmHeight_ : -1;
+          mmHeight_ ? ((rect_.bottom - rect_.top) * kUmPerInch) /mmHeight_: -1;
       }
       break;
     default:
@@ -451,8 +452,8 @@ void DrmDisplay::SetDisplayAttribute(const drmModeModeInfo &mode_info) {
     width_ = rect_.right - rect_.left;
     height_ = rect_.bottom - rect_.top;
   }
-  IHOTPLUGEVENTTRACE("SetDisplayAttribute: width %d, height %d",
-    width_, height_);
+  IHOTPLUGEVENTTRACE("SetDisplayAttribute: width %d, height %d", width_,
+                     height_);
 
   current_mode_ = mode_info;
 }
@@ -521,11 +522,12 @@ int64_t DrmDisplay::FloatToFixedPoint(float value) const {
   uint32_t negative = (*pointer & (1u << 31)) >> 31;
   *pointer &= 0x7fffffff; /* abs of value*/
   return (negative ? (1ll << 63) : 0) |
-          (__s64)((*(float *)pointer) * (double)(1ll << 32));
+         (__s64)((*(float *)pointer) * (double)(1ll << 32));
 }
 
-void DrmDisplay::ApplyPendingCTM(struct drm_color_ctm *ctm,
-                                 struct drm_color_ctm_post_offset *ctm_post_offset) const {
+void DrmDisplay::ApplyPendingCTM(
+    struct drm_color_ctm *ctm,
+    struct drm_color_ctm_post_offset *ctm_post_offset) const {
   if (ctm_id_prop_ == 0) {
     ETRACE("ctm_id_prop_ == 0");
     return;
@@ -544,7 +546,9 @@ void DrmDisplay::ApplyPendingCTM(struct drm_color_ctm *ctm,
   }
 
   uint32_t ctm_post_offset_id = 0;
-  drmModeCreatePropertyBlob(gpu_fd_, ctm_post_offset, sizeof(drm_color_ctm_post_offset), &ctm_post_offset_id);
+  drmModeCreatePropertyBlob(gpu_fd_, ctm_post_offset,
+                            sizeof(drm_color_ctm_post_offset),
+                            &ctm_post_offset_id);
   if (ctm_post_offset_id == 0) {
     ETRACE("ctm_post_offset_id == 0");
     return;
@@ -557,7 +561,6 @@ void DrmDisplay::ApplyPendingCTM(struct drm_color_ctm *ctm,
   drmModeObjectSetProperty(gpu_fd_, crtc_id_, DRM_MODE_OBJECT_CRTC,
                            ctm_post_offset_id_prop_, ctm_post_offset_id);
   drmModeDestroyPropertyBlob(gpu_fd_, ctm_post_offset_id);
-
 }
 
 void DrmDisplay::ApplyPendingLUT(struct drm_color_lut *lut) const {
@@ -639,9 +642,11 @@ float DrmDisplay::TransformGamma(float value, float gamma) const {
   return result;
 }
 
-void DrmDisplay::SetColorTransformMatrix(const float *color_transform_matrix,
-                                         HWCColorTransform color_transform_hint) const {
-  struct drm_color_ctm *ctm = (struct drm_color_ctm *)malloc(sizeof(struct drm_color_ctm));
+void DrmDisplay::SetColorTransformMatrix(
+    const float *color_transform_matrix,
+    HWCColorTransform color_transform_hint) const {
+  struct drm_color_ctm *ctm =
+      (struct drm_color_ctm *)malloc(sizeof(struct drm_color_ctm));
   if (!ctm) {
     ETRACE("Cannot allocate CTM memory");
     return;
@@ -671,7 +676,8 @@ void DrmDisplay::SetColorTransformMatrix(const float *color_transform_matrix,
     case HWCColorTransform::kArbitraryMatrix: {
       for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {
-          ctm->matrix[i * 3 + j] = FloatToFixedPoint(color_transform_matrix[j * 4 + i]);
+          ctm->matrix[i * 3 + j] =
+              FloatToFixedPoint(color_transform_matrix[j * 4 + i]);
         }
       }
       ctm_post_offset->red = color_transform_matrix[12] * 0xffff;

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -17,8 +17,8 @@
 #ifndef WSI_DRMDISPLAY_H_
 #define WSI_DRMDISPLAY_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <xf86drmMode.h>
 
 #include <drmscopedtypes.h>
@@ -27,8 +27,8 @@
 #include "physicaldisplay.h"
 
 #ifndef DRM_RGBA8888
-#define DRM_RGBA8888(r,g,b,a) DrmRGBA(8, r, g, b, a)
-#define DRM_RGBA16161616(r,g,b,a) DrmRGBA(16, r, g, b, a)
+#define DRM_RGBA8888(r, g, b, a) DrmRGBA(8, r, g, b, a)
+#define DRM_RGBA16161616(r, g, b, a) DrmRGBA(16, r, g, b, a)
 #endif
 
 namespace hwcomposer {
@@ -63,8 +63,9 @@ class DrmDisplay : public PhysicalDisplay {
                           uint32_t brightness) const override;
   void SetPipeCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
                           uint16_t blue, uint16_t alpha) const override;
-  void SetColorTransformMatrix(const float *color_transform_matrix,
-                               HWCColorTransform color_transform_hint) const override;
+  void SetColorTransformMatrix(
+      const float *color_transform_matrix,
+      HWCColorTransform color_transform_hint) const override;
   void Disable(const DisplayPlaneStateList &composition_planes) override;
   bool Commit(const DisplayPlaneStateList &composition_planes,
               const DisplayPlaneStateList &previous_composition_planes,

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -16,23 +16,23 @@
 
 #include "drmdisplaymanager.h"
 
-#include <stdlib.h>
-#include <time.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
-#include <errno.h>
 
-#include <linux/types.h>
 #include <linux/netlink.h>
+#include <linux/types.h>
 
-#include <hwctrace.h>
 #include <gpudevice.h>
+#include <hwctrace.h>
 
 #include <nativebufferhandler.h>
 

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -25,14 +25,14 @@
 
 #include "spinlock.h"
 
-#include "displayplanemanager.h"
 #include "displaymanager.h"
+#include "displayplanemanager.h"
 #include "drmdisplay.h"
 #include "drmscopedtypes.h"
 #include "hwcthread.h"
+#include "nesteddisplay.h"
 #include "vblankeventhandler.h"
 #include "virtualdisplay.h"
-#include "nesteddisplay.h"
 
 namespace hwcomposer {
 

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -16,14 +16,14 @@
 
 #include "drmplane.h"
 
-#include <cmath>
 #include <drm_fourcc.h>
+#include <cmath>
 
 #include <gpudevice.h>
 
 #include "hwctrace.h"
-#include "overlaylayer.h"
 #include "hwcutils.h"
+#include "overlaylayer.h"
 
 namespace hwcomposer {
 

--- a/wsi/drm/drmplane.h
+++ b/wsi/drm/drmplane.h
@@ -17,8 +17,8 @@
 #ifndef WSI_DRMPLANE_H_
 #define WSI_DRMPLANE_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <xf86drmMode.h>
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -23,11 +23,11 @@
 #include <hwctrace.h>
 
 #include <algorithm>
-#include <string>
 #include <sstream>
+#include <string>
 
-#include "displayqueue.h"
 #include "displayplanemanager.h"
+#include "displayqueue.h"
 #include "hwcutils.h"
 #include "wsi_utils.h"
 
@@ -143,7 +143,7 @@ void PhysicalDisplay::Connect() {
     // Current display is a cloned display, set the source_display_'s
     // k_RefreshClonedDisplays flag. This makes clone parent have a
     // chance to update it's cloned display list
-    PhysicalDisplay* p_clone_parent = (PhysicalDisplay*) source_display_;
+    PhysicalDisplay *p_clone_parent = (PhysicalDisplay *)source_display_;
     SPIN_LOCK(p_clone_parent->modeset_lock_);
     p_clone_parent->display_state_ |= kRefreshClonedDisplays;
     SPIN_UNLOCK(p_clone_parent->modeset_lock_);
@@ -411,7 +411,8 @@ void PhysicalDisplay::SetGamma(float red, float green, float blue) {
   display_queue_->SetGamma(red, green, blue);
 }
 
-void PhysicalDisplay::SetColorTransform(const float *matrix, HWCColorTransform hint) {
+void PhysicalDisplay::SetColorTransform(const float *matrix,
+                                        HWCColorTransform hint) {
   display_queue_->SetColorTransform(matrix, hint);
 }
 
@@ -436,8 +437,8 @@ void PhysicalDisplay::SetVideoColor(HWCColorControl color, float value) {
   display_queue_->SetVideoColor(color, value);
 }
 
-void PhysicalDisplay::GetVideoColor(HWCColorControl color,
-                                    float* value, float* start, float* end) {
+void PhysicalDisplay::GetVideoColor(HWCColorControl color, float *value,
+                                    float *start, float *end) {
   display_queue_->GetVideoColor(color, value, start, end);
 }
 
@@ -593,8 +594,9 @@ bool PhysicalDisplay::SetCustomResolution(const HwcRect<int32_t> &rect) {
     rect_.bottom = rect.bottom;
     custom_resolution_ = true;
 
-    IHOTPLUGEVENTTRACE("SetCustomResolution: custom width %d, height %d, bool %d",
-      rect_.right - rect_.left, rect_.bottom - rect_.top, custom_resolution_);
+    IHOTPLUGEVENTTRACE(
+        "SetCustomResolution: custom width %d, height %d, bool %d",
+        rect_.right - rect_.left, rect_.bottom - rect_.top, custom_resolution_);
 
     return true;
   } else {

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -17,18 +17,18 @@
 #ifndef WSI_PHYSICALDISPLAY_H_
 #define WSI_PHYSICALDISPLAY_H_
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <nativedisplay.h>
 
 #include <memory>
 #include <vector>
 
-#include "platformdefines.h"
-#include "displayplanestate.h"
-#include "displayplanehandler.h"
 #include <spinlock.h>
+#include "displayplanehandler.h"
+#include "displayplanestate.h"
+#include "platformdefines.h"
 
 namespace hwcomposer {
 class DisplayPlaneState;
@@ -63,7 +63,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool SetActiveConfig(uint32_t config) override;
   bool GetActiveConfig(uint32_t *config) override;
 
-  bool SetCustomResolution(const HwcRect<int32_t>&) override;
+  bool SetCustomResolution(const HwcRect<int32_t> &) override;
 
   bool SetPowerMode(uint32_t power_mode) override;
 
@@ -91,8 +91,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   void SetVideoColor(HWCColorControl color, float value) override;
   void GetVideoColor(HWCColorControl color, float *value, float *start,
                      float *end) override;
-  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
-                      uint16_t blue, uint16_t alpha) override;
+  void SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green, uint16_t blue,
+                      uint16_t alpha) override;
   void RestoreVideoDefaultColor(HWCColorControl color) override;
   void SetVideoDeinterlace(HWCDeinterlaceFlag flag,
                            HWCDeinterlaceControl mode) override;
@@ -158,8 +158,9 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   /**
   * API for setting color transform matrix.
   */
-  virtual void SetColorTransformMatrix(const float *color_transform_matrix,
-                                       HWCColorTransform color_transform_hint) const = 0;
+  virtual void SetColorTransformMatrix(
+      const float *color_transform_matrix,
+      HWCColorTransform color_transform_hint) const = 0;
 
   /**
   * API is called when display needs to be disabled.


### PR DESCRIPTION
Ran a clang-format on multiple directories. This align formatting once
and for all to avoid having to run clang-format and get a bunch of
formatting changes that aren't relevant to the patch you're working on
but end up sticking around.

Jira: None
Test: HWC build passes without errors
Signed-off-by: Richard Avelar richard.avelar@intel.com