### PR TITLE
Weston: Fix window animation

### DIFF
--- a/os/linux/weston/plugin/compositor-iahwc.c
+++ b/os/linux/weston/plugin/compositor-iahwc.c
@@ -736,7 +736,10 @@ static struct weston_plane *iahwc_output_prepare_overlay_view(
     src_h = (tbox.y2 - tbox.y1) << 8;
     pixman_region32_fini(&src_rect);
 
-    iahwc_rect_t source_crop = {0, 0, dest_w, dest_h};
+    src_w = src_w >> 16;
+    src_h = src_h >> 16;
+
+    iahwc_rect_t source_crop = {src_x, src_y, src_w + src_x, src_h + src_y};
 
     iahwc_rect_t display_frame = {dest_x, dest_y, dest_w + dest_x,
                                   dest_h + dest_y};


### PR DESCRIPTION
Weston animates the opening of new windows in a spring like motion.
This is achieved by setting src_{w,h} of the buffer smaller than
the actual buffer width/height and varying the dest_{w,h}.
Previously we were fixing the source buffer dimentions to the acutal
buffer dimentions. This patch uses the dimentions provided by weston
instead of the actual buffer dimentions.

Jira: None
Test: Windows should open with a spring like animation.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>