### PR TITLE
Specify pointer alignment in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,5 @@ BasedOnStyle: Google
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
+# Pointer alignment works for clang version 5.0 and up.
+PointerAlignment: Right


### PR DESCRIPTION
Add line in .clang-format to right align pointer and leave a
comment to avoid using older clang-format version than 5.
Clang is available up to version 7 currently.

Jira: None
Test: Running clang with the modified .clang-format now right aligns pointers
Signed-off-by: Richard Avelar richard.avelar@intel.com