### PR TITLE
compositor thread: adding corner case check before wait in Draw.

### DIFF
--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -103,6 +103,13 @@ bool CompositorThread::Draw(std::vector<DrawState> &states,
   // succeed.
   draw_succeeded_ = true;
   tasks_lock_.unlock();
+
+  // Adding check to end up waiting in this
+  // thread in certain corner case.
+  if (states_.empty() && media_states_.empty()) {
+    return draw_succeeded_;
+  }
+
   Resume();
   Wait();
   return draw_succeeded_;


### PR DESCRIPTION
Adding the check to avoid compositor thread not responsing in some
corner case and leads to UIWDT that found in android stability test.

Jira: https://jira01.devtools.intel.com/browse/OAM-61985
Test: stability test

Signed-off-by: Yuanjun Huang <yuanjun.huang@intel.com>