### PR TITLE
Skip HWC rendering if /etc/vendor/hwc.lock is locked by another process exclusively.

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -479,6 +479,13 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     return true;
   }
 
+  if (!display_->GetDisplayRenderingState()) {
+#ifdef SURFACE_TRACING
+        ISURFACETRACE("display_->GetRenderingState returned false, skip the display rendering");
+#endif
+    return true;
+  }
+
   size_t size = source_layers.size();
   size_t previous_size = in_flight_layers_.size();
   std::vector<OverlayLayer> layers;

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -106,6 +106,8 @@ class GpuDevice : public HWCThread {
   SpinLock thread_stage_lock_;
   SpinLock thread_sync_lock_;
   int lock_fd_ = -1;
+  bool hwc_locked = false;
+  bool use_lock_file = true;
   friend class DrmDisplayManager;
 };
 

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -53,6 +53,8 @@ class DisplayManager {
   // manager until ForceRefresh is called.
   virtual void IgnoreUpdates() = 0;
 
+  virtual void SetDisplayRenderingState(bool rendering) = 0;
+
   virtual NativeDisplay *GetVirtualDisplay() = 0;
   virtual NativeDisplay *GetNestedDisplay() = 0;
 

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -352,6 +352,19 @@ bool DrmDisplayManager::UpdateDisplayState() {
   return true;
 }
 
+
+void DrmDisplayManager::SetDisplayRenderingState(bool rendering)
+{
+  spin_lock_.lock();
+
+  for (auto &display: displays_) {
+    display->SetDisplayRenderingState(rendering);
+  }
+
+  spin_lock_.unlock();
+
+}
+
 void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
   spin_lock_.lock();
   for (auto &display : displays_) {

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -67,6 +67,8 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void HandleLazyInitialization();
 
+  void SetDisplayRenderingState(bool rendering);
+
  protected:
   void HandleWait() override;
   void HandleRoutine() override;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -586,6 +586,18 @@ bool PhysicalDisplay::GetDisplayConfigs(uint32_t *num_configs,
   return true;
 }
 
+void PhysicalDisplay::SetDisplayRenderingState(bool rendering)
+{
+  SPIN_LOCK(modeset_lock_);
+  rendering_state_ = rendering;
+  SPIN_UNLOCK(modeset_lock_);
+}
+
+bool PhysicalDisplay::GetDisplayRenderingState()
+{
+  return rendering_state_;
+}
+
 bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   std::ostringstream stream;
   stream << "Headless";

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -209,6 +209,9 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
+  void SetDisplayRenderingState(bool rendering);
+  bool GetDisplayRenderingState();
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();
@@ -259,6 +262,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
+  volatile bool rendering_state_ = true;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
Skip rendering Android system UI if /vendor/etc/hwc.lock presents
and exclusively locked by another process. This is to avoid
screen flash if earlyEVS and HWC both rendering content into DRM.
The Android system UI will be rendered once get the exclusive clock.

JIRA: OAM-60710
Test: Boot into home screen in normal boot flow;
      Show earlyEVS camera content if boot with showing rear view
        camera mode;
      Show Android system UI if exit showing rear view camera mode.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>