### PR TITLE
Skip rendering Android system UI if /vendor/hwc.lock locked by another process exclusively.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -35,6 +35,8 @@ bool GpuDevice::Initialize() {
   if (initialization_state_ & kInitialized)
     return true;
 
+  lock_fd_ = open("/vendor/hwc.lock", O_RDONLY);
+
   bool use_thread = true;
   if (!InitWorker()) {
     ETRACE("Failed to initalize thread for GpuDevice. %s", PRINTERROR());
@@ -61,9 +63,10 @@ bool GpuDevice::Initialize() {
   initialization_state_ &= ~kHWCSettingsDone;
   thread_sync_lock_.unlock();
 
-  if (use_thread && lock_fd_ == -1) {
+  if (-1 == lock_fd_) {
     // Exit thread as we don't need worker thread after
     // Initialization.
+    ETRACE("Failed to open /vendor/hwc.lock file.");
     HWCThread::Exit();
   }
 
@@ -652,8 +655,6 @@ void GpuDevice::InitializeHotPlugEvents(bool take_lock) {
 }
 
 void GpuDevice::HandleRoutine() {
-  thread_sync_lock_.lock();
-  HandleHWCSettings();
 
   // Iniitialize resources to monitor external events.
   // These can be two types:
@@ -663,14 +664,11 @@ void GpuDevice::HandleRoutine() {
   // 2) Another app is having control of display and we
   //    we need to take control.
   // TODO: Add splash screen support.
-  lock_fd_ = open("/vendor/hwc.lock", O_RDONLY);
-  if (lock_fd_ == -1) {
-    thread_sync_lock_.unlock();
-    return;
-  }
 
-  thread_sync_lock_.unlock();
-  display_manager_->IgnoreUpdates();
+  if (flock(lock_fd_, LOCK_EX|LOCK_NB) != 0) {
+    ETRACE("Getting the exlusive file lock on /vendor/hwc.lock failed.");
+    display_manager_->IgnoreUpdates();
+  }
 
   if (flock(lock_fd_, LOCK_EX) != 0)
     ETRACE("Failed to wait on hwc lock.");

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -917,6 +917,10 @@ void DisplayQueue::IgnoreUpdates() {
   idle_tracker_.revalidate_frames_counter_ = 0;
 }
 
+bool DisplayQueue::IsIgnoreUpdates() {
+  return idle_tracker_.state_ & FrameStateTracker::kIgnoreUpdates;
+}
+
 void DisplayQueue::HandleCommitFailure(
     DisplayPlaneStateList& current_composition_planes) {
   for (DisplayPlaneState& plane : current_composition_planes) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -85,6 +85,8 @@ class DisplayQueue {
 
   void ForceRefresh();
 
+  bool IsIgnoreUpdates();
+
   void UpdateScalingRatio(uint32_t primary_width, uint32_t primary_height,
                           uint32_t display_width, uint32_t display_height);
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -80,7 +80,9 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
   SPIN_UNLOCK(modeset_lock_);
 
   if (refresh_needed) {
-    display_queue_->ForceRefresh();
+    if (!display_queue_->IsIgnoreUpdates()) {
+      display_queue_->ForceRefresh();
+    }
   }
 }
 


### PR DESCRIPTION
Skip rendering Android system UI if /vendor/hwc.lock presents and exclusively locked by another process. This is to avoid screen flash if earlyEVS and HWC both rendering content into DRM.
The Android system UI will be rendered once get the exclusive clock.

JIRA: OAM-60710
Test: Boot into home screen in normal boot flow;
      Show earlyEVS camera content if boot with showing rear view
        camera mode;
      Show Android system UI if exit showing rear view camera mode.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>