### PR TITLE
Fix Klockwork NULL pointer dereference issue

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -96,6 +96,10 @@ bool Compositor::Draw(DisplayPlaneStateList &comp_planes,
           plane.GetCompositionRegion();
       bool regions_empty = comp_regions.empty();
       NativeSurface *surface = plane.GetOffScreenTarget();
+      if(surface == NULL) {
+        ETRACE("GetOffScreenTarget() returned NULL pointer 'surface'.");
+        return false;
+      }
       if (!regions_empty &&
           (surface->ClearSurface() || surface->IsPartialClear() ||
            surface->IsSurfaceDamageChanged())) {

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -131,6 +131,10 @@ bool DrmDisplay::ConnectDisplay(const drmModeModeInfo &mode_info,
 
   drmModePropertyPtr broadcastrgb_props =
       drmModeGetProperty(gpu_fd_, broadcastrgb_id_);
+  if (broadcastrgb_props == NULL) {
+    ETRACE("drmModeGetProperty() returned NULL pointer 'broadcastrgb_props'.");
+    return false;
+  }
 
   SetPowerMode(power_mode_);
 


### PR DESCRIPTION
Results of function that can return NULL may be dereferenced and
cause catastrophic failure.

Jira: GSE-1592
Test: Builds on Android

Signed-off-by: Michele Lim <michele.lim@intel.com>