### PR TITLE
More Klocwork fixes

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -30,8 +30,12 @@ DisplayPlaneManager::DisplayPlaneManager(DisplayPlaneHandler *plane_handler,
                                          ResourceManager *resource_manager)
     : plane_handler_(plane_handler),
       resource_manager_(resource_manager),
+      cursor_plane_(nullptr),
       width_(0),
-      height_(0) {
+      height_(0),
+      total_overlays_(0),
+      display_transform_(kIdentity),
+      release_surfaces_(false) {
 }
 
 DisplayPlaneManager::~DisplayPlaneManager() {

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -173,9 +173,9 @@ class DisplayPlaneManager {
 
   uint32_t width_;
   uint32_t height_;
-  uint32_t total_overlays_ = 0;
-  uint32_t display_transform_ = kIdentity;
-  bool release_surfaces_ = false;
+  uint32_t total_overlays_;
+  uint32_t display_transform_;
+  bool release_surfaces_;
 };
 
 }  // namespace hwcomposer

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -44,7 +44,23 @@ NativeBufferHandler *NativeBufferHandler::CreateInstance(uint32_t fd) {
   return handler;
 }
 
-Gralloc1BufferHandler::Gralloc1BufferHandler(uint32_t fd) : fd_(fd) {
+Gralloc1BufferHandler::Gralloc1BufferHandler(uint32_t fd)
+    : fd_(fd),
+      gralloc_(nullptr),
+      device_(nullptr),
+      register_(nullptr),
+      release_(nullptr),
+      dimensions_(nullptr),
+      lock_(nullptr),
+      unlock_(nullptr),
+      create_descriptor_(nullptr),
+      destroy_descriptor_(nullptr),
+      set_consumer_usage_(nullptr),
+      set_dimensions_(nullptr),
+      set_format_(nullptr),
+      set_producer_usage_(nullptr),
+      allocate_(nullptr),
+      set_modifier_(nullptr) {
 }
 
 Gralloc1BufferHandler::~Gralloc1BufferHandler() {

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -282,7 +282,15 @@ HWC2::Error IAHWC2::RegisterCallback(int32_t descriptor,
   return error;
 }
 
-IAHWC2::HwcDisplay::HwcDisplay() {
+IAHWC2::HwcDisplay::HwcDisplay()
+    : display_(nullptr),
+      handle_(0),
+      type_(HWC2::DisplayType::Invalid),
+      frame_no_(0),
+      check_validate_display_(false),
+      disable_explicit_sync_(false),
+      enable_nested_display_compose_(false),
+      scaling_mode_(0) {
   supported(__func__);
 }
 
@@ -395,7 +403,7 @@ HWC2::Error IAHWC2::HwcDisplay::RegisterHotPlugCallback(
 
 HWC2::Error IAHWC2::HwcDisplay::AcceptDisplayChanges() {
   supported(__func__);
-  if (!checkValidateDisplay) {
+  if (!check_validate_display_) {
     ALOGV("AcceptChanges failed, not validated");
     return HWC2::Error::NotValidated;
   }
@@ -404,7 +412,7 @@ HWC2::Error IAHWC2::HwcDisplay::AcceptDisplayChanges() {
     l.second.accept_type_change();
 
   // reset the value to false
-  checkValidateDisplay = false;
+  check_validate_display_ = false;
   return HWC2::Error::None;
 }
 
@@ -839,7 +847,7 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
     }
   }
 
-  checkValidateDisplay = true;
+  check_validate_display_ = true;
   return HWC2::Error::None;
 }
 

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -197,18 +197,18 @@ class IAHWC2 : public hwc2_device_t {
     hwcomposer::NativeDisplay *GetDisplay();
 
    private:
-    hwcomposer::NativeDisplay *display_ = NULL;
+    hwcomposer::NativeDisplay *display_;
     hwc2_display_t handle_;
     HWC2::DisplayType type_;
     std::map<hwc2_layer_t, Hwc2Layer> layers_;
     Hwc2Layer client_layer_;
 
-    uint32_t frame_no_ = 0;
+    uint32_t frame_no_;
     // True after validateDisplay
-    bool checkValidateDisplay = false;
-    bool disable_explicit_sync_ = false;
-    bool enable_nested_display_compose_ = false;
-    uint32_t scaling_mode_ = 0;
+    bool check_validate_display_;
+    bool disable_explicit_sync_;
+    bool enable_nested_display_compose_;
+    uint32_t scaling_mode_;
   };
 
   static IAHWC2 *toIAHWC2(hwc2_device_t *dev) {

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -206,8 +206,8 @@ bool DrmPlane::Initialize(uint32_t gpu_fd,
   if (in_formats_prop_value != 0) {
     drmModePropertyBlobPtr blob =
         drmModeGetPropertyBlob(gpu_fd, in_formats_prop_value);
-    if (blob == NULL) {
-      ETRACE("Unable to get property blob\n");
+    if (blob == nullptr || blob->data == nullptr) {
+      ETRACE("Unable to get property data\n");
       return false;
     }
 


### PR DESCRIPTION
Initialize member variables found in Klocwork scan. Also, do all
initialization in constructor init list.

Jira: GSE-1594
Test: Build and boot to graphics on Android

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>