### PR TITLE
Skip rendering Android system UI if /vendor/hwc.lock locked by another process exclusively.

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -917,6 +917,10 @@ void DisplayQueue::IgnoreUpdates() {
   idle_tracker_.revalidate_frames_counter_ = 0;
 }
 
+bool DisplayQueue::IsIgnoreUpdates() {
+  return idle_tracker_.state_ & FrameStateTracker::kIgnoreUpdates;
+}
+
 void DisplayQueue::HandleCommitFailure(
     DisplayPlaneStateList& current_composition_planes) {
   for (DisplayPlaneState& plane : current_composition_planes) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -83,6 +83,8 @@ class DisplayQueue {
 
   void DisplayConfigurationChanged();
 
+  bool IsIgnoreUpdates();
+
   void ForceRefresh();
 
   void UpdateScalingRatio(uint32_t primary_width, uint32_t primary_height,

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -80,7 +80,9 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
   SPIN_UNLOCK(modeset_lock_);
 
   if (refresh_needed) {
-    display_queue_->ForceRefresh();
+    if (!display_queue_->IsIgnoreUpdates()) {
+      display_queue_->ForceRefresh();
+    }
   }
 }
 


### PR DESCRIPTION
Skip rendering Android system UI if /vendor/hwc.lock presents
and exclusively locked by another process. This is to avoid
screen flash if earlyEVS and HWC both rendering content into DRM.
The Android system UI will be rendered once get the exclusive clock.

JIRA: OAM-60710
Test: Boot into home screen in normal boot flow;
      Show earlyEVS camera content if boot with showing rear view
        camera mode;
      Show Android system UI if exit showing rear view camera mode.
      Unplug/Plug the HDMI displays several times

Signed-off-by: Wan Shuang <shuang.wan@intel.com>