### PR TITLE
Fix flicker during boot up.

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -1123,6 +1123,10 @@ void DisplayQueue::IgnoreUpdates() {
   idle_tracker_.revalidate_frames_counter_ = 0;
 }
 
+bool DisplayQueue::IsIgnoreUpdates() {
+  return idle_tracker_.state_ & FrameStateTracker::kIgnoreUpdates;
+}
+
 void DisplayQueue::HandleCommitFailure(
     DisplayPlaneStateList& current_composition_planes) {
   for (DisplayPlaneState& plane : current_composition_planes) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -94,6 +94,8 @@ class DisplayQueue {
 
   void DisplayConfigurationChanged();
 
+  bool IsIgnoreUpdates();
+
   void ForceRefresh();
 
   void UpdateScalingRatio(uint32_t primary_width, uint32_t primary_height,

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -106,7 +106,6 @@ class GpuDevice : public HWCThread {
   uint32_t initialization_state_ = kUnInitialized;
   SpinLock initialization_state_lock_;
   SpinLock thread_stage_lock_;
-  SpinLock thread_sync_lock_;
   int lock_fd_ = -1;
   friend class DrmDisplayManager;
 };

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -88,7 +88,9 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
   SPIN_UNLOCK(modeset_lock_);
 
   if (refresh_needed) {
-    display_queue_->ForceRefresh();
+    if (!display_queue_->IsIgnoreUpdates()) {
+      display_queue_->ForceRefresh();
+    }
   }
 }
 


### PR DESCRIPTION
Skip rendering Android system UI if /vendor/hwc.lock
is present and exclusively locked by another process.
This is to avoid screen flash if earlyEVS and HWC both
rendering content into DRM. The Android system UI will
be rendered once we get the exclusive clock.

JIRA: OAM-60710
Test: Boot into home screen in normal boot flow;
      Show earlyEVS camera content if boot with showing rear view
        camera mode;
      Show Android system UI if exit showing rear view camera mode.
      Unplug/Plug the HDMI displays several times

Signed-off-by: Wan Shuang <shuang.wan@intel.com>