### PR TITLE
Force to ABGR for video

### DIFF
--- a/common/compositor/va/vautils.cpp
+++ b/common/compositor/va/vautils.cpp
@@ -28,6 +28,8 @@ namespace hwcomposer {
 
 int DrmFormatToVAFormat(int format) {
   switch (format) {
+    case DRM_FORMAT_ABGR8888:
+      return VA_FOURCC_ABGR;
     case DRM_FORMAT_NV12:
       return VA_FOURCC_NV12;
     case DRM_FORMAT_YVU420:
@@ -69,6 +71,8 @@ int DrmFormatToRTFormat(int format) {
       return VA_RT_FORMAT_YUV444;
     case DRM_FORMAT_P010:
       return VA_RT_FORMAT_YUV420_10BPP;
+    case DRM_FORMAT_ABGR8888:
+      return VA_RT_FORMAT_RGB32;
     default:
       ETRACE("Unable to convert to RTFormat from format %x", format);
       break;

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -109,6 +109,10 @@ endif
 
 LOCAL_CPPFLAGS += -DENABLE_ANDROID_WA
 
+ifeq ($(strip $(HWC_VIDEO_PERF_WA)), true)
+LOCAL_CPPFLAGS += -DPREFER_ABGR
+endif
+
 LOCAL_MODULE := libhwcomposer_wsi
 LOCAL_CFLAGS += -fvisibility=default
 LOCAL_LDFLAGS += -no-undefined

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -91,8 +91,15 @@ bool DrmPlane::Initialize(uint32_t gpu_fd,
   uint32_t total_size = supported_formats_.size();
   for (uint32_t j = 0; j < total_size; j++) {
     uint32_t format = supported_formats_.at(j);
+#ifdef PREFER_ABGR
+    // fixme? force to use ABGR8888 to WA h264 1080p 60fps issue
+    // http://jira01.devtools.intel.com/browse/OAM-62484
+    if(format == DRM_FORMAT_ABGR8888) {
+      prefered_video_format_ = DRM_FORMAT_ABGR8888;
+#else
     if (IsSupportedMediaFormat(format)) {
-      prefered_video_format_ = format;
+      prefered_video_format_= format;
+#endif
       break;
     }
   }


### PR DESCRIPTION
Using YUYV somehow can not reach 60FPS for
h264 1080p. This is a temp WA for it on 8Gb board.
Issue not resolved on 2Gb yet.

Jira: https://jira01.devtools.intel.com/browse/OAM-62484
Signed-off-by: Lin Johnson <johnson.lin@intel.com>