### PR TITLE
More Klocwork fixes

### DIFF
--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -37,13 +37,12 @@ struct OverlayLayer;
 class Compositor {
  public:
   Compositor();
+  Compositor(const Compositor &) = delete;
+  Compositor &operator=(const Compositor &) = delete;
   ~Compositor();
 
   void Init(ResourceManager *buffer_manager, uint32_t gpu_fd);
   void Reset();
-
-  Compositor(const Compositor &) = delete;
-
   void BeginFrame(bool disable_explicit_sync);
   bool Draw(DisplayPlaneStateList &planes, std::vector<OverlayLayer> &layers,
             const std::vector<HwcRect<int>> &display_frame);

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -33,6 +33,8 @@ class VirtualDisplay : public NativeDisplay {
  public:
   VirtualDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
                  uint32_t pipe_id, uint32_t crtc_id);
+  VirtualDisplay(const VirtualDisplay &) = delete;
+  VirtualDisplay &operator=(const VirtualDisplay &) = delete;
   ~VirtualDisplay() override;
 
   void InitVirtualDisplay(uint32_t width, uint32_t height) override;

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -136,6 +136,8 @@ class IAHWC2 : public hwc2_device_t {
    public:
     HwcDisplay();
     HwcDisplay(const HwcDisplay &) = delete;
+    HwcDisplay &operator=(const HwcDisplay &) = delete;
+
     HWC2::Error Init(hwcomposer::NativeDisplay *display, int display_index,
                      bool disable_explicit_sync, uint32_t scaling_mode);
     HWC2::Error InitVirtualDisplay(hwcomposer::NativeDisplay *display,

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -51,7 +51,7 @@ enum HWCContentType {
   kCONTENT_TYPE1,  // Can support only HDCP 2.2 and higher specification.
 };
 
-enum HWCTransform {
+enum HWCTransform : uint32_t {
   kIdentity = 0,
   kReflectX = 1 << 0,
   kReflectY = 1 << 1,


### PR DESCRIPTION
Cleaning up constructor use to protect from double free and defining a type for one of our enums