### PR TITLE
Varenderer: should call vaSyncSurfcae before commit

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -314,6 +314,8 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
       vaRenderPicture(va_display_, va_context_, &pipeline_buffer.buffer(), 1);
   ret |= vaEndPicture(va_display_, va_context_);
 
+  int retSync = vaSyncSurface(va_display_, surface_out);
+
   surface->ResetDamage();
 
   return ret == VA_STATUS_SUCCESS ? true : false;


### PR DESCRIPTION
now vaSyncSuface return an error 1. need to ignore it
Limit this WA to only 1920x1080

Change-Id: I6aed3e50ef62721ffd76734aaba593df7c2974a9
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63127
Signed-off-by: Lin Johnson <johnson.lin@intel.com>