### PR TITLE
Fixed the HWC crash due to improper thread initialization sequence.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -51,11 +51,6 @@ bool GpuDevice::Initialize() {
 
   display_manager_.reset(DisplayManager::CreateDisplayManager(this));
 
-  if (!InitWorker()) {
-    ETRACE("Failed to initalize thread for GpuDevice. %s", PRINTERROR());
-    use_thread = false;
-  }
-
   bool success = display_manager_->Initialize();
   if (!success) {
     return false;
@@ -64,6 +59,10 @@ bool GpuDevice::Initialize() {
   HandleHWCSettings();
   InitializeHotPlugEvents();
 
+  if (!InitWorker()) {
+    ETRACE("Failed to initalize thread for GpuDevice. %s", PRINTERROR());
+    use_thread = false;
+  }
   if ((use_lock && !use_thread) || (!use_lock && use_thread)) {
     // Exit thread as we don't need worker thread after
     // Initialization.

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -221,16 +221,16 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   if (previous_layer && layer->HasZorderChanged()) {
     if (previous_layer->actual_composition_ == kGpu) {
       CalculateRect(previous_layer->display_frame_, surface_damage_);
-      bool force_partial_clear = true;
+      bool force_validation = true;
       // We can skip Clear in case display frame, transforms are same.
       if (previous_layer->display_frame_ == display_frame_ &&
           transform_ == previous_layer->transform_ &&
           plane_transform_ == previous_layer->plane_transform_) {
-        force_partial_clear = false;
+        force_validation = false;
       }
 
-      if (force_partial_clear) {
-        state_ |= kForcePartialClear;
+      if (force_validation) {
+        state_ |= kForceFullValidation;
       }
     } else if (!layer->IsCursorLayer()) {
       state_ |= kNeedsReValidation;

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -232,6 +232,8 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
       if (force_validation) {
         state_ |= kForceFullValidation;
       }
+
+      state_ |= kResetIdleFrame;
     } else if (!layer->IsCursorLayer()) {
       state_ |= kNeedsReValidation;
     }

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -206,6 +206,10 @@ struct OverlayLayer {
     return state_ & kNeedsReValidation;
   }
 
+  bool ForceFullValidation() const {
+    return state_ & kForceFullValidation;
+  }
+
   bool NeedsPartialClear() const {
     return state_ & kForcePartialClear;
   }
@@ -222,7 +226,8 @@ struct OverlayLayer {
     kInvisible = 1 << 2,
     kSourceRectChanged = 1 << 3,
     kNeedsReValidation = 1 << 4,
-    kForcePartialClear = 1 << 5
+    kForcePartialClear = 1 << 5,
+    kForceFullValidation = 1 << 6
   };
 
   struct ImportedBuffer {

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -214,10 +214,6 @@ struct OverlayLayer {
     return state_ & kResetIdleFrame;
   }
 
-  bool NeedsPartialClear() const {
-    return state_ & kForcePartialClear;
-  }
-
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
                   ResourceManager* resource_manager, uint32_t z_order);
 
@@ -230,9 +226,8 @@ struct OverlayLayer {
     kInvisible = 1 << 2,
     kSourceRectChanged = 1 << 3,
     kNeedsReValidation = 1 << 4,
-    kForcePartialClear = 1 << 5,
-    kForceFullValidation = 1 << 6,
-    kResetIdleFrame = 1 << 7
+    kForceFullValidation = 1 << 5,
+    kResetIdleFrame = 1 << 6
   };
 
   struct ImportedBuffer {

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -210,6 +210,10 @@ struct OverlayLayer {
     return state_ & kForceFullValidation;
   }
 
+  bool ResetIdleFrame() const {
+    return state_ & kResetIdleFrame;
+  }
+
   bool NeedsPartialClear() const {
     return state_ & kForcePartialClear;
   }
@@ -227,7 +231,8 @@ struct OverlayLayer {
     kSourceRectChanged = 1 << 3,
     kNeedsReValidation = 1 << 4,
     kForcePartialClear = 1 << 5,
-    kForceFullValidation = 1 << 6
+    kForceFullValidation = 1 << 6,
+    kResetIdleFrame = 1 << 7
   };
 
   struct ImportedBuffer {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -600,6 +600,15 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
       has_video_layer = true;
     }
 
+    if (overlay_layer->ForceFullValidation()) {
+      if (add_index == -1) {
+        add_index = z_order;
+      }
+
+      if (previous_layer)
+        remove_index = z_order;
+    }
+
     if (overlay_layer->NeedsRevalidation()) {
       re_validate_commit = true;
     } else if (overlay_layer->HasLayerContentChanged()) {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -549,6 +549,7 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
   uint32_t z_order = 0;
   bool has_video_layer = false;
   bool re_validate_commit = false;
+  bool tracking_idle = idle_frame || tracker.TrackingFrames();
   needs_clone_validation_ = false;
 
   for (size_t layer_index = 0; layer_index < size; layer_index++) {
@@ -596,6 +597,12 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
       continue;
     }
 
+    if (tracking_idle && overlay_layer->ResetIdleFrame()) {
+      idle_frame = false;
+      validate_layers = true;
+      add_index = 0;
+    }
+
     if (overlay_layer->IsVideoLayer()) {
       has_video_layer = true;
     }
@@ -611,8 +618,6 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
 
     if (overlay_layer->NeedsRevalidation()) {
       re_validate_commit = true;
-    } else if (overlay_layer->HasLayerContentChanged()) {
-      idle_frame = false;
     }
 
     if (overlay_layer->IsCursorLayer()) {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -304,7 +304,6 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
       HwcRect<int> surface_damage = HwcRect<int>(0, 0, 0, 0);
       bool update_rect = reset_plane;
       bool refresh_surfaces = reset_composition_regions;
-      bool force_partial_clear = false;
 
       const std::vector<size_t>& source_layers = target_plane.GetSourceLayers();
       size_t layers_size = source_layers.size();
@@ -319,10 +318,6 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
 
           if (refresh_surfaces) {
             continue;
-          }
-
-          if (layer.NeedsPartialClear()) {
-            force_partial_clear = true;
           }
 
           if (layer.HasLayerContentChanged()) {
@@ -369,18 +364,13 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
         }
       }
 
-      if (update_rect || refresh_surfaces || !surface_damage.empty() ||
-          force_partial_clear) {
+      if (update_rect || refresh_surfaces || !surface_damage.empty()) {
         needs_gpu_composition = true;
         if (target_plane.NeedsSurfaceAllocation()) {
           display_plane_manager_->SetOffScreenPlaneTarget(target_plane);
         } else if (refresh_surfaces || reset_plane) {
           target_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
         } else if (!update_rect && !surface_damage.empty()) {
-          if (force_partial_clear) {
-            target_plane.RefreshSurfaces(NativeSurface::kPartialClear, true);
-          }
-
           target_plane.UpdateDamage(surface_damage);
         }
 


### PR DESCRIPTION
 The thread of GpuDevice is started before DRM Display Manager's Initialization method, there is a chance that GpuDevice thread call method of display manager but underlying DRM display manager implementation still not fully initialized yet. This will lead HWC crash.

JIRA: OAM-63288
Test: Switch clone & mosaic mode and no crash during boot.