### PR TITLE
Stop assuming that enums is a valid pointer when count_enums > 0

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -146,11 +146,13 @@ bool DrmDisplay::ConnectDisplay(const drmModeModeInfo &mode_info,
     return false;
   }
 
-  for (int i = 0; i < broadcastrgb_props->count_enums; i++) {
-    if (!strcmp(broadcastrgb_props->enums[i].name, "Full")) {
-      broadcastrgb_full_ = broadcastrgb_props->enums[i].value;
-    } else if (!strcmp(broadcastrgb_props->enums[i].name, "Automatic")) {
-      broadcastrgb_automatic_ = broadcastrgb_props->enums[i].value;
+  if (broadcastrgb_props->enums != NULL) {
+    for (int i = 0; i < broadcastrgb_props->count_enums; i++) {
+      if (!strcmp(broadcastrgb_props->enums[i].name, "Full")) {
+        broadcastrgb_full_ = broadcastrgb_props->enums[i].value;
+      } else if (!strcmp(broadcastrgb_props->enums[i].name, "Automatic")) {
+        broadcastrgb_automatic_ = broadcastrgb_props->enums[i].value;
+      }
     }
   }
 


### PR DESCRIPTION
If libdrm fails to allocate enums for some reason it will still give us a
value in count_enums that it meant to allocate. This would be a rare
condition but we ought to handle it.

Test: Build and boot on Android
Bug: GSE-1586

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>