### PR TITLE
FrameBufferManager Instance owned by GPUDevice

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -40,11 +40,12 @@ Compositor::Compositor() {
 Compositor::~Compositor() {
 }
 
-void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd) {
+void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd,
+                      FrameBufferManager *frame_buffer_manager) {
   if (!thread_)
     thread_.reset(new CompositorThread());
 
-  thread_->Initialize(resource_manager, gpu_fd);
+  thread_->Initialize(resource_manager, gpu_fd, frame_buffer_manager);
 }
 
 void Compositor::BeginFrame(bool disable_explicit_sync) {

--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -41,7 +41,8 @@ class Compositor {
   Compositor &operator=(const Compositor &) = delete;
   ~Compositor();
 
-  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd);
+  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd,
+            FrameBufferManager *frame_buffer_manager);
   void Reset();
   void BeginFrame(bool disable_explicit_sync);
   bool Draw(DisplayPlaneStateList &planes, std::vector<OverlayLayer> &layers,

--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -41,7 +41,9 @@ CompositorThread::~CompositorThread() {
 }
 
 void CompositorThread::Initialize(ResourceManager *resource_manager,
-                                  uint32_t gpu_fd) {
+                                  uint32_t gpu_fd,
+                                  FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   tasks_lock_.lock();
   if (!gpu_resource_handler_)
     gpu_resource_handler_.reset(CreateNativeGpuResourceHandler());
@@ -159,8 +161,6 @@ void CompositorThread::HandleReleaseRequest() {
       purged_gl_resources, purged_media_resources, &has_gpu_resource);
   size_t purged_size = purged_gl_resources.size();
 
-  FrameBufferManager *pFBManager = FrameBufferManager::GetInstance();
-
   if (purged_size != 0) {
     if (has_gpu_resource) {
       Ensure3DRenderer();
@@ -176,8 +176,8 @@ void CompositorThread::HandleReleaseRequest() {
         continue;
       }
 
-      pFBManager->RemoveFB(handle.handle_->meta_data_.num_planes_,
-                           handle.handle_->meta_data_.gem_handles_);
+      fb_manager_->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                            handle.handle_->meta_data_.gem_handles_);
 
       handler->ReleaseBuffer(handle.handle_);
       handler->DestroyHandle(handle.handle_);
@@ -199,8 +199,8 @@ void CompositorThread::HandleReleaseRequest() {
         continue;
       }
 
-      pFBManager->RemoveFB(handle.handle_->meta_data_.num_planes_,
-                           handle.handle_->meta_data_.gem_handles_);
+      fb_manager_->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                            handle.handle_->meta_data_.gem_handles_);
       handler->ReleaseBuffer(handle.handle_);
       handler->DestroyHandle(handle.handle_);
     }

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -36,13 +36,15 @@ class OverlayBuffer;
 class DisplayPlaneManager;
 class ResourceManager;
 class NativeBufferHandler;
+class FrameBufferManager;
 
 class CompositorThread : public HWCThread {
  public:
   CompositorThread();
   ~CompositorThread() override;
 
-  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd);
+  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd,
+                  FrameBufferManager* frame_buffer_manager);
 
   bool Draw(std::vector<DrawState>& states,
             std::vector<DrawState>& media_states,
@@ -85,6 +87,7 @@ class CompositorThread : public HWCThread {
   uint32_t gpu_fd_ = 0;
   FDHandler fd_chandler_;
   HWCEvent cevent_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -44,7 +44,9 @@ NativeSurface::~NativeSurface() {
 
 bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
                          uint32_t usage, uint64_t modifier,
-                         bool *modifier_succeeded) {
+                         bool *modifier_succeeded,
+                         FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   const NativeBufferHandler *handler =
       resource_manager->GetNativeBufferHandler();
   resource_manager_ = resource_manager;
@@ -210,7 +212,7 @@ void NativeSurface::ResetDamage() {
 
 void NativeSurface::InitializeLayer(HWCNativeHandle native_handle) {
   layer_.SetBlending(HWCBlending::kBlendingPremult);
-  layer_.SetBuffer(native_handle, -1, resource_manager_, false);
+  layer_.SetBuffer(native_handle, -1, resource_manager_, false, fb_manager_);
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/nativesurface.h
+++ b/common/compositor/nativesurface.h
@@ -24,6 +24,7 @@
 
 namespace hwcomposer {
 
+class FrameBufferManager;
 class ResourceManager;
 class DisplayPlaneState;
 
@@ -43,7 +44,8 @@ class NativeSurface {
   virtual ~NativeSurface();
 
   bool Init(ResourceManager* resource_manager, uint32_t format, uint32_t usage,
-            uint64_t modifier, bool* modifier_succeeded);
+            uint64_t modifier, bool* modifier_succeeded,
+            FrameBufferManager* frame_buffer_manager);
 
   bool InitializeForOffScreenRendering(HWCNativeHandle native_handle,
                                        ResourceManager* resource_manager);
@@ -150,6 +152,7 @@ class NativeSurface {
   bool on_screen_ = false;
   HwcRect<int> previous_damage_;
   HwcRect<int> previous_nc_damage_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/core/framebuffermanager.cpp
+++ b/common/core/framebuffermanager.cpp
@@ -20,17 +20,6 @@
 
 namespace hwcomposer {
 
-FrameBufferManager *FrameBufferManager::pInstance = NULL;
-
-FrameBufferManager *FrameBufferManager::GetInstance() {
-  return pInstance;
-}
-
-void FrameBufferManager::CreateInstance(uint32_t gpu_fd) {
-  if (pInstance == NULL)
-    pInstance = new FrameBufferManager(gpu_fd);
-}
-
 void FrameBufferManager::RegisterGemHandles(const uint32_t &num_planes,
                                             const uint32_t (&igem_handles)[4]) {
   lock_.lock();

--- a/common/core/framebuffermanager.h
+++ b/common/core/framebuffermanager.h
@@ -77,8 +77,12 @@ struct FBEqual {
 
 class FrameBufferManager {
  public:
-  static FrameBufferManager *GetInstance();
-  static void CreateInstance(uint32_t gpu_fd);
+  FrameBufferManager(uint32_t gpu_fd) : gpu_fd_(gpu_fd) {
+  }
+  ~FrameBufferManager() {
+    PurgeAllFBs();
+  }
+
   void RegisterGemHandles(const uint32_t &num_planes,
                           const uint32_t (&igem_handles)[4]);
   uint32_t FindFB(const uint32_t &iwidth, const uint32_t &iheight,
@@ -89,14 +93,8 @@ class FrameBufferManager {
   int RemoveFB(uint32_t num_planes, const uint32_t (&igem_handles)[4]);
 
  private:
-  static FrameBufferManager *pInstance;
   SpinLock lock_;
   void PurgeAllFBs();
-  FrameBufferManager(uint32_t gpu_fd) : gpu_fd_(gpu_fd) {
-  }
-  ~FrameBufferManager() {
-    PurgeAllFBs();
-  }
 
   std::unordered_map<FBKey, FBValue, FBHash, FBEqual> fb_map_;
   uint32_t gpu_fd_ = 0;

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -35,7 +35,8 @@ LogicalDisplay::LogicalDisplay(LogicalDisplayManager *display_manager,
 LogicalDisplay::~LogicalDisplay() {
 }
 
-bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                                FrameBufferManager * /*frame_buffer_manager*/) {
   return true;
 }
 

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -35,7 +35,8 @@ class LogicalDisplay : public NativeDisplay {
                  uint32_t index);
   ~LogicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager * /*frame_buffer_manager*/) override;
 
   DisplayType Type() const override {
     return DisplayType::kLogical;

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -76,7 +76,8 @@ MosaicDisplay::MosaicDisplay(const std::vector<NativeDisplay *> &displays)
 MosaicDisplay::~MosaicDisplay() {
 }
 
-bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                               FrameBufferManager * /*frame_buffer_manager*/) {
   return true;
 }
 

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -32,7 +32,8 @@ class MosaicDisplay : public NativeDisplay {
   MosaicDisplay(const std::vector<NativeDisplay *> &displays);
   ~MosaicDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager * /*frame_buffer_manager*/) override;
 
   DisplayType Type() const override {
     return DisplayType::kMosaic;

--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -158,7 +158,8 @@ void NestedDisplay::InitNestedDisplay(uint32_t width, uint32_t height,
 #endif
 }
 
-bool NestedDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
+bool NestedDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
+                               FrameBufferManager * /*frame_buffer_manager*/) {
   return true;
 }
 

--- a/common/core/nesteddisplay.h
+++ b/common/core/nesteddisplay.h
@@ -102,7 +102,8 @@ class NestedDisplay : public NativeDisplay {
   void InitNestedDisplay(uint32_t width, uint32_t height,
                          uint32_t port) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager * /*frame_buffer_manager*/) override;
 
   DisplayType Type() const override {
     return DisplayType::kNested;

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -72,7 +72,8 @@ std::shared_ptr<OverlayBuffer>& OverlayLayer::GetSharedBuffer() const {
 
 void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
                              ResourceManager* resource_manager,
-                             bool register_buffer) {
+                             bool register_buffer,
+                             FrameBufferManager* frame_buffer_manager) {
   std::shared_ptr<OverlayBuffer> buffer(NULL);
 
   uint32_t id;
@@ -85,7 +86,8 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
 
   if (buffer == NULL) {
     buffer = OverlayBuffer::CreateOverlayBuffer();
-    buffer->InitializeFromNativeHandle(handle, resource_manager);
+    buffer->InitializeFromNativeHandle(handle, resource_manager,
+                                       frame_buffer_manager);
     if (resource_manager && register_buffer) {
       resource_manager->RegisterBuffer(id, buffer);
     }
@@ -202,7 +204,8 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
                                    OverlayLayer* previous_layer,
                                    uint32_t z_order, uint32_t layer_index,
                                    uint32_t max_height, uint32_t rotation,
-                                   bool handle_constraints) {
+                                   bool handle_constraints,
+                                   FrameBufferManager* frame_buffer_manager) {
   transform_ = layer->GetTransform();
   if (rotation != kRotateNone) {
     ValidateTransform(layer->GetTransform(), rotation);
@@ -238,7 +241,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   }
 
   SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
-            resource_manager, true);
+            resource_manager, true, frame_buffer_manager);
 
   if (!surface_damage_.empty()) {
     if (type_ == kLayerCursor) {
@@ -370,22 +373,25 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
 void OverlayLayer::InitializeFromHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
-    uint32_t max_height, uint32_t rotation, bool handle_constraints) {
+    uint32_t max_height, uint32_t rotation, bool handle_constraints,
+    FrameBufferManager* frame_buffer_manager) {
   display_frame_width_ = layer->GetDisplayFrameWidth();
   display_frame_height_ = layer->GetDisplayFrameHeight();
   display_frame_ = layer->GetDisplayFrame();
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints);
+                  max_height, rotation, handle_constraints,
+                  frame_buffer_manager);
 }
 
 void OverlayLayer::InitializeFromScaledHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
     const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
-    bool handle_constraints) {
+    bool handle_constraints, FrameBufferManager* frame_buffer_manager) {
   SetDisplayFrame(display_frame);
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints);
+                  max_height, rotation, handle_constraints,
+                  frame_buffer_manager);
 }
 
 void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
@@ -480,7 +486,8 @@ void OverlayLayer::ValidateForOverlayUsage() {
 void OverlayLayer::CloneLayer(const OverlayLayer* layer,
                               const HwcRect<int>& display_frame,
                               ResourceManager* resource_manager,
-                              uint32_t z_order) {
+                              uint32_t z_order,
+                              FrameBufferManager* frame_buffer_manager) {
   int32_t fence = layer->GetAcquireFence();
   int32_t aquire_fence = 0;
   if (fence > 0) {
@@ -489,7 +496,7 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   SetDisplayFrame(display_frame);
   SetSourceCrop(layer->GetSourceCrop());
   SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
-            resource_manager, true);
+            resource_manager, true, frame_buffer_manager);
   ValidateForOverlayUsage();
   surface_damage_ = layer->GetSurfaceDamage();
   transform_ = layer->transform_;

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -49,15 +49,14 @@ struct OverlayLayer {
   void InitializeFromHwcLayer(HwcLayer* layer, ResourceManager* buffer_manager,
                               OverlayLayer* previous_layer, uint32_t z_order,
                               uint32_t layer_index, uint32_t max_height,
-                              uint32_t rotation, bool handle_constraints);
+                              uint32_t rotation, bool handle_constraints,
+                              FrameBufferManager* frame_buffer_manager);
 
-  void InitializeFromScaledHwcLayer(HwcLayer* layer,
-                                    ResourceManager* buffer_manager,
-                                    OverlayLayer* previous_layer,
-                                    uint32_t z_order, uint32_t layer_index,
-                                    const HwcRect<int>& display_frame,
-                                    uint32_t max_height, uint32_t rotation,
-                                    bool handle_constraints);
+  void InitializeFromScaledHwcLayer(
+      HwcLayer* layer, ResourceManager* buffer_manager,
+      OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
+      const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
+      bool handle_constraints, FrameBufferManager* frame_buffer_manager);
   // Get z order of this layer.
   uint32_t GetZorder() const {
     return z_order_;
@@ -101,7 +100,8 @@ struct OverlayLayer {
   OverlayBuffer* GetBuffer() const;
 
   void SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
-                 ResourceManager* buffer_manager, bool register_buffer);
+                 ResourceManager* buffer_manager, bool register_buffer,
+                 FrameBufferManager* frame_buffer_manager);
 
   std::shared_ptr<OverlayBuffer>& GetSharedBuffer() const;
 
@@ -211,7 +211,8 @@ struct OverlayLayer {
   }
 
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
-                  ResourceManager* resource_manager, uint32_t z_order);
+                  ResourceManager* resource_manager, uint32_t z_order,
+                  FrameBufferManager* frame_buffer_manager);
 
   void Dump();
 
@@ -248,7 +249,8 @@ struct OverlayLayer {
   void InitializeState(HwcLayer* layer, ResourceManager* buffer_manager,
                        OverlayLayer* previous_layer, uint32_t z_order,
                        uint32_t layer_index, uint32_t max_height,
-                       uint32_t rotation, bool handle_constraints);
+                       uint32_t rotation, bool handle_constraints,
+                       FrameBufferManager* frame_buffer_manager);
 
   uint32_t transform_ = 0;
   uint32_t plane_transform_ = 0;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -46,7 +46,9 @@ DisplayPlaneManager::DisplayPlaneManager(DisplayPlaneHandler *plane_handler,
 DisplayPlaneManager::~DisplayPlaneManager() {
 }
 
-bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height) {
+bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height,
+                                     FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   width_ = width;
   height_ = height;
   bool status = plane_handler_->PopulatePlanes(overlay_planes_);
@@ -747,7 +749,7 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 
     bool modifer_succeeded = false;
     new_surface->Init(resource_manager_, preferred_format, usage, modifier,
-                      &modifer_succeeded);
+                      &modifer_succeeded, fb_manager_);
 
     if (modifer_succeeded) {
       plane.GetDisplayPlane()->PreferredFormatModifierValidated();

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -29,6 +29,7 @@ namespace hwcomposer {
 
 class DisplayPlane;
 class DisplayPlaneState;
+class FrameBufferManager;
 class GpuDevice;
 class ResourceManager;
 struct OverlayLayer;
@@ -40,7 +41,8 @@ class DisplayPlaneManager {
 
   virtual ~DisplayPlaneManager();
 
-  bool Initialize(uint32_t width, uint32_t height);
+  bool Initialize(uint32_t width, uint32_t height,
+                  FrameBufferManager *frame_buffer_manager);
 
   bool ValidateLayers(std::vector<OverlayLayer> &layers, int add_index,
                       bool disable_overlay, bool *commit_checked,
@@ -181,6 +183,7 @@ class DisplayPlaneManager {
 #ifdef DISABLE_CURSOR_PLANE
   bool enable_last_plane_;
 #endif
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -48,6 +48,7 @@ struct canvas_color_comps {
   uint16_t alpha;
 };
 
+class FrameBufferManager;
 class PhysicalDisplay;
 class DisplayPlaneHandler;
 struct HwcLayer;
@@ -61,7 +62,8 @@ class DisplayQueue {
   ~DisplayQueue();
 
   bool Initialize(uint32_t pipe, uint32_t width, uint32_t height,
-                  DisplayPlaneHandler* plane_manager);
+                  DisplayPlaneHandler* plane_manager,
+                  FrameBufferManager* frame_buffer_manager);
 
   bool QueueUpdate(std::vector<HwcLayer*>& source_layers, int32_t* retire_fence,
                    bool* ignore_clone_update, PixelUploaderCallback* call_back,
@@ -367,6 +369,7 @@ class DisplayQueue {
   // need to be marked as not in use during next
   // frame.
   std::vector<NativeSurface*> surfaces_not_inuse_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -40,7 +40,7 @@ VirtualDisplay::VirtualDisplay(uint32_t gpu_fd,
     ETRACE("Failed to construct hwc layer buffer manager");
   }
 
-  compositor_.Init(resource_manager_.get(), gpu_fd);
+  compositor_.Init(resource_manager_.get(), gpu_fd, fb_manager_);
 }
 
 VirtualDisplay::~VirtualDisplay() {
@@ -110,7 +110,7 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
     overlay_layer.InitializeFromHwcLayer(
         layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-        height_, kIdentity, handle_constraints);
+        height_, kIdentity, handle_constraints, fb_manager_);
     index.emplace_back(z_order);
     layers_rects.emplace_back(layer->GetDisplayFrame());
     z_order++;
@@ -196,7 +196,9 @@ void VirtualDisplay::SetOutputBuffer(HWCNativeHandle buffer,
   }
 }
 
-bool VirtualDisplay::Initialize(NativeBufferHandler * /*buffer_manager*/) {
+bool VirtualDisplay::Initialize(NativeBufferHandler * /*buffer_manager*/,
+                                FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   return true;
 }
 

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -27,6 +27,7 @@
 
 namespace hwcomposer {
 struct HwcLayer;
+class FrameBufferManager;
 class NativeBufferHandler;
 
 class VirtualDisplay : public NativeDisplay {
@@ -49,7 +50,8 @@ class VirtualDisplay : public NativeDisplay {
 
   void SetOutputBuffer(HWCNativeHandle buffer, int32_t acquire_fence) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager *frame_buffer_manager) override;
 
   DisplayType Type() const override {
     return DisplayType::kVirtual;
@@ -91,6 +93,7 @@ class VirtualDisplay : public NativeDisplay {
   std::vector<OverlayLayer> in_flight_layers_;
   HWCNativeHandle handle_ = 0;
   std::unique_ptr<ResourceManager> resource_manager_;
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -24,7 +24,6 @@
 #include <hwcdefs.h>
 #include <nativebufferhandler.h>
 
-#include "framebuffermanager.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "resourcemanager.h"
@@ -96,13 +95,14 @@ void DrmBuffer::Initialize(const HwcBuffer& bo) {
     frame_buffer_format_ = format_;
   }
 
-  FrameBufferManager::GetInstance()->RegisterGemHandles(
-      image_.handle_->meta_data_.num_planes_,
-      image_.handle_->meta_data_.gem_handles_);
+  fb_manager_->RegisterGemHandles(image_.handle_->meta_data_.num_planes_,
+                                  image_.handle_->meta_data_.gem_handles_);
 }
 
-void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
-                                           ResourceManager* resource_manager) {
+void DrmBuffer::InitializeFromNativeHandle(
+    HWCNativeHandle handle, ResourceManager* resource_manager,
+    FrameBufferManager* frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   resource_manager_ = resource_manager;
   const NativeBufferHandler* handler =
       resource_manager_->GetNativeBufferHandler();
@@ -381,9 +381,9 @@ bool DrmBuffer::CreateFrameBuffer() {
   image_.drm_fd_ = 0;
   media_image_.drm_fd_ = 0;
 
-  image_.drm_fd_ = FrameBufferManager::GetInstance()->FindFB(
-      width_, height_, 0, frame_buffer_format_,
-      image_.handle_->meta_data_.num_planes_, gem_handles_, pitches_, offsets_);
+  image_.drm_fd_ = fb_manager_->FindFB(width_, height_, 0, frame_buffer_format_,
+                                       image_.handle_->meta_data_.num_planes_,
+                                       gem_handles_, pitches_, offsets_);
   media_image_.drm_fd_ = image_.drm_fd_;
   return true;
 }
@@ -396,7 +396,7 @@ bool DrmBuffer::CreateFrameBufferWithModifier(uint64_t modifier) {
   image_.drm_fd_ = 0;
   media_image_.drm_fd_ = 0;
 
-  image_.drm_fd_ = FrameBufferManager::GetInstance()->FindFB(
+  image_.drm_fd_ = fb_manager_->FindFB(
       width_, height_, modifier, frame_buffer_format_,
       image_.handle_->meta_data_.num_planes_, gem_handles_, pitches_, offsets_);
   media_image_.drm_fd_ = image_.drm_fd_;

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -18,6 +18,7 @@
 
 #include <platformdefines.h>
 
+#include "framebuffermanager.h"
 #include "overlaybuffer.h"
 
 namespace hwcomposer {
@@ -33,8 +34,9 @@ class DrmBuffer : public OverlayBuffer {
 
   ~DrmBuffer() override;
 
-  void InitializeFromNativeHandle(HWCNativeHandle handle,
-                                  ResourceManager* buffer_manager) override;
+  void InitializeFromNativeHandle(
+      HWCNativeHandle handle, ResourceManager* buffer_manager,
+      FrameBufferManager* frame_buffer_manager) override;
 
   uint32_t GetWidth() const override {
     return width_;
@@ -110,6 +112,7 @@ class DrmBuffer : public OverlayBuffer {
   ResourceHandle image_;
   MediaResourceHandle media_image_;
   HWCNativeHandle original_handle_;
+  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -36,8 +36,6 @@
 
 #include <nativebufferhandler.h>
 
-#include "framebuffermanager.h"
-
 namespace hwcomposer {
 
 DrmDisplayManager::DrmDisplayManager(GpuDevice *device)
@@ -170,8 +168,7 @@ void DrmDisplayManager::HandleWait() {
 
 void DrmDisplayManager::InitializeDisplayResources() {
   buffer_handler_.reset(NativeBufferHandler::CreateInstance(fd_));
-  // FIXME: Remove this once #303 is fixed.
-  FrameBufferManager::CreateInstance(fd_);
+  frame_buffer_manager_.reset(new FrameBufferManager(fd_));
   if (!buffer_handler_) {
     ETRACE("Failed to create native buffer handler instance");
     return;
@@ -179,7 +176,8 @@ void DrmDisplayManager::InitializeDisplayResources() {
 
   int size = displays_.size();
   for (int i = 0; i < size; ++i) {
-    if (!displays_.at(i)->Initialize(buffer_handler_.get())) {
+    if (!displays_.at(i)->Initialize(buffer_handler_.get(),
+                                     frame_buffer_manager_.get())) {
       ETRACE("Failed to Initialize Display %d", i);
     }
   }

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -29,6 +29,7 @@
 #include "displayplanemanager.h"
 #include "drmdisplay.h"
 #include "drmscopedtypes.h"
+#include "framebuffermanager.h"
 #include "hwcthread.h"
 #include "nesteddisplay.h"
 #include "vblankeventhandler.h"
@@ -80,6 +81,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   bool UpdateDisplayState();
   std::unique_ptr<NativeDisplay> virtual_display_;
   std::unique_ptr<NativeDisplay> nested_display_;
+  std::unique_ptr<FrameBufferManager> frame_buffer_manager_;
   std::vector<std::unique_ptr<DrmDisplay>> displays_;
   std::shared_ptr<DisplayHotPlugEventCallback> callback_ = NULL;
   std::unique_ptr<NativeBufferHandler> buffer_handler_;

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -26,6 +26,7 @@
 
 namespace hwcomposer {
 
+class FrameBufferManager;
 class NativeBufferHandler;
 class ResourceManager;
 
@@ -40,8 +41,9 @@ class OverlayBuffer {
   virtual ~OverlayBuffer() {
   }
 
-  virtual void InitializeFromNativeHandle(HWCNativeHandle handle,
-                                          ResourceManager* buffer_manager) = 0;
+  virtual void InitializeFromNativeHandle(
+      HWCNativeHandle handle, ResourceManager* buffer_manager,
+      FrameBufferManager* frame_buffer_manager) = 0;
 
   virtual uint32_t GetWidth() const = 0;
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -45,7 +45,9 @@ PhysicalDisplay::PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id)
 PhysicalDisplay::~PhysicalDisplay() {
 }
 
-bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler) {
+bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler,
+                                 FrameBufferManager *frame_buffer_manager) {
+  fb_manager_ = frame_buffer_manager;
   display_queue_.reset(new DisplayQueue(gpu_fd_, false, buffer_handler, this));
   InitializeDisplay();
   return true;
@@ -165,7 +167,7 @@ void PhysicalDisplay::Connect() {
   display_state_ |= kNotifyClient;
   IHOTPLUGEVENTTRACE("PhysicalDisplay::Connect recieved. %p \n", this);
 
-  if (!display_queue_->Initialize(pipe_, width_, height_, this)) {
+  if (!display_queue_->Initialize(pipe_, width_, height_, this, fb_manager_)) {
     ETRACE("Failed to initialize Display Queue.");
   } else {
     display_state_ |= kInitialized;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -43,7 +43,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id);
   ~PhysicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler) override;
+  bool Initialize(NativeBufferHandler *buffer_handler,
+                  FrameBufferManager *frame_buffer_manager) override;
 
   DisplayType Type() const override {
     return DisplayType::kInternal;
@@ -151,79 +152,79 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   const NativeBufferHandler *GetNativeBufferHandler() const override;
 
   /**
-  * API for setting color correction for display.
-  */
+   * API for setting color correction for display.
+   */
   virtual void SetColorCorrection(struct gamma_colors gamma, uint32_t contrast,
                                   uint32_t brightness) const = 0;
   /**
-  * API for setting color transform matrix.
-  */
+   * API for setting color transform matrix.
+   */
   virtual void SetColorTransformMatrix(
       const float *color_transform_matrix,
       HWCColorTransform color_transform_hint) const = 0;
 
   /**
-  * API is called when display needs to be disabled.
-  * @param composition_planes contains list of planes enabled last
-  * frame.
-  */
+   * API is called when display needs to be disabled.
+   * @param composition_planes contains list of planes enabled last
+   * frame.
+   */
   virtual void Disable(const DisplayPlaneStateList &composition_planes) = 0;
 
   /**
-  * API for showing content on display
-  * @param composition_planes contains list of layers which need to displayed.
-  * @param previous_composition_planes contains list of planes enabled last
-  * frame.
-  * @param disable_explicit_fence is set to true if we want a hardware fence
-  *        associated with this commit request set to commit_fence.
-  * @param commit_fence hardware fence associated with this commit request.
-  */
+   * API for showing content on display
+   * @param composition_planes contains list of layers which need to displayed.
+   * @param previous_composition_planes contains list of planes enabled last
+   * frame.
+   * @param disable_explicit_fence is set to true if we want a hardware fence
+   *        associated with this commit request set to commit_fence.
+   * @param commit_fence hardware fence associated with this commit request.
+   */
   virtual bool Commit(const DisplayPlaneStateList &composition_planes,
                       const DisplayPlaneStateList &previous_composition_planes,
                       bool disable_explicit_fence, int32_t previous_fence,
                       int32_t *commit_fence, bool *previous_fence_released) = 0;
 
   /**
-  * API is called if current active display configuration has changed.
-  * Implementations need to reset any state in this case.
-  */
+   * API is called if current active display configuration has changed.
+   * Implementations need to reset any state in this case.
+   */
   virtual void UpdateDisplayConfig() = 0;
 
   /**
-  * API for powering on the display
-  */
+   * API for powering on the display
+   */
   virtual void PowerOn() = 0;
 
   /**
-  * API for initializing display. Implementation needs to handle all things
-  * needed to set up the physical display.
-  */
+   * API for initializing display. Implementation needs to handle all things
+   * needed to set up the physical display.
+   */
   virtual bool InitializeDisplay() = 0;
 
   virtual void NotifyClientsOfDisplayChangeStatus() = 0;
 
   /**
-  * API for setting the color of the pipe canvas.
-  */
+   * API for setting the color of the pipe canvas.
+   */
   virtual void SetPipeCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
                                   uint16_t blue, uint16_t alpha) const = 0;
 
   /**
-  * API for informing the display that it might be disconnected in near
-  * future.
-  */
+   * API for informing the display that it might be disconnected in near
+   * future.
+   */
   void MarkForDisconnect();
 
   /**
-  * API for informing the clients resgistered via RegisterHotPlugCallback
-  * that this display had been disconnected.
-  */
+   * API for informing the clients resgistered via RegisterHotPlugCallback
+   * that this display had been disconnected.
+   */
   void NotifyClientOfConnectedState();
 
   /**
-  * API for informing the clients resgistered via RegisterHotPlugCallback
-  * that this display had been connected.
-  */
+   * API for informing the clients resgistered via RegisterHotPlugCallback
+   * that this display had been connected.
+   */
   void NotifyClientOfDisConnectedState();
 
   /**
@@ -244,9 +245,9 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void DisConnect();
 
   /**
-  * API to handle any lazy initializations which need to be handled
-  * during first present call.
-  */
+   * API to handle any lazy initializations which need to be handled
+   * during first present call.
+   */
   virtual void HandleLazyInitialization() {
   }
 
@@ -300,6 +301,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
+  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
This patch addresses issue #303 and has the GpuDevice take ownership
of the FrameBufferManager Instance which then gets passed to all
displays on initialization to pass to the drmbuffer and the
compositorthread as needed in place of calling the instances from
FrameBufferManager directly.

Jira: GSE-1502
Test: android_ia and HWC build passes without errors
Signed-off-by: Richard Avelar richard.avelar@intel.com