### PR TITLE
Fix compilation warnings.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -95,7 +95,7 @@ void GpuDevice::GetConnectedPhysicalDisplays(
   }
 }
 
-std::vector<NativeDisplay *> GpuDevice::GetAllDisplays() {
+std::vector<NativeDisplay *>& GpuDevice::GetAllDisplays() {
   return total_displays_;
 }
 

--- a/os/linux/linux_frontend.cpp
+++ b/os/linux/linux_frontend.cpp
@@ -104,7 +104,7 @@ int32_t IAHWC::Init() {
     return IAHWC_ERROR_NO_RESOURCES;
   }
 
-  std::vector<hwcomposer::NativeDisplay*> displays = device_.GetAllDisplays();
+  std::vector<hwcomposer::NativeDisplay*>& displays = device_.GetAllDisplays();
 
   for (hwcomposer::NativeDisplay* display : displays) {
     displays_.emplace_back(new IAHWCDisplay());
@@ -293,6 +293,7 @@ int IAHWC::IAHWCDisplay::Init(hwcomposer::NativeDisplay* display,
   native_display_->InitializeLayerHashGenerator(4);
   raw_data_uploader_ =
       new PixelUploader(native_display_->GetNativeBufferHandler());
+  return 0;
 }
 
 int IAHWC::IAHWCDisplay::GetDisplayInfo(uint32_t config, int attribute,
@@ -412,6 +413,7 @@ int IAHWC::IAHWCDisplay::RunPixelUploader(bool enable) {
     raw_data_uploader_->Initialize();
   else
     raw_data_uploader_->ExitThread();
+  return 0;
 }
 
 int IAHWC::IAHWCDisplay::CreateLayer(uint32_t* layer_handle) {

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -53,7 +53,7 @@ class GpuDevice : public HWCThread {
 
   void GetConnectedPhysicalDisplays(std::vector<NativeDisplay*>& displays);
 
-  std::vector<NativeDisplay*> GetAllDisplays();
+  std::vector<NativeDisplay*>& GetAllDisplays();
 
   void RegisterHotPlugEventCallback(
       std::shared_ptr<DisplayHotPlugEventCallback> callback);


### PR DESCRIPTION
As a consequence of this change, linux_test app doesn't
crash when compiled using gcc 8.1.0

Jira: None
Test: Compile the test app with gcc 8.1.0 and run. It shouldn't
      crash.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>