### PR TITLE
ignore interlace modes

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -464,7 +464,12 @@ void DrmDisplay::SetDrmModeInfo(const std::vector<drmModeModeInfo> &mode_info) {
   uint32_t size = mode_info.size();
   std::vector<drmModeModeInfo>().swap(modes_);
   for (uint32_t i = 0; i < size; ++i) {
-    modes_.emplace_back(mode_info[i]);
+#ifdef ENABLE_ANDROID_WA
+    //FIXME: SurfaceFlinger can't distinguish interlace mode config.
+    //interlace mode is not requirement for android, ignore them.
+    if (!(mode_info[i].flags & DRM_MODE_FLAG_INTERLACE))
+#endif
+      modes_.emplace_back(mode_info[i]);
   }
 
   SPIN_UNLOCK(display_lock_);


### PR DESCRIPTION
In AOSP PPR1.180528.001 version code, connector mode config list
reported to SurfaceFlinger are changed to unsorted.
Interlace mode config will be chosen and set in display. This will cause
display shake issue. Interlace mode configs are not requirement on
android, so we ignore them(the flags with DRM_MODE_FLAG_INTERLACE).

Change-Id: I2397045ce127046b942b974f30f1d4d8618a3f80
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-64528
Signed-off-by: Liu Zhiquan <zhiquan.liu@intel.com>