### PR TITLE
HwcLayer: Apply rotation transformation to damage.

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -207,23 +207,6 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
       const std::shared_ptr<OverlayBuffer>& buffer = imported_buffer_->buffer_;
       surface_damage_.right = surface_damage_.left + buffer->GetWidth();
       surface_damage_.bottom = surface_damage_.top + buffer->GetHeight();
-    } else {
-      switch (plane_transform_) {
-        case HWCTransform::kTransform270:
-        case HWCTransform::kTransform90: {
-          bool swap = true;
-          if (surface_damage_ == display_frame_) {
-            swap = false;
-          }
-
-          if (swap) {
-            std::swap(surface_damage_.right, surface_damage_.bottom);
-          }
-          break;
-        }
-        default:
-          break;
-      }
     }
   }
 

--- a/hwc_display.ini
+++ b/hwc_display.ini
@@ -14,7 +14,11 @@ PHYSICAL_DISPLAY="0:1:2"
 
 # Rotation of display, with format "physical-display-number:rotation".
 # physical-display-number: start from 0, included all display ports(whatever connected or disconnected)
-# rotation: Rotation which needs to be applied. Check HWCRotation in public/hwcdefs.h
+# rotation: Rotation which needs to be applied.
+# 0 - 0 degree
+# 1 - 90 degree
+# 2 - 180 degree
+# 3 - 270 degree
 PHYSICAL_DISPLAY_ROTATION="1:1"
 
 # Logical display definitions, with format "physical-display-number:split-number"


### PR DESCRIPTION
This enables us to remove the workaround in Overlaylayer.

Jira: None
Test: No regressions seens on Android and Linux.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>