### PR TITLE
[Android] Add option to disable video vpp if va driver is not ready.

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -117,12 +117,16 @@ LOCAL_CPPFLAGS += \
 	-DENABLE_RBC
 endif
 
+ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)
 LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/common/compositor/va
 
 LOCAL_SHARED_LIBRARIES += \
 	libva \
 	libva-android
+else
+LOCAL_CPPFLAGS += -DDISABLE_VA
+endif
 
 LOCAL_C_INCLUDES += \
 	$(INTEL_MINIGBM)/cros_gralloc/

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -39,12 +39,8 @@ LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/../os \
         $(LOCAL_PATH)/../os/android \
         $(LOCAL_PATH)/../wsi \
-        $(LOCAL_PATH)/../wsi/drm \
-        $(TARGET_OUT_HEADERS)/libva
+        $(LOCAL_PATH)/../wsi/drm
 
-LOCAL_SHARED_LIBRARIES += \
-	libva \
-	libva-android
 
 ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += \
@@ -71,8 +67,6 @@ LOCAL_SRC_FILES := \
         compositor/factory.cpp \
         compositor/nativesurface.cpp \
         compositor/renderstate.cpp \
-	compositor/va/varenderer.cpp \
-	compositor/va/vautils.cpp \
         core/gpudevice.cpp \
         core/hwclayer.cpp \
 	core/resourcemanager.cpp \
@@ -92,6 +86,19 @@ LOCAL_SRC_FILES := \
         utils/hwcthread.cpp \
         utils/hwcutils.cpp \
         utils/disjoint_layers.cpp
+
+ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)
+LOCAL_SHARED_LIBRARIES += \
+	libva \
+	libva-android
+
+LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/libva
+
+LOCAL_SRC_FILES += compositor/va/varenderer.cpp \
+	           compositor/va/vautils.cpp
+else
+LOCAL_CPPFLAGS += -DDISABLE_VA
+endif
 
 ifeq ($(strip $(ENABLE_NESTED_DISPLAY_SUPPORT)), true)
 LOCAL_CPPFLAGS += -DNESTED_DISPLAY_SUPPORT

--- a/common/compositor/compositordefs.h
+++ b/common/compositor/compositordefs.h
@@ -27,7 +27,9 @@
 
 #include <platformdefines.h>
 
+#ifndef DISABLE_VA
 #include <va/va.h>
+#endif
 
 namespace hwcomposer {
 
@@ -80,7 +82,9 @@ typedef void* GpuDisplay;
 #endif
 
 typedef struct media_import {
+#ifndef DISABLE_VA
   VASurfaceID surface_ = VA_INVALID_ID;
+#endif
   HWCNativeHandle handle_ = 0;
   uint32_t drm_fd_ = 0;
 } MediaResourceHandle;

--- a/common/compositor/factory.cpp
+++ b/common/compositor/factory.cpp
@@ -29,7 +29,9 @@
 #include "vksurface.h"
 #endif
 
+#ifndef DISABLE_VA
 #include "va/varenderer.h"
+#endif
 
 namespace hwcomposer {
 
@@ -61,7 +63,11 @@ Renderer* CreateMediaRenderer() {
 #ifdef USE_DC
   return NULL;
 #else
+#ifndef DISABLE_VA
   return new VARenderer();
+#else
+  return NULL;
+#endif
 #endif
 }
 

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -216,7 +216,6 @@ bool DisplayPlaneManager::ValidateLayers(
           if (layer->IsVideoLayer()) {
             last_plane.SetVideoPlane(true);
           }
-
           if (fall_back) {
             if (!validate_final_layers)
               validate_final_layers = !(last_plane.GetOffScreenTarget());

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -473,12 +473,14 @@ bool DisplayPlaneState::IsVideoPlane() const {
 }
 
 void DisplayPlaneState::SetVideoPlane(bool enable_video) {
+#ifndef DISABLE_VA
   if (enable_video) {
     private_data_->type_ = DisplayPlanePrivateState::PlaneType::kVideo;
     private_data_->supports_video_ = true;
   } else {
     private_data_->type_ = DisplayPlanePrivateState::PlaneType::kNormal;
   }
+#endif
 }
 
 void DisplayPlaneState::UsePlaneScalar(bool enable, bool force_refresh) {

--- a/os/android/platformdefines.cpp
+++ b/os/android/platformdefines.cpp
@@ -16,7 +16,9 @@
 
 #include "platformdefines.h"
 
+#ifndef DISABLE_VA
 #include <va/va_android.h>
+#endif
 
 #define ANDROID_DISPLAY_HANDLE 0x18C34078
 
@@ -71,8 +73,10 @@ VkFormat NativeToVkFormat(int native_format) {
 }
 #endif
 
+#ifndef DISABLE_VA
 void* GetVADisplay(uint32_t gpu_fd) {
   HWC_UNUSED(gpu_fd);
   unsigned int native_display = ANDROID_DISPLAY_HANDLE;
   return vaGetDisplay(&native_display);
 }
+#endif

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -40,11 +40,16 @@ LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/../os \
         $(LOCAL_PATH)/../os/android \
         $(LOCAL_PATH)/../wsi \
-	$(LOCAL_PATH)/../wsi/drm \
-	$(TARGET_OUT_HEADERS)/libva
+	$(LOCAL_PATH)/../wsi/drm
 
+ifeq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)
+LOCAL_CPPFLAGS += -DDISABLE_VA
+else
 LOCAL_SHARED_LIBRARIES += \
 	libva
+LOCAL_C_INCLUDES += \
+	$(TARGET_OUT_HEADERS)/libva
+endif
 
 LOCAL_SRC_FILES := \
         physicaldisplay.cpp \


### PR DESCRIPTION
For certain reason on some platform the va driver is not enabled,
then video vpp path should be disabled.

Test: video playback normal and no other side effect.
Signed-off-by: Yuanjun Huang <yuanjun.huang@intel.com>
Singed-off-by: Lin Johnson <johnson.lin@intel.com>