### PR TITLE
Fix Klockwork indirect path traversal issue.

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -127,6 +127,7 @@ LOCAL_CPPFLAGS += \
         -Wall -Wsign-compare -Wpointer-arith \
         -Wcast-qual -Wcast-align \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
+        -DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
         -O3
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -27,6 +27,7 @@ AM_CPP_INCLUDES = -Icore -Iutils -Icompositor -Idisplay -I../os/ -I../os/linux/ 
 AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE -DENABLE_DOUBLE_BUFFERING
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 AM_CPPFLAGS += -DLOCK_DIR_PREFIX='"${prefix}/etc"'
+AM_CPPFLAGS += -DHWC_DISPLAY_INI_PATH='"${prefix}/etc/hwc_display.ini"'
 
 libhwcomposer_common_la_LIBADD = \
 	$(DRM_LIBS) \

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -106,10 +106,8 @@ void GpuDevice::RegisterHotPlugEventCallback(
 
 void GpuDevice::HandleHWCSettings() {
   // Handle config file reading
-  const char *hwc_dp_cfg_path = std::getenv("HWC_DISPLAY_CONFIG");
-  if (!hwc_dp_cfg_path) {
-    hwc_dp_cfg_path = "/vendor/etc/hwc_display.ini";
-  }
+  const char *hwc_dp_cfg_path = HWC_DISPLAY_INI_PATH;
+  ITRACE("Hwc display config file is %s", hwc_dp_cfg_path);
 
   bool use_logical = false;
   bool use_mosaic = false;


### PR DESCRIPTION
Jira: None
Test: File path on
      Android: /vendor/etc/hwc_display.ini
      Linux: {prefix}/etc/hwc_display.ini

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>