### PR TITLE
MosaicMode: return more reliable fences

### DIFF
--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -128,7 +128,6 @@ class MosaicDisplay : public NativeDisplay {
   uint32_t config_ = 0;
   uint32_t vsync_counter_ = 0;
   uint32_t vsync_divisor_ = 0;
-  uint32_t preferred_display_index_ = 0;
   int64_t vsync_timestamp_ = 0;
   bool enable_vsync_ = false;
   bool connected_ = false;


### PR DESCRIPTION
Currently we pick a display with the maximum refresh rate
as the preferred display and return its fence.
Instead, merge the fences from all the displays and return it.
Such merged fences are signaled when all the individual fences
are signaled.

Jira: None
Test: No regressions seen on Linux and Android

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>