### PR TITLE
Several 2 plane drm format modifiers incorrectly returning value of 1 plane

### DIFF
--- a/wsi/drm/commondrmutils.h
+++ b/wsi/drm/commondrmutils.h
@@ -31,8 +31,6 @@ static size_t drm_bo_get_num_planes(uint32_t format) {
     case DRM_FORMAT_ARGB8888:
     case DRM_FORMAT_AYUV:
     case DRM_FORMAT_BGR233:
-    case DRM_FORMAT_BGR565:
-    case DRM_FORMAT_BGR888:
     case DRM_FORMAT_BGRA1010102:
     case DRM_FORMAT_BGRA4444:
     case DRM_FORMAT_BGRA5551:
@@ -40,14 +38,11 @@ static size_t drm_bo_get_num_planes(uint32_t format) {
     case DRM_FORMAT_BGRX1010102:
     case DRM_FORMAT_BGRX4444:
     case DRM_FORMAT_BGRX5551:
-    case DRM_FORMAT_BGRX8888:
     case DRM_FORMAT_C8:
     case DRM_FORMAT_GR88:
     case DRM_FORMAT_R8:
     case DRM_FORMAT_RG88:
     case DRM_FORMAT_RGB332:
-    case DRM_FORMAT_RGB565:
-    case DRM_FORMAT_RGB888:
     case DRM_FORMAT_RGBA1010102:
     case DRM_FORMAT_RGBA4444:
     case DRM_FORMAT_RGBA5551:
@@ -55,26 +50,31 @@ static size_t drm_bo_get_num_planes(uint32_t format) {
     case DRM_FORMAT_RGBX1010102:
     case DRM_FORMAT_RGBX4444:
     case DRM_FORMAT_RGBX5551:
-    case DRM_FORMAT_RGBX8888:
     case DRM_FORMAT_UYVY:
     case DRM_FORMAT_VYUY:
     case DRM_FORMAT_XBGR1555:
     case DRM_FORMAT_XBGR2101010:
     case DRM_FORMAT_XBGR4444:
-    case DRM_FORMAT_XBGR8888:
     case DRM_FORMAT_XRGB1555:
     case DRM_FORMAT_XRGB2101010:
     case DRM_FORMAT_XRGB4444:
-    case DRM_FORMAT_XRGB8888:
     case DRM_FORMAT_YUYV:
     case DRM_FORMAT_YVYU:
     case DRM_FORMAT_R16:
       return 1;
+    case DRM_FORMAT_BGR565:
+    case DRM_FORMAT_BGR888:
+    case DRM_FORMAT_BGRX8888:
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_NV21:
     case DRM_FORMAT_NV12_Y_TILED_INTEL:
     case DRM_FORMAT_NV16:
     case DRM_FORMAT_P010:
+    case DRM_FORMAT_RGB565:
+    case DRM_FORMAT_RGB888:
+    case DRM_FORMAT_RGBX8888:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_XRGB8888:
       return 2;
     case DRM_FORMAT_YVU420:
     case DRM_FORMAT_YVU420_ANDROID:


### PR DESCRIPTION
All DRM_FORMAT_* that were moved have 2 planes -- RGB & A

Jira: None
Test: None

Signed-off-by: Kelly Ledford <kelly.ledford@intel.com>