### PR TITLE
Add note to doxy installation instructions readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ To install doxygen on ubuntu simply run:
 sudo apt install doxygen
 ```
 
+Note: You may also need to install graphviz if you do not have it already.
+
+```
+sudo apt install graphviz
+```
+
 Once installed, you should provide documentation to any new features you add to
 the project or modify/create documentation for any big changes in methods,
 classes, etc that you change.


### PR DESCRIPTION
Since we are using the HAVE_DOT option in the doxygen config file,
we should make a note to the user that they may need to install
graphviz if they do not already have it installed on their machine.

Tests: Run Doxygen
Jira: None
Signed-off-by: Richard Avelar richard.avelar@intel.com