### PR TITLE
Fix virtual display regression

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -152,6 +152,7 @@ bool Compositor::DrawOffscreen(std::vector<OverlayLayer> &layers,
                                const std::vector<HwcRect<int>> &display_frame,
                                const std::vector<size_t> &source_layers,
                                ResourceManager *resource_manager,
+                               FrameBufferManager *framebuffer_manager,
                                uint32_t width, uint32_t height,
                                HWCNativeHandle output_handle,
                                int32_t acquire_fence, int32_t *retire_fence) {
@@ -167,7 +168,8 @@ bool Compositor::DrawOffscreen(std::vector<OverlayLayer> &layers,
   }
 
   NativeSurface *surface = Create3DBuffer(width, height);
-  surface->InitializeForOffScreenRendering(output_handle, resource_manager);
+  surface->InitializeForOffScreenRendering(output_handle, resource_manager,
+                                           framebuffer_manager);
   std::vector<DrawState> draw;
   std::vector<DrawState> media;
   draw.emplace_back();

--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -50,7 +50,8 @@ class Compositor {
   bool DrawOffscreen(std::vector<OverlayLayer> &layers,
                      const std::vector<HwcRect<int>> &display_frame,
                      const std::vector<size_t> &source_layers,
-                     ResourceManager *resource_manager, uint32_t width,
+                     ResourceManager *resource_manager,
+                     FrameBufferManager *framebuffer_manager, uint32_t width,
                      uint32_t height, HWCNativeHandle output_handle,
                      int32_t acquire_fence, int32_t *retire_fence);
   void FreeResources();

--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -94,8 +94,10 @@ bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
 }
 
 bool NativeSurface::InitializeForOffScreenRendering(
-    HWCNativeHandle native_handle, ResourceManager *resource_manager) {
+    HWCNativeHandle native_handle, ResourceManager *resource_manager,
+    FrameBufferManager *framebuffer_manager) {
   resource_manager_ = resource_manager;
+  fb_manager_ = framebuffer_manager;
   InitializeLayer(native_handle);
   layer_.SetSourceCrop(HwcRect<float>(0, 0, width_, height_));
   layer_.SetDisplayFrame(HwcRect<int>(0, 0, width_, height_));

--- a/common/compositor/nativesurface.h
+++ b/common/compositor/nativesurface.h
@@ -47,8 +47,9 @@ class NativeSurface {
             uint64_t modifier, bool* modifier_succeeded,
             FrameBufferManager* frame_buffer_manager);
 
-  bool InitializeForOffScreenRendering(HWCNativeHandle native_handle,
-                                       ResourceManager* resource_manager);
+  bool InitializeForOffScreenRendering(
+      HWCNativeHandle native_handle, ResourceManager* resource_manager,
+      FrameBufferManager* frame_buffer_manager);
 
   virtual bool MakeCurrent() {
     return false;

--- a/common/core/nesteddisplay.cpp
+++ b/common/core/nesteddisplay.cpp
@@ -70,13 +70,15 @@ void SocketThread::HandleRoutine() {
 #endif
 
 NestedDisplay::NestedDisplay(uint32_t gpu_fd,
-                             NativeBufferHandler *buffer_handler) {
+                             NativeBufferHandler *buffer_handler,
+                             FrameBufferManager *framebuffermanager) {
 #ifdef NESTED_DISPLAY_SUPPORT
   int ret;
   struct ioctl_hyper_dmabuf_tx_ch_setup msg;
   memset(&msg, 0, sizeof(ioctl_hyper_dmabuf_tx_ch_setup));
 
   resource_manager_.reset(new ResourceManager(buffer_handler));
+  fb_manger_ = framebuffermanager;
   if (!resource_manager_) {
     ETRACE("Failed to construct hwc layer buffer manager");
   }

--- a/common/core/nesteddisplay.h
+++ b/common/core/nesteddisplay.h
@@ -97,7 +97,8 @@ class SocketThread : public HWCThread {
 
 class NestedDisplay : public NativeDisplay {
  public:
-  NestedDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler);
+  NestedDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
+                FrameBufferManager *framebuffermanager);
   ~NestedDisplay() override;
 
   void InitNestedDisplay(uint32_t width, uint32_t height,

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -33,7 +33,8 @@ class NativeBufferHandler;
 class VirtualDisplay : public NativeDisplay {
  public:
   VirtualDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
-                 uint32_t pipe_id, uint32_t crtc_id);
+                 FrameBufferManager *framebuffermanager, uint32_t pipe_id,
+                 uint32_t crtc_id);
   VirtualDisplay(const VirtualDisplay &) = delete;
   VirtualDisplay &operator=(const VirtualDisplay &) = delete;
   ~VirtualDisplay() override;
@@ -94,6 +95,7 @@ class VirtualDisplay : public NativeDisplay {
   HWCNativeHandle handle_ = 0;
   std::unique_ptr<ResourceManager> resource_manager_;
   FrameBufferManager *fb_manager_ = NULL;
+  uint32_t gpu_fd_ = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -182,8 +182,10 @@ void DrmDisplayManager::InitializeDisplayResources() {
     }
   }
 
-  virtual_display_.reset(new VirtualDisplay(fd_, buffer_handler_.get(), 0, 0));
-  nested_display_.reset(new NestedDisplay(fd_, buffer_handler_.get()));
+  virtual_display_.reset(new VirtualDisplay(fd_, buffer_handler_.get(),
+                                            frame_buffer_manager_.get(), 0, 0));
+  nested_display_.reset(new NestedDisplay(fd_, buffer_handler_.get(),
+                                          frame_buffer_manager_.get()));
 }
 
 void DrmDisplayManager::StartHotPlugMonitor() {


### PR DESCRIPTION
caused by b6ff1590f362fefadbc0ad3b3128fef9895e28be
virtual display and nested display should have fb_manager in
constructor because compositor is intialized in constructor

Jira: https://jira01.devtools.intel.com/browse/OAM-67091
Tests: virtual display on Android P GP2.0
Signed-off-by: Lin Johnson <johnson.lin@intel.com>