### PR TITLE
Add file command to documented files

### DIFF
--- a/common/core/framebuffermanager.h
+++ b/common/core/framebuffermanager.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 */
 
-/*
+/** \file
 Design of ResourceManager:
 The purpose is to add cache magagement to external buffer owned by hwcLayer
 to avoid import buffer and glimage/texture generation overhead

--- a/public/hwcrect.h
+++ b/public/hwcrect.h
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-
+/** \file */
 #ifndef PUBLIC_HWCRECT_H_
 #define PUBLIC_HWCRECT_H_
 

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-
+/** \file */
 #ifndef COMMON_UTILS_HWCUTILS_H_
 #define COMMON_UTILS_HWCUTILS_H_
 


### PR DESCRIPTION
The \file command at the top of a file allows doxygen to know
the file is documented and the documentation should be used in the
generation of documentation output to html/latex

Jira: GSE-1575
Tests: Run Doxygen, examine file tab page in html
Signed-off-by: Richard Avelar richard.avelar@intel.com