### PR TITLE
Fix screen flicker when selecting option in setting menu

### DIFF
--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -210,7 +210,7 @@ inline HwcRect<int> Intersection(const hwcomposer::HwcRect<int>& rect1,
   int rmin = std::min(rect1.right, rect2.right);
   int bmin = std::min(rect1.bottom, rect2.bottom);
 
-  if (rmin < lmax || bmin < tmax)
+  if (rmin <= lmax || bmin <= tmax)
     return rect;
 
   rect.left = lmax;


### PR DESCRIPTION
This help fix screen flicker when selecting any option in the
setting menu screen with touch screen. We should return empty
rectangle when rmin <= lmax or bmin <= tmax.

Jira: OAM-67240
Test: Screen won't flicker when selecting option in setting menu