### PR TITLE
  GP2.0 Renderer interlaced video mode control

### DIFF
--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -19,8 +19,9 @@
 
 #include <map>
 
-#include "renderer.h"
 #include "hwcdefs.h"
+#include "overlaybuffer.h"
+#include "renderer.h"
 
 #include "vautils.h"
 
@@ -101,12 +102,14 @@ class VARenderer : public Renderer {
   unsigned int GetVAProcFilterScalingMode(uint32_t mode);
   bool SetVAProcFilterColorValue(HWCColorControl type,
                                  const HWCColorProp& prop);
-  bool SetVAProcFilterDeinterlaceMode(const HWCDeinterlaceProp& prop);
+  bool SetVAProcFilterDeinterlaceMode(const HWCDeinterlaceProp& prop,
+                                      OverlayBuffer* buffer);
   bool SetVAProcFilterColorDefaultValue(VAProcFilterCapColorBalance* caps);
   bool SetVAProcFilterDeinterlaceDefaultMode();
   bool MapVAProcFilterColorModetoHwc(HWCColorControl& vppmode,
                                      VAProcColorBalanceType vamode);
-  bool GetVAProcDeinterlaceFlagFromVideo(HWCDeinterlaceFlag flag);
+  bool GetVAProcDeinterlaceFlagFromVideo(const HWCDeinterlaceFlag flag,
+                                         OverlayBuffer* buffer);
   bool CreateContext();
   void DestroyContext();
   bool LoadCaps();

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -95,6 +95,7 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
     }
   } else {
     buffer->SetOriginalHandle(handle);
+    buffer->SetInterlace(handle->meta_data_.is_interlaced_);
   }
 
   imported_buffer_.reset(new ImportedBuffer(buffer, acquire_fence));

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -251,6 +251,9 @@ static bool ImportGraphicsBuffer(HWCNativeHandle handle, int fd) {
   if (handle->meta_data_.format_ == DRM_FORMAT_YVU420_ANDROID)
     handle->meta_data_.format_ = DRM_FORMAT_YVU420;
 
+  // Store is_interlaced flag from Gralloc1
+  handle->meta_data_.is_interlaced_ = gr_handle->is_interlaced;
+
   return true;
 }
 #ifdef __cplusplus

--- a/public/hwcbuffer.h
+++ b/public/hwcbuffer.h
@@ -26,7 +26,7 @@ struct HwcBuffer {
   HwcBuffer() = default;
 
   HwcBuffer &operator=(const HwcBuffer &rhs) = delete;
-
+  bool is_interlaced_ = false;
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint32_t format_ = 0;  // Drm format equivalent to native_format.

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -76,6 +76,14 @@ class DrmBuffer : public OverlayBuffer {
     return METADATA(tiling_mode_);
   }
 
+  bool GetInterlace() override {
+    return METADATA(is_interlaced_);
+  }
+
+  void SetInterlace(bool isInterlaced) override {
+    METADATA(is_interlaced_) = isInterlaced;
+  }
+
   const ResourceHandle& GetGpuResource(GpuDisplay egl_display,
                                        bool external_import) override;
 

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -63,6 +63,10 @@ class OverlayBuffer {
 
   virtual uint32_t GetTilingMode() const = 0;
 
+  virtual bool GetInterlace() = 0;
+
+  virtual void SetInterlace(bool isInterlaced) = 0;
+
   // external_import should be true if this resource is not owned by HWC.
   // If resource is owned by HWC, than the implementation needs to create
   // frame buffer for this buffer.


### PR DESCRIPTION
  Many interlaced video clips still exist despite the fact that
  most modern computer monitors do not support interlaced video.
  Since this capability does not currently exist in Android,
  provide the interface to deinterlace the video prior to
  rendering to enhance the user experience.

  Jira: GSE-1618
  Test: To be tested on KabyLake NUC

  Signed-off-by: Michele Lim <michele.lim@intel.com>