### PR TITLE
Robustness for AaaG: when there is no pipe assigned,

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -1032,6 +1032,7 @@ bool DisplayPlaneManager::ReValidatePlanes(
       }
 
       // Check if we can rotate using Display plane.
+      EnsureOffScreenTarget(last_plane);
       if (FallbacktoGPU(last_plane.GetDisplayPlane(),
                         last_plane.GetOffScreenTarget()->GetLayer(),
                         commit_planes)) {

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -75,6 +75,8 @@ bool DrmDisplayManager::Initialize() {
   }
 
   ScopedDrmResourcesPtr res(drmModeGetResources(fd_));
+  if (res->count_crtcs == 0)
+    return false;
 
   for (int32_t i = 0; i < res->count_crtcs; ++i) {
     ScopedDrmCrtcPtr c(drmModeGetCrtc(fd_, res->crtcs[i]));


### PR DESCRIPTION
HWC should return false instead of crash

Jira: None
Tests: Android boot with no pipe assigned in AaaG
Signed-off-by: Lin Johnson <johnson.lin@intel.com>