### PR TITLE
Re-map display rotation values before calculation

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -133,8 +133,10 @@ void OverlayLayer::ValidateTransform(uint32_t transform,
   std::vector<int> inv_tmap = {kIdentity, kTransform90, kTransform180,
                                kTransform270};
 
+  int mdisplay_transform = display_transform;
   int mtransform =
       transform & (kIdentity | kTransform90 | kTransform180 | kTransform270);
+
   if (tmap.find(mtransform) != tmap.end()) {
     mtransform = tmap[mtransform];
   } else {
@@ -144,8 +146,14 @@ void OverlayLayer::ValidateTransform(uint32_t transform,
     mtransform = kIdentity;
   }
 
+  if (tmap.find(mdisplay_transform) != tmap.end()) {
+    mdisplay_transform = tmap[mdisplay_transform];
+  } else {
+    mdisplay_transform = kIdentity;
+  }
+
   // The elements {0, 1, 2, 3} form a circulant matrix under mod 4 arithmetic
-  mtransform = (mtransform + display_transform) % 4;
+  mtransform = (mtransform + mdisplay_transform) % 4;
   mtransform = inv_tmap[mtransform];
   plane_transform_ = mtransform;
 


### PR DESCRIPTION
the display rotation values are one of {kIdentity, kTransform90,
kTransform180, kTransform270}. First remap them to 0..3 before adding it to
the layer's transform.

Jira: None
Test: The display's rotation should reflect based on the setting in hwc_display.ini

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>