### PR TITLE
  Fix for Antutu Regression

### DIFF
--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -139,7 +139,9 @@ class DisplayQueue {
     kConfigurationChanged = 1 << 1,  // Layers need to be re-validated.
     kPoweredOn = 1 << 2,
     kDisableOverlayUsage = 1 << 3,  // Disable Overlays.
-    kIgnoreIdleRefresh = 1 << 4  // Ignore refresh request during idle callback.
+    kIgnoreIdleRefresh =
+        1 << 4,  // Ignore refresh request during idle callback.
+    kCanvasColorChanged = 1 << 5  // Update color change
   };
 
   struct ScalingTracker {


### PR DESCRIPTION
  The issue here is canvas color was updated to kernel
  everytime during the display update eventhough there
  was no update in the color from the upper layer. Bcos,
  of this redundant ioctl calls to kernel, 3d scores
  regressed. The fix here is to call the ioctl only
  when there is a set/update in the canvas pipe color

  Signed-off-by: Aravindan M <aravindan.muthukumar@intel.com>
  Signed-off-by: Kedar Karanje <kedar.j.karanje@intel.com>

  JIRA: https://jira01.devtools.intel.com/browse/OAM-65913