### PR TITLE
Implement display rotation.

### DIFF
--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -85,6 +85,10 @@ class DisplayPlaneManager {
     return height_;
   }
 
+  uint32_t GetWidth() const {
+    return width_;
+  }
+
   uint32_t GetTotalOverlays() const {
     return total_overlays_;
   }

--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -166,4 +166,71 @@ std::string StringifyRegion(HwcRegion region) {
   return ss.str();
 }
 
+HwcRect<int> RotateRect(const HwcRect<int>& rect, int disp_width,
+                        int disp_height, uint32_t transform) {
+  int ox = 0, oy = 0;
+  HwcRect<int> rotated_rect;
+  if (transform == 0)
+    return rect;
+  if (transform == hwcomposer::HWCTransform::kTransform270) {
+    ox = 0;
+    oy = disp_width;
+    rotated_rect.left = ox + rect.top;
+    rotated_rect.top = oy - rect.right;
+    rotated_rect.right = ox + rect.bottom;
+    rotated_rect.bottom = oy - rect.left;
+  } else if (transform == hwcomposer::HWCTransform::kTransform180) {
+    ox = disp_width;
+    oy = disp_height;
+    rotated_rect.left = ox - rect.right;
+    rotated_rect.top = oy - rect.bottom;
+    rotated_rect.right = ox - rect.left;
+    rotated_rect.bottom = oy - rect.top;
+  } else if (transform & hwcomposer::HWCTransform::kTransform90) {
+    if (transform & hwcomposer::HWCTransform::kReflectY) {
+      ox = 0;
+      oy = 0;
+      rotated_rect.left = ox + rect.top;
+      rotated_rect.top = oy + rect.left;
+      rotated_rect.right = ox + rect.bottom;
+      rotated_rect.bottom = oy + rect.right;
+    } else if (transform & hwcomposer::HWCTransform::kReflectX) {
+      ox = disp_height;
+      oy = disp_width;
+      rotated_rect.left = ox - rect.bottom;
+      rotated_rect.top = oy - rect.right;
+      rotated_rect.right = ox - rect.top;
+      rotated_rect.bottom = oy - rect.left;
+    } else {
+      ox = disp_height;
+      oy = 0;
+      rotated_rect.left = ox - rect.bottom;
+      rotated_rect.top = oy + rect.left;
+      rotated_rect.right = ox - rect.top;
+      rotated_rect.bottom = oy + rect.right;
+    }
+  }
+  return rotated_rect;
+}
+
+HwcRect<int> ScaleRect(HwcRect<int> rect, float x_scale, float y_scale) {
+  rect.left = rect.left * x_scale;
+  rect.top = rect.top * y_scale;
+  rect.right = rect.right * x_scale;
+  rect.bottom = rect.bottom * y_scale;
+  return rect;
+}
+
+HwcRect<int> RotateScaleRect(HwcRect<int> rect, int width, int height,
+                             uint32_t plane_transform) {
+  HwcRect<int> rotate_scale_rect =
+      RotateRect(rect, width, height, plane_transform);
+  if (plane_transform & (hwcomposer::HWCTransform::kTransform270 |
+                         hwcomposer::HWCTransform::kTransform90)) {
+    float x_scale = float(width) / height;
+    float y_scale = float(height) / width;
+    rotate_scale_rect = ScaleRect(rotate_scale_rect, x_scale, y_scale);
+  }
+  return rotate_scale_rect;
+}
 }  // namespace hwcomposer

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -231,6 +231,11 @@ std::string StringifyRect(HwcRect<int> rect);
  */
 std::string StringifyRegion(HwcRegion region);
 
+HwcRect<int> RotateRect(const HwcRect<int>& rect, int disp_width,
+                        int disp_height, uint32_t transform);
+HwcRect<int> ScaleRect(HwcRect<int> rect, float x_scale, float y_scale);
+HwcRect<int> RotateScaleRect(HwcRect<int> rect, int width, int height,
+                             uint32_t plane_transform);
 }  // namespace hwcomposer
 
 #endif  // COMMON_UTILS_HWCUTILS_H_


### PR DESCRIPTION
When display rotation is applied (not layer rotation)
especially configured in hwc_display.ini,
it is necessary to recalculate the layer's display frame
(position) of each plane.

If the plane needs GPU render and rotation type is GPU rotation,
re-calculate its source layers's display frame before
GPU composit and rotate; for other scan out plane
re-calculate its overlay layer's display frame before DRM commit.

Jira: None
Tests: On Android, rotation works towards setting in hwc_display.ini.
Signed-off-by: Yuanjun Huang <yuanjun.huang@intel.com>