### PR TITLE
Remove NON_BLOCKING flag when drm commit

### DIFF
--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -104,6 +104,8 @@ LOCAL_CPPFLAGS += \
         -DUSE_GL
 endif
 
+LOCAL_CPPFLAGS += -DUSE_BLOCKING_COMMIT
+
 LOCAL_C_INCLUDES += \
 	$(INTEL_MINIGBM)/cros_gralloc/
 

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -393,7 +393,9 @@ bool DrmDisplay::Commit(
     display_state_ &= ~kNeedsModeset;
     if (!disable_explicit_fence) {
       flags_ = 0;
+#ifndef USE_BLOCKING_COMMIT
       flags_ |= DRM_MODE_ATOMIC_NONBLOCK;
+#endif
     }
   }
 


### PR DESCRIPTION
It will cause frame dropping in Android
It can be due to an issue of between AOSP and HWC
That this flag should be discard

Jira: ACI-5424
Tests: On Android, no frame droping with DialogTest.apk
Signed-off-by: Lin Johnson <johnson.lin@intel.com>