### PR TITLE
Add support for SolidColor Type layer in HWC

### DIFF
--- a/common/compositor/gl/nativeglresource.cpp
+++ b/common/compositor/gl/nativeglresource.cpp
@@ -29,15 +29,18 @@ bool NativeGLResource::PrepareResources(
   EGLDisplay egl_display = eglGetCurrentDisplay();
   for (auto& buffer : buffers) {
     // Create EGLImage.
-    const ResourceHandle& import_image =
-        buffer->GetGpuResource(egl_display, true);
+    if (buffer) {
+      const ResourceHandle& import_image =
+          buffer->GetGpuResource(egl_display, true);
 
-    if (import_image.image_ == EGL_NO_IMAGE_KHR) {
-      ETRACE("Failed to make import image.");
-      return false;
-    }
+      if (import_image.image_ == EGL_NO_IMAGE_KHR) {
+        ETRACE("Failed to make import image.");
+        return false;
+      }
 
-    layer_textures_.emplace_back(import_image.texture_);
+      layer_textures_.emplace_back(import_image.texture_);
+    } else
+      layer_textures_.emplace_back(0);
   }
 
   return true;

--- a/common/compositor/renderstate.cpp
+++ b/common/compositor/renderstate.cpp
@@ -124,8 +124,16 @@ void RenderState::ConstructState(std::vector<OverlayLayer> &layers,
       }
     }
 
-    float tex_width = static_cast<float>(layer.GetBuffer()->GetWidth());
-    float tex_height = static_cast<float>(layer.GetBuffer()->GetHeight());
+    float tex_width = 0;
+    float tex_height = 0;
+    if (layer.GetBuffer()) {
+      tex_width = static_cast<float>(layer.GetBuffer()->GetWidth());
+      tex_height = static_cast<float>(layer.GetBuffer()->GetHeight());
+    } else {
+      tex_width = static_cast<float>(layer.GetSourceCropWidth());
+      tex_height = static_cast<float>(layer.GetSourceCropHeight());
+    }
+
     const HwcRect<float> &source_crop = layer.GetSourceCrop();
 
     HwcRect<float> crop_rect(

--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -177,6 +177,8 @@ void HwcLayer::SetReleaseFence(int32_t fd) {
 }
 
 int32_t HwcLayer::GetReleaseFence() {
+  if (!sf_handle_)
+    return -1;
   int32_t old_fd = release_fd_;
   release_fd_ = -1;
   return old_fd;
@@ -192,6 +194,8 @@ void HwcLayer::SetAcquireFence(int32_t fd) {
 }
 
 int32_t HwcLayer::GetAcquireFence() {
+  if (!sf_handle_)
+    return -1;
   int32_t old_fd = acquire_fence_;
   acquire_fence_ = -1;
   return old_fd;

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -176,6 +176,10 @@ struct OverlayLayer {
     return type_ == kLayerVideo;
   }
 
+  bool IsSolidColor() const {
+    return type_ == kLayerSolidColor;
+  }
+
   // Returns true if we should prefer
   // a separate plane for this layer
   // when validating layers in

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -788,6 +788,9 @@ void DisplayPlaneManager::ValidateFinalLayers(
 bool DisplayPlaneManager::FallbacktoGPU(
     DisplayPlane *target_plane, OverlayLayer *layer,
     const std::vector<OverlayPlane> &commit_planes) const {
+  // SolidColor can't be scanout directly
+  if (layer->IsSolidColor())
+    return true;
   // For Video, we always want to support Display Composition.
   if (layer->IsVideoLayer()) {
     layer->SupportedDisplayComposition(OverlayLayer::kAll);

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -426,6 +426,12 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
       const OverlayLayer* layer =
           &(layers.at(last_plane.GetSourceLayers().front()));
 
+      if (layer->IsSolidColor()) {
+        *force_full_validation = true;
+        *can_ignore_commit = false;
+        return;
+      }
+
       OverlayBuffer* buffer = layer->GetBuffer();
       if (buffer->GetFb() == 0) {
         buffer->CreateFrameBuffer();

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -620,6 +620,7 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
 
     switch (l.second.validated_type()) {
       case HWC2::Composition::Device:
+      case HWC2::Composition::SolidColor:
         z_map.emplace(std::make_pair(l.second.z_order(), &l.second));
         break;
       case HWC2::Composition::Client:
@@ -862,6 +863,7 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerColor(hwc_color_t color) {
   // We only support Opaque colors so far.
   if (color.r == 0 && color.g == 0 && color.b == 0 && color.a == 255) {
     sf_type_ = HWC2::Composition::SolidColor;
+    hwc_layer_.SetLayerCompositionType(hwcomposer::Composition_SolidColor);
     return HWC2::Error::None;
   }
 

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -75,7 +75,8 @@ enum HWCLayerType {
   kLayerNormal = 0,
   kLayerCursor = 1,
   kLayerProtected = 2,
-  kLayerVideo = 3
+  kLayerVideo = 3,
+  kLayerSolidColor = 4,
 };
 
 enum class HWCDisplayAttribute : int32_t {

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -23,6 +23,12 @@
 
 namespace hwcomposer {
 
+typedef enum {
+  Composition_Device = 0,
+  Composition_Client = 1,
+  Composition_SolidColor = 2,
+} HWCLayerCompositionType;
+
 struct HwcLayer {
   ~HwcLayer();
 
@@ -232,6 +238,14 @@ struct HwcLayer {
     return state_ & kZorderChanged;
   }
 
+  void SetLayerCompositionType(HWCLayerCompositionType type) {
+    composition_type_ = type;
+  }
+
+  HWCLayerCompositionType GetLayerCompositionType() {
+    return composition_type_;
+  }
+
   void SetLeftConstraint(int32_t left_constraint);
   int32_t GetLeftConstraint();
 
@@ -302,6 +316,7 @@ struct HwcLayer {
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
   bool damage_dirty_ = true;
+  HWCLayerCompositionType composition_type_ = Composition_Device;
 };
 
 }  // namespace hwcomposer

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -104,6 +104,8 @@ LOCAL_CPPFLAGS += \
         -DUSE_GL
 endif
 
+LOCAL_CPPFLAGS += -DUSE_BLOCKING_COMMIT
+
 LOCAL_C_INCLUDES += \
 	$(INTEL_MINIGBM)/cros_gralloc/
 

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -393,7 +393,9 @@ bool DrmDisplay::Commit(
     display_state_ &= ~kNeedsModeset;
     if (!disable_explicit_fence) {
       flags_ = 0;
+#ifndef USE_BLOCKING_COMMIT
       flags_ |= DRM_MODE_ATOMIC_NONBLOCK;
+#endif
     }
   }
 


### PR DESCRIPTION
It is a layer without buffer handler,
it expected HWC can fill the layer with
color(0,0,0) and multiplay with an Alpha value

Jira: https://jir01.devtoosl.intel.com/browse/OAM-68857
Tests: SolidColor composition layer can be rendered
Signed-off-by: Lin Johnson <johnson.lin@intel.com>