### PR TITLE
Revert "Apply damage transformations in GetLayerDamage"

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -621,6 +621,15 @@ void GpuDevice::DisableHDCPSessionForAllDisplays() {
   }
 }
 
+void GpuDevice::SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                                     uint32_t pavp_instance_id) {
+  size_t size = total_displays_.size();
+  for (size_t i = 0; i < size; i++) {
+    total_displays_.at(i)->SetPAVPSessionStatus(enabled, pavp_session_id,
+                                                pavp_instance_id);
+  }
+}
+
 void GpuDevice::HandleRoutine() {
   bool update_ignored = false;
 

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -549,6 +549,14 @@ void DisplayQueue::InitializeOverlayLayers(
     if (!layer->IsVisible())
       continue;
 
+    // Discard protected video for tear down
+    if (state_ & kVideoDiscardProtected) {
+      if (layer->GetNativeHandle() != NULL &&
+          (layer->GetNativeHandle()->meta_data_.usage_ &
+           hwcomposer::kLayerProtected))
+        continue;
+    }
+
     layers.emplace_back();
     OverlayLayer* overlay_layer = &(layers.back());
     OverlayLayer* previous_layer = NULL;
@@ -1041,7 +1049,7 @@ void DisplayQueue::PresentClonedCommit(DisplayQueue* queue) {
                      resource_manager_.get(), layers.size() - 1, fb_manager_);
 
     if (add_index != 0 && layer.IsVideoLayer()) {
-      if (previous_layer && !previous_layer->IsVideoLayer() ||
+      if ((previous_layer && !previous_layer->IsVideoLayer()) ||
           !previous_layer) {
         add_index = 0;
         continue;

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -133,6 +133,15 @@ class DisplayQueue {
     return source_layers_;
   }
 
+  void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                            uint32_t pavp_instance_id) {
+    if (enabled) {
+      state_ &= ~kVideoDiscardProtected;
+    } else {
+      state_ |= kVideoDiscardProtected;
+    }
+  }
+
  private:
   enum QueueState {
     kNeedsColorCorrection = 1 << 0,  // Needs Color correction.
@@ -141,7 +150,9 @@ class DisplayQueue {
     kDisableOverlayUsage = 1 << 3,  // Disable Overlays.
     kIgnoreIdleRefresh =
         1 << 4,  // Ignore refresh request during idle callback.
-    kCanvasColorChanged = 1 << 5  // Update color change
+    kCanvasColorChanged = 1 << 5,  // Update color change
+    kVideoDiscardProtected =
+        1 << 6,  // Need to discard protected video due to tearing down
   };
 
   struct ScalingTracker {

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -166,6 +166,14 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
       HwcLayer *layer = source_layers.at(layer_index);
       if (!layer->IsVisible())
         continue;
+      // Discard protected video for tear down
+      if (discard_protected_video_) {
+        if (layer->GetNativeHandle() != NULL &&
+            (layer->GetNativeHandle()->meta_data_.usage_ &
+             hwcomposer::kLayerProtected))
+          continue;
+      }
+
       buffer_number++;
     }
 
@@ -180,6 +188,13 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
       HwcLayer *layer = source_layers.at(layer_index);
       if (!layer->IsVisible())
         continue;
+
+      if (discard_protected_video_) {
+        if (layer->GetNativeHandle() != NULL &&
+            (layer->GetNativeHandle()->meta_data_.usage_ &
+             hwcomposer::kLayerProtected))
+          continue;
+      }
 
       const HwcRect<int> &display_frame = layer->GetDisplayFrame();
       sf_handle = layer->GetNativeHandle();
@@ -314,6 +329,12 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
     layer->SetReleaseFence(-1);
     if (!layer->IsVisible())
       continue;
+    if (discard_protected_video_) {
+      if (layer->GetNativeHandle() != NULL &&
+          (layer->GetNativeHandle()->meta_data_.usage_ &
+           hwcomposer::kLayerProtected))
+        continue;
+    }
 
     layers.emplace_back();
     OverlayLayer &overlay_layer = layers.back();

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -122,6 +122,14 @@ class VirtualDisplay : public NativeDisplay {
 
   void VSyncControl(bool enabled) override;
   bool CheckPlaneFormat(uint32_t format) override;
+  void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                            uint32_t pavp_instance_id) override {
+    if (enabled) {
+      discard_protected_video_ = false;
+    } else {
+      discard_protected_video_ = true;
+    }
+  }
 
  private:
   HWCNativeHandle output_handle_;
@@ -134,6 +142,7 @@ class VirtualDisplay : public NativeDisplay {
   std::unique_ptr<ResourceManager> resource_manager_;
   FrameBufferManager *fb_manager_ = NULL;
   uint32_t display_index_ = 0;
+  bool discard_protected_video_ = false;
 
 #ifdef HYPER_DMABUF_SHARING
   int mHyperDmaBuf_Fd = -1;

--- a/os/android/hwcservice.cpp
+++ b/os/android/hwcservice.cpp
@@ -388,18 +388,18 @@ status_t HwcService::Controls::DisableHDCPSessionForAllDisplays() {
 
 status_t HwcService::Controls::VideoEnableEncryptedSession(
     uint32_t sessionID, uint32_t instanceID) {
-  // TO DO
+  mHwc.SetPAVPSessionStatus(true, sessionID, instanceID);
   return OK;
 }
 
 status_t HwcService::Controls::VideoDisableAllEncryptedSessions(
     uint32_t sessionID) {
-  // TO DO
+  mHwc.SetPAVPSessionStatus(false, -1, -1);
   return OK;
 }
 
 status_t HwcService::Controls::VideoDisableAllEncryptedSessions() {
-  // TO DO
+  mHwc.SetPAVPSessionStatus(false, -1, -1);
   return OK;
 }
 

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1248,6 +1248,11 @@ void IAHWC2::DisableHDCPSessionForAllDisplays() {
   device_.DisableHDCPSessionForAllDisplays();
 }
 
+void IAHWC2::SetPAVPSessionStatus(bool enabled, uint32_t papv_session_id,
+                                  uint32_t pavp_instance_id) {
+  device_.SetPAVPSessionStatus(enabled, papv_session_id, pavp_instance_id);
+}
+
 }  // namespace android
 
 static struct hw_module_methods_t hwc2_module_methods = {

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -60,6 +60,9 @@ class IAHWC2 : public hwc2_device_t {
 
   void DisableHDCPSessionForAllDisplays();
 
+  void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                            uint32_t pavp_instance_id);
+
  public:
   class Hwc2Layer {
    public:

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -82,6 +82,9 @@ class GpuDevice : public HWCThread {
   // feature on all connected displays.
   void DisableHDCPSessionForAllDisplays();
 
+  void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                            uint32_t pavp_instance_id);
+
  private:
   enum InitializationType {
     kUnInitialized = 0,    // Nothing Initialized.

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -404,6 +404,10 @@ class NativeDisplay {
                             HWCContentType /*content_type*/) {
   }
 
+  virtual void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                                    uint32_t pavp_instance_id) {
+  }
+
   virtual const NativeBufferHandler *GetNativeBufferHandler() const {
     return NULL;
   }

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -467,6 +467,13 @@ void PhysicalDisplay::SetCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
   display_queue_->SetCanvasColor(bpc, red, green, blue, alpha);
 }
 
+void PhysicalDisplay::SetPAVPSessionStatus(bool enabled,
+                                           uint32_t pavp_session_id,
+                                           uint32_t pavp_instance_id) {
+  display_queue_->SetPAVPSessionStatus(enabled, pavp_session_id,
+                                       pavp_instance_id);
+}
+
 bool PhysicalDisplay::PopulatePlanes(
     std::vector<std::unique_ptr<DisplayPlane>> & /*overlay_planes*/) {
   ETRACE("PopulatePlanes unimplemented in PhysicalDisplay.");

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -151,6 +151,9 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
 
   const NativeBufferHandler *GetNativeBufferHandler() const override;
 
+  void SetPAVPSessionStatus(bool enabled, uint32_t pavp_session_id,
+                            uint32_t pavp_instance_id) override;
+
   /**
    * API for setting color correction for display.
    */


### PR DESCRIPTION
Flicker is observed when start an APK after this patch.
for example use Car Launcher

This reverts commit 145bf9c5853cb5b0de0136a076d1a8b9b0b1c8dc.

Conflicts:
	common/core/hwclayer.cpp
	public/hwclayer.h
	public/hwcutils.h