### PR TITLE
Fixed the HWC flicking due to broken state of ignore update

### DIFF
--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -365,7 +365,9 @@ void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
 
   for (auto &display : displays_) {
     display->NotifyDisplayWA(disable_last_plane_usage);
-    display->ForceRefresh();
+    if (!ignore_updates_) {
+      display->ForceRefresh();
+    }
   }
 
   for (auto &display : displays_) {
@@ -422,6 +424,7 @@ void DrmDisplayManager::RegisterHotPlugEventCallback(
 
 void DrmDisplayManager::ForceRefresh() {
   spin_lock_.lock();
+  ignore_updates_ = false;
   size_t size = displays_.size();
   for (size_t i = 0; i < size; ++i) {
     displays_.at(i)->ForceRefresh();
@@ -432,6 +435,10 @@ void DrmDisplayManager::ForceRefresh() {
 }
 
 void DrmDisplayManager::IgnoreUpdates() {
+  spin_lock_.lock();
+  ignore_updates_ = true;
+  spin_lock_.unlock();
+
   size_t size = displays_.size();
   for (size_t i = 0; i < size; ++i) {
     displays_.at(i)->IgnoreUpdates();

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -86,6 +86,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   std::shared_ptr<DisplayHotPlugEventCallback> callback_ = NULL;
   std::unique_ptr<NativeBufferHandler> buffer_handler_;
   GpuDevice *device_ = NULL;
+  bool ignore_updates_ = false;
   int fd_ = -1;
   int hotplug_fd_ = -1;
   bool notify_client_ = false;


### PR DESCRIPTION
Added ignore_updates_ to track if HWC needs to ignore rendering request.
Don't invoke display's ForceRefresh if ignore_updates_ is true.

Jira: OAM-68565
Tests: Boot with RVC and no flicking

Signed-off-by: Wan Shuang <shuang.wan@intel.com>