### PR TITLE
Revert "Added Support for 64bit RGB format"

### DIFF
--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -54,8 +54,6 @@ static uint32_t GetDrmFormatFromHALFormat(int format) {
       return DRM_FORMAT_ARGB8888;
     case HAL_PIXEL_FORMAT_YV12:
       return DRM_FORMAT_YVU420;
-    case HAL_PIXEL_FORMAT_RGBA_FP16:
-      return DRM_FORMAT_XBGR161616;
     case HAL_PIXEL_FORMAT_RGBA_1010102:
       return DRM_FORMAT_ABGR2101010;
     default:
@@ -167,8 +165,6 @@ static uint32_t DrmFormatToHALFormat(int format) {
       return HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL;
     case DRM_FORMAT_P010:
       return HAL_PIXEL_FORMAT_P010_INTEL;
-    case DRM_FORMAT_XBGR161616:
-      return HAL_PIXEL_FORMAT_RGBA_FP16;
     default:
       return 0;
       break;


### PR DESCRIPTION
This reverts commit fe1ae18bbf190a96252ecad17aa21a2fe94f9c63
The Android framework uses successful allocation of
HAL_PIXEL_FORMAT_RGBA_FP16 to test for wide-gamut capabilities.
We don't want to advertise this, so let's revert.

This revert won't cause regression on CTS test case
android.hardware.cts.HardwareBufferTest#testCreate

android.graphics.cts.BitmapColorSpaceTest#test16bitHardware
can pass if the framework falls back to RGBA8888, as is the plan.

Jira: https://jira01.devtools.intel.com/browse/OAM-68897
Tests: test16bitHardware and testCreate both pass