### PR TITLE
Set HWC as DRM master when got exclusive lock of /vendor/hwc.lock.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -670,6 +670,8 @@ void GpuDevice::HandleRoutine() {
       ITRACE("Successfully grabbed the hwc lock.");
     }
 
+    display_manager_->setDrmMaster();
+
     close(lock_fd_);
     lock_fd_ = -1;
   }

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -53,6 +53,8 @@ class DisplayManager {
   // manager until ForceRefresh is called.
   virtual void IgnoreUpdates() = 0;
 
+  virtual void setDrmMaster() = 0;
+
   // Get FD associated with this DisplayManager.
   virtual uint32_t GetFD() const = 0;
 

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -445,6 +445,13 @@ void DrmDisplayManager::IgnoreUpdates() {
   }
 }
 
+void DrmDisplayManager::setDrmMaster() {
+  int ret = drmSetMaster(fd_);
+  if (ret) {
+    ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
+  }
+}
+
 void DrmDisplayManager::HandleLazyInitialization() {
   spin_lock_.lock();
   if (release_lock_) {

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -63,6 +63,8 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void IgnoreUpdates() override;
 
+  void setDrmMaster() override;
+
   uint32_t GetFD() const override {
     return fd_;
   }


### PR DESCRIPTION
This is to ensure HWC could take over the DRM master role when earlyEvs
exits and make the Android UI rendering correctly as expected.

Jira: OAM-70073
Tests: Boot into Android home screen
Signed-off-by: Wan Shuang <shuang.wan@intel.com>