### PR TITLE
Add function to transfrom source damage to rendering damage

### DIFF
--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -271,6 +271,11 @@ struct HwcLayer {
   void Validate();
   void UpdateRenderingDamage(const HwcRect<int>& old_rect,
                              const HwcRect<int>& newrect, bool same_rect);
+  /*
+   Get Rendering Damage from source surface damage
+   Apply transform here
+  */
+  void SufaceDamageTransfrom();
 
   void SetTotalDisplays(uint32_t total_displays);
   friend class VirtualDisplay;


### PR DESCRIPTION
this paritial incorparate 145bf9c5853cb5b0de0136a076d1a8b9b0b1c8dc
after reverting it.
Also consider the situation source corp is not the same size with
display_rect. That means we also have to scale the output rendering
damage rect

Jira: None
Tests: On Android, HVAC should behave normally
Signed-off-by: Lin Johnson <johnson.lin@intel.com>