### PR TITLE
Deinterlace: change the default settings to auto

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -33,8 +33,8 @@
 namespace hwcomposer {
 
 Compositor::Compositor() {
-  deinterlace_.flag_ = HWCDeinterlaceFlag::kDeinterlaceFlagNone;
-  deinterlace_.mode_ = HWCDeinterlaceControl::kDeinterlaceNone;
+  deinterlace_.flag_ = HWCDeinterlaceFlag::kDeinterlaceFlagAuto;
+  deinterlace_.mode_ = HWCDeinterlaceControl::kDeinterlaceMotionAdaptive;
 }
 
 Compositor::~Compositor() {
@@ -264,8 +264,8 @@ void Compositor::SetVideoDeinterlace(HWCDeinterlaceFlag flag,
 
 void Compositor::RestoreVideoDefaultDeinterlace() {
   lock_.lock();
-  deinterlace_.flag_ = HWCDeinterlaceFlag::kDeinterlaceFlagNone;
-  deinterlace_.mode_ = HWCDeinterlaceControl::kDeinterlaceNone;
+  deinterlace_.flag_ = HWCDeinterlaceFlag::kDeinterlaceFlagAuto;
+  deinterlace_.mode_ = HWCDeinterlaceControl::kDeinterlaceMotionAdaptive;
   lock_.unlock();
 }
 

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -108,11 +108,6 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
     }
   } else {
     buffer->SetOriginalHandle(handle);
-    // need to update interlace info since interlace info is update frame by
-    // frame
-    if (buffer->GetUsage() == kLayerVideo)
-      buffer->SetInterlace(
-          resource_manager->GetNativeBufferHandler()->GetInterlace(handle));
   }
 
   imported_buffer_.reset(new ImportedBuffer(buffer, acquire_fence));

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -39,6 +39,8 @@
 extern "C" {
 #endif
 
+#define GRALLOC_USAGE_PRIVATE_INTERLACE GRALLOC_USAGE_PRIVATE_0
+
 // Conversion from HAL to fourcc-based DRM formats
 static uint32_t GetDrmFormatFromHALFormat(int format) {
   switch (format) {
@@ -218,7 +220,8 @@ static bool ImportGraphicsBuffer(HWCNativeHandle handle, int fd) {
   handle->meta_data_.width_ = gr_handle->width;
   handle->meta_data_.height_ = gr_handle->height;
   handle->meta_data_.native_format_ = gr_handle->droid_format;
-  if (gr_handle->is_interlaced > 0) {
+
+  if (gr_handle->consumer_usage & GRALLOC_USAGE_PRIVATE_INTERLACE) {
     handle->meta_data_.is_interlaced_ = true;
   } else {
     handle->meta_data_.is_interlaced_ = false;


### PR DESCRIPTION
interlace infomation should be according to GRALLOC_USAGE_PRIVATE_0
frame by frame tracking is not necessary

Jira: None
Tests: Android UI starts normally
Signed-off-by: Lin Johnson <johnson.lin@intel.com>