### PR TITLE
Fixed the crash due to layer->GetNativeHandle returns a null pointer.

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -198,6 +198,13 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
       const HwcRect<int> &display_frame = layer->GetDisplayFrame();
       sf_handle = layer->GetNativeHandle();
+
+      if (NULL == sf_handle) {
+        ITRACE("Skip layer index: %u for Hyper DMA buffer sharing",
+               layer_index);
+        continue;
+      }
+
       std::shared_ptr<OverlayBuffer> buffer(NULL);
       uint32_t gpu_fd = resource_manager_->GetNativeBufferHandler()->GetFd();
       uint32_t id = GetNativeBuffer(gpu_fd, sf_handle);


### PR DESCRIPTION
The fix is to skip the layer handling if the layer buffer is NULL.

Jira: OAM-70263
Tests: HWC doesn't crash if handling layer with no buffer attached.
Signed-off-by: Wan Shuang <shuang.wan@intel.com>