### PR TITLE
SolidColor type: as the layer is a render target of GPU, we should still

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -178,14 +178,18 @@ void HwcLayer::SetReleaseFence(int32_t fd) {
 }
 
 int32_t HwcLayer::GetReleaseFence() {
-  if (!sf_handle_)
-    return -1;
   int32_t old_fd = release_fd_;
   release_fd_ = -1;
   return old_fd;
 }
 
 void HwcLayer::SetAcquireFence(int32_t fd) {
+  if (!sf_handle_) {
+    if (fd > 0) {
+      close(fd);
+    }
+    acquire_fence_ = -1;
+  }
   if (acquire_fence_ > 0) {
     close(acquire_fence_);
     acquire_fence_ = -1;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -618,6 +618,13 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
       continue;
     }
 
+    if ((l.second.validated_type() != HWC2::Composition::SolidColor) &&
+        (l.second.GetLayer()->GetNativeHandle() == NULL)) {
+      ETRACE(
+          "HWC don't support layer without buffer if not in type SolidColor");
+      continue;
+    }
+
     switch (l.second.validated_type()) {
       case HWC2::Composition::Device:
       case HWC2::Composition::SolidColor:


### PR DESCRIPTION
set the release fence of it. SurfaceFlinger need the fence to sync.
The acquire fence is not necessary since the layer has no buffer at all

Jira: https://jira01.devtools.intel.com/browse/OAM-70347
Tests: Android UI normal and no fd leak
Signed-off-by: Lin Johnson <johnson.lin@intel.com>