### PR TITLE
Android: Fix unused parameters complie warnings in Makefile

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -128,6 +128,7 @@ LOCAL_CPPFLAGS += \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
         -DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -Wno-unused-parameter \
         -O3
 
 ifeq ($(strip $(BOARD_USES_VULKAN)), true)

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -86,6 +86,7 @@ LOCAL_CPPFLAGS += \
         -Wall -Wsign-compare -Wpointer-arith \
         -Wcast-qual -Wcast-align \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+        -Wno-unused-parameter \
         -O3
 
 ifeq ($(strip $(BOARD_USES_VULKAN)), true)


### PR DESCRIPTION
This reduce the unused parameter warning.
Keep these unused parameters for further feature or function.
Just add flag to makefile to deduce these warnings.

Jira: None
Signed-off-by: HeYue <yue.he@intel.com>