### PR TITLE
Fix critical KW issue

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -416,8 +416,8 @@ void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
     if (!rhs->imported_buffer_.get()) {
       state_ |= kNeedsReValidation;
       return;
-    } else if (buffer->GetFormat() !=
-               rhs->imported_buffer_->buffer_->GetFormat()) {
+    } else if (buffer && (buffer->GetFormat() !=
+                          rhs->imported_buffer_->buffer_->GetFormat())) {
       state_ |= kNeedsReValidation;
       return;
     }

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -132,6 +132,10 @@ void DrmDisplay::DrmConnectorGetDCIP3Support(
   }
 
   edid = (uint8_t *)blob->data;
+  if (!edid) {
+    return;
+  }
+
   blocks = FindExtendedBlocksForTag(edid, CTA_EXTENDED_TAG_CODE);
 
   for (uint8_t *ext_block : blocks) {


### PR DESCRIPTION
1): Do null check for pointer 'edid' before dereferenced.
2): Do null check for pointer 'buffer' before dereferenced.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70809
Signed-off-by: Jenny Cao <jenny.q.cao@intel.com>