### PR TITLE
Rename HwcBuffer to HwcMeta

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,7 +72,7 @@ endif
 libiahwcincdir = $(includedir)/libiahwc
 libiahwcinc_HEADERS =	\
 	$(top_srcdir)/public/gpudevice.h	\
-	$(top_srcdir)/public/hwcbuffer.h	\
+	$(top_srcdir)/public/hwcmeta.h	\
 	$(top_srcdir)/public/hwcdefs.h	\
 	$(top_srcdir)/public/hwclayer.h	\
 	$(top_srcdir)/public/hwcrect.h	\

--- a/os/alios/platformdefines.h
+++ b/os/alios/platformdefines.h
@@ -1,7 +1,7 @@
 #ifndef OS_ALIOS_PLATFORMDEFINES_H_
 #define OS_ALIOS_PLATFORMDEFINES_H_
 
-#include <hwcbuffer.h>
+#include <hwcmeta.h>
 #include <log/Log.h>
 #include <string.h>
 #include <cstdint>
@@ -74,7 +74,7 @@ struct yalloc_handle {
   gb_target_t target_;
   native_target_t* imported_target_;
   bool hwc_buffer_ = false;
-  HwcBuffer meta_data_;
+  HwcMeta meta_data_;
   void* pixel_memory_ = NULL;
 };
 

--- a/os/alios/utils_alios.h
+++ b/os/alios/utils_alios.h
@@ -294,7 +294,7 @@ static bool ImportGraphicsBuffer(HWCNativeHandle handle, int fd) {
   auto gr_handle = &handle_data;
   int32_t total_planes;
 
-  memset(&(handle->meta_data_), 0, sizeof(struct HwcBuffer));
+  memset(&(handle->meta_data_), 0, sizeof(struct HwcMeta));
   handle->meta_data_.format_ = GetDrmFormatFromHALFormat(gr_handle->format);
   handle->meta_data_.width_ = gr_handle->width;
   handle->meta_data_.height_ = gr_handle->height;

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -43,7 +43,7 @@ extern "C" {
 struct gralloc_handle {
   buffer_handle_t handle_ = NULL;
   native_handle_t* imported_handle_ = NULL;
-  HwcBuffer meta_data_;
+  HwcMeta meta_data_;
   uint64_t gralloc1_buffer_descriptor_t_ = 0;
   bool hwc_buffer_ = false;
   void* pixel_memory_ = NULL;

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -214,7 +214,7 @@ static void DestroyBufferHandle(HWCNativeHandle handle) {
 
 static bool ImportGraphicsBuffer(HWCNativeHandle handle, int fd) {
   auto gr_handle = (struct cros_gralloc_handle *)handle->imported_handle_;
-  memset(&(handle->meta_data_), 0, sizeof(struct HwcBuffer));
+  memset(&(handle->meta_data_), 0, sizeof(struct HwcMeta));
   handle->meta_data_.format_ = gr_handle->format;
   handle->meta_data_.tiling_mode_ = gr_handle->tiling_mode;
   handle->meta_data_.width_ = gr_handle->width;

--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -268,22 +268,22 @@ void GbmBufferHandler::CopyHandle(HWCNativeHandle source,
 
 bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle) const {
   uint32_t gem_handle = 0;
-  HwcBuffer *bo = &(handle->meta_data_);
+  HwcMeta *meta = &(handle->meta_data_);
   bool use_modifier = true;
   uint64_t mod = 0;
 
   if (!handle->imported_bo) {
     if (!handle->meta_data_.fb_modifiers_[0]) {
       use_modifier = false;
-      bo->format_ = handle->import_data.fd_data.format;
-      bo->native_format_ = handle->import_data.fd_data.format;
+      meta->format_ = handle->import_data.fd_data.format;
+      meta->native_format_ = handle->import_data.fd_data.format;
 
       handle->imported_bo =
           gbm_bo_import(device_, GBM_BO_IMPORT_FD, &handle->import_data.fd_data,
                         handle->gbm_flags);
     } else {
-      bo->format_ = handle->import_data.fd_modifier_data.format;
-      bo->native_format_ = handle->import_data.fd_modifier_data.format;
+      meta->format_ = handle->import_data.fd_modifier_data.format;
+      meta->native_format_ = handle->import_data.fd_modifier_data.format;
       handle->imported_bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_MODIFIER,
                                           &handle->import_data.fd_modifier_data,
                                           handle->gbm_flags);
@@ -323,7 +323,7 @@ bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle) const {
   handle->meta_data_.num_planes_ = total_planes;
 
   if (!use_modifier) {
-    bo->prime_fds_[0] = handle->import_data.fd_data.fd;
+    meta->prime_fds_[0] = handle->import_data.fd_data.fd;
     for (size_t i = 0; i < total_planes; i++) {
       handle->meta_data_.gem_handles_[i] = gem_handle;
       handle->meta_data_.offsets_[i] =
@@ -333,7 +333,7 @@ bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle) const {
       handle->meta_data_.prime_fds_[i] = handle->import_data.fd_data.fd;
     }
   } else {
-    bo->prime_fds_[0] = handle->import_data.fd_modifier_data.fds[0];
+    meta->prime_fds_[0] = handle->import_data.fd_modifier_data.fds[0];
 
     mod = gbm_bo_get_modifier(handle->imported_bo);
     uint32_t modifier_low = static_cast<uint32_t>(mod >> 32);
@@ -347,8 +347,8 @@ bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle) const {
           gbm_bo_get_stride_for_plane(handle->imported_bo, i);
       handle->meta_data_.prime_fds_[i] =
           handle->import_data.fd_modifier_data.fds[0];
-      bo->fb_modifiers_[2 * i] = modifier_low;
-      bo->fb_modifiers_[2 * i + 1] = modifier_high;
+      meta->fb_modifiers_[2 * i] = modifier_low;
+      meta->fb_modifiers_[2 * i + 1] = modifier_high;
     }
   }
 

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -41,7 +41,7 @@ struct gbm_handle {
   } import_data;
   struct gbm_bo* bo = NULL;
   struct gbm_bo* imported_bo = NULL;
-  HwcBuffer meta_data_;
+  HwcMeta meta_data_;
   bool hwc_buffer_ = false;
   void* pixel_memory_ = NULL;
   uint32_t gbm_flags = 0;

--- a/os/platformcommondefines.h
+++ b/os/platformcommondefines.h
@@ -23,7 +23,7 @@
 VkFormat NativeToVkFormat(int native_format);
 #endif
 
-#include <hwcbuffer.h>
+#include <hwcmeta.h>
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/public/hwcmeta.h
+++ b/public/hwcmeta.h
@@ -14,18 +14,18 @@
 // limitations under the License.
 */
 
-#ifndef PUBLIC_HWCBUFFER_H_
-#define PUBLIC_HWCBUFFER_H_
+#ifndef PUBLIC_HWCMETA_H_
+#define PUBLIC_HWCMETA_H_
 
 #include <stdint.h>
 #include <unistd.h>
 
 #include <hwcdefs.h>
 
-struct HwcBuffer {
-  HwcBuffer() = default;
+struct HwcMeta {
+  HwcMeta() = default;
 
-  HwcBuffer &operator=(const HwcBuffer &rhs) = delete;
+  HwcMeta &operator=(const HwcMeta &rhs) = delete;
   bool is_interlaced_ = false;
   uint32_t width_ = 0;
   uint32_t height_ = 0;
@@ -41,4 +41,4 @@ struct HwcBuffer {
   hwcomposer::HWCLayerType usage_ = hwcomposer::kLayerNormal;
 };
 
-#endif  // PUBLIC_HWCBUFFER_H_
+#endif  // PUBLIC_HWCMETA_H_

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -77,8 +77,8 @@ DrmBuffer::~DrmBuffer() {
 #endif
 }
 
-void DrmBuffer::Initialize(const HwcBuffer& bo) {
-  format_ = bo.format_;
+void DrmBuffer::Initialize(const HwcMeta& meta) {
+  format_ = meta.format_;
   if (format_ == DRM_FORMAT_NV12_Y_TILED_INTEL || format_ == DRM_FORMAT_NV21)
     format_ = DRM_FORMAT_NV12;
   else if (format_ == DRM_FORMAT_YVU420_ANDROID)

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -106,7 +106,7 @@ class DrmBuffer : public OverlayBuffer {
   void Dump() override;
 
  private:
-  void Initialize(const HwcBuffer& bo);
+  void Initialize(const HwcMeta& meta);
   uint32_t format_ = 0;
   uint32_t frame_buffer_format_ = 0;
   uint32_t previous_width_ = 0;   // For Media usage.


### PR DESCRIPTION
HwcBuffer name is misleading, actually it is just some meta info

Tracked-On: None
Tests: None
Signed-off-by: Lin Johnson <johnson.lin@intel.com>