### PR TITLE
Add support for the Color Depth control

### DIFF
--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -32,6 +32,16 @@
 #endif
 
 namespace hwcomposer {
+
+enum pipe_bpc {
+  PIPE_BPC_INVALID = -1,
+  PIPE_BPC_SIX = 6,
+  PIPE_BPC_EIGHT = 8,
+  PIPE_BPC_TEN = 10,
+  PIPE_BPC_TWELVE = 12,
+  PIPE_BPC_SIXTEEN = 16
+};
+
 class DrmDisplayManager;
 class DisplayPlaneState;
 class DisplayQueue;
@@ -66,6 +76,7 @@ class DrmDisplay : public PhysicalDisplay {
                           uint32_t brightness) const override;
   void SetPipeCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
                           uint16_t blue, uint16_t alpha) const override;
+  bool SetPipeMaxBpc(uint16_t max_bpc) const override;
   void SetColorTransformMatrix(
       const float *color_transform_matrix,
       HWCColorTransform color_transform_hint) const override;
@@ -160,6 +171,7 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t canvas_color_prop_ = 0;
   uint32_t connector_ = 0;
   bool dcip3_ = false;
+  uint32_t max_bpc_prop_ = 0;
   uint64_t lut_size_ = 0;
   int64_t broadcastrgb_full_ = -1;
   int64_t broadcastrgb_automatic_ = -1;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -213,6 +213,11 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
                                   uint16_t blue, uint16_t alpha) const = 0;
 
   /**
+   * API for setting the colordepth of the pipe.
+   */
+  virtual bool SetPipeMaxBpc(uint16_t max_bpc) const = 0;
+
+  /**
    * API for informing the display that it might be disconnected in near
    * future.
    */


### PR DESCRIPTION
By default the Kernel sets the bpc for a Pipe based on EDID
while considering the range of bpc supported by the pipe .
In this patch, Userspace requests the kernel for a specific bpc
based on a particular resolution.

Jira: None
Tests: Android UI starts normally and bpc request to kernel goes fine
       leaving the kernel to decide for the pipe.
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>