### PR TITLE
Do not need change size from source crop to display rect

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -211,24 +211,14 @@ void HwcLayer::SufaceDamageTransfrom() {
   HwcRect<int> translated_damage =
       TranslateRect(surface_damage_, -source_crop_.left, -source_crop_.top);
 
-  int display_width = display_frame_.right - display_frame_.left;
-  int display_height = display_frame_.bottom - display_frame_.top;
-  int source_width = source_crop_.right - source_crop_.left;
-  int source_height = source_crop_.bottom - source_crop_.top;
+  // From observation: In Android, when the source crop coordinate
+  // is (0, 0), the surface damage is already translated to global display
+  // coordinate. Therefore, no translation is needed.
+  // The rotation scenario is not verified as the rotation is not supported on P
+  // Leave the rotation scenario code here temporary.
 
-  // From observation: In Android, when the source crop doesn't
-  // begin from (0, 0) the surface damage is already translated
-  // to global display co-ordinates
   if (!surface_damage_.empty() &&
       ((source_crop_.left == 0) && (source_crop_.top == 0))) {
-    if (display_width != source_width || display_height != source_height) {
-      float ratiow = display_width * 1.0 / source_width;
-      float ratioh = display_height * 1.0 / source_height;
-      translated_damage.left = translated_damage.left * ratiow + 0.5;
-      translated_damage.right = translated_damage.right * ratiow + 0.5;
-      translated_damage.top = translated_damage.right * ratioh + 0.5;
-      translated_damage.bottom = translated_damage.bottom * ratioh + 0.5;
-    }
     if (transform_ == hwcomposer::HWCTransform::kTransform270) {
       ox = display_frame_.left;
       oy = display_frame_.bottom;


### PR DESCRIPTION
When source crop begin from (0, 0), the source crop size
change will cause translated damage region doesn't correct.

Change-Id: Iae3143ac9be38b35c1e6649e7721469e6f39a790
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71102
Tests: AutoBots test don't have flick/half screen, the HAVC working ok.
Signed-off-by: HeYue <yue.he@intel.com>