### PR TITLE
Fix Critical KW issue:Buffer Overflow

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -252,7 +252,7 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
       char index[15];
       mHyperDmaExportedBuffers[buffer->GetPrimeFD()].surf_index = surf_index;
       memset(index, 0, sizeof(index));
-      sprintf(index, "Cluster_%d", surf_index);
+      snprintf(index, sizeof(index), "Cluster_%d", surf_index);
       strncpy(mHyperDmaExportedBuffers[buffer->GetPrimeFD()].surface_name,
               index, SURFACE_NAME_LENGTH);
       mHyperDmaExportedBuffers[buffer->GetPrimeFD()].hyper_dmabuf_id =


### PR DESCRIPTION
Klockwork has issue for buffer overflow in use sprintf.
Change the sprintf to snprintf.

Tracked-on: https://jira01.devtools.intel.com/browse/OAM-71738
Tests: Compliation on Android pass
Signed-off-by: Jenny Cao <jenny.q.cao@intel.com>