### PR TITLE
Android: Fix the compile warning

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -1017,8 +1017,8 @@ void DisplayQueue::PresentClonedCommit(DisplayQueue* queue) {
   std::vector<OverlayLayer> layers;
   int add_index = -1;
   int remove_index = -1;
-  int z_order = 0;
-  int previous_size = in_flight_layers_.size();
+  size_t z_order = 0;
+  size_t previous_size = in_flight_layers_.size();
   for (const DisplayPlaneState& previous_plane : source_planes) {
     layers.emplace_back();
 

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -300,7 +300,7 @@ int32_t Gralloc1BufferHandler::UnMap(HWCNativeHandle handle,
 }
 
 bool Gralloc1BufferHandler::GetInterlace(HWCNativeHandle handle) const {
-  if (((struct cros_gralloc_handle *)handle->handle_)->is_interlaced > 0)
+  if (((const struct cros_gralloc_handle *)handle->handle_)->is_interlaced > 0)
     return true;
   else
     return false;

--- a/os/platformcommondrmdefines.cpp
+++ b/os/platformcommondrmdefines.cpp
@@ -63,9 +63,9 @@ int CreateFrameBuffer(
     const uint32_t (&igem_handles)[4], const uint32_t (&ipitches)[4],
     const uint32_t (&ioffsets)[4], uint32_t gpu_fd, uint32_t *fb_id) {
   int ret = 0;
-  uint32_t *m_igem_handles = (uint32_t *)igem_handles;
-  uint32_t *m_ipitches = (uint32_t *)ipitches;
-  uint32_t *m_ioffsets = (uint32_t *)ioffsets;
+  const uint32_t *m_igem_handles = igem_handles;
+  const uint32_t *m_ipitches = ipitches;
+  const uint32_t *m_ioffsets = ioffsets;
   if (modifier > 0) {
     uint64_t modifiers[4];
     for (uint32_t i = 0; i < num_planes; i++) {


### PR DESCRIPTION
Reduce the Wsign-compare and Wcast-qual warning.

Change-Id: If1dfcfa0357c17a84b2227fc23c737c36c6d3530
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71835
Tests: Compile sucessful for Android.
Signed-off-by: HeYue <yue.he@intel.com>