### PR TITLE
Add support for Non-black SolidColor type

### DIFF
--- a/common/compositor/gl/glprogram.cpp
+++ b/common/compositor/gl/glprogram.cpp
@@ -95,6 +95,7 @@ static std::string GenerateFragmentShader(int layer_count) {
   }
   fragment_shader_stream << "uniform float uLayerAlpha[LAYER_COUNT];\n"
                          << "uniform float uLayerPremult[LAYER_COUNT];\n"
+                         << "uniform vec4 uLayerColor[LAYER_COUNT];\n"
                          << "in vec2 fTexCoords[LAYER_COUNT];\n"
                          << "out vec4 oFragColor;\n"
                          << "void main() {\n"
@@ -110,6 +111,8 @@ static std::string GenerateFragmentShader(int layer_count) {
                            << ",\n"
                            << "                        fTexCoords[" << i
                            << "]);\n"
+                           << "  texSample = texSample + uLayerColor[" << i
+                           << "];\n"
                            << "  multRgb = texSample.rgb *\n"
                            << "            max(texSample.a, uLayerPremult[" << i
                            << "]);\n"
@@ -324,6 +327,7 @@ void GLProgram::UseProgram(const RenderState &state, GLuint viewport_width,
     alpha_loc_ = glGetUniformLocation(program_, "uLayerAlpha");
     premult_loc_ = glGetUniformLocation(program_, "uLayerPremult");
     tex_matrix_loc_ = glGetUniformLocation(program_, "uTexMatrix");
+    solid_color_loc_ = glGetUniformLocation(program_, "uLayerColor");
     for (unsigned src_index = 0; src_index < size; src_index++) {
       std::ostringstream texture_name_formatter;
       texture_name_formatter << "uLayerTexture" << src_index;
@@ -351,6 +355,10 @@ void GLProgram::UseProgram(const RenderState &state, GLuint viewport_width,
                        src.texture_matrix_);
     glActiveTexture(GL_TEXTURE0 + src_index);
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, src.handle_);
+    glUniform4f(solid_color_loc_ + src_index, (float)src.solid_color_array_[3],
+                (float)src.solid_color_array_[2],
+                (float)src.solid_color_array_[1],
+                (float)src.solid_color_array_[0]);
   }
 }
 

--- a/common/compositor/gl/glprogram.h
+++ b/common/compositor/gl/glprogram.h
@@ -44,6 +44,7 @@ class GLProgram {
   GLint alpha_loc_;
   GLint premult_loc_;
   GLint tex_matrix_loc_;
+  GLint solid_color_loc_;
   bool initialized_;
 };
 

--- a/common/compositor/renderstate.cpp
+++ b/common/compositor/renderstate.cpp
@@ -47,6 +47,7 @@ void RenderState::ConstructState(std::vector<OverlayLayer> &layers,
     layer_state_.emplace_back();
     RenderState::LayerState &src = layer_state_.back();
     src.layer_index_ = texture_index;
+    src.solid_color_array_ = layer.GetSolidColorArray();
     bool swap_xy = false;
     bool flip_xy[2] = {false, false};
     uint32_t transform = layer.GetTransform();

--- a/common/compositor/renderstate.h
+++ b/common/compositor/renderstate.h
@@ -40,6 +40,7 @@ struct RenderState {
     float premult_;
     float texture_matrix_[4];
     uint32_t layer_index_;
+    uint8_t *solid_color_array_;
     GpuResourceHandle handle_;
   };
 

--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -198,6 +198,11 @@ void HwcLayer::SetAcquireFence(int32_t fd) {
   acquire_fence_ = fd;
 }
 
+void HwcLayer::SetSolidColor(hwc_color_t color) {
+  solid_color_ = (uint32_t)color.r << 24 | (uint32_t)color.g << 16 |
+                 (uint32_t)color.b << 8 | (uint32_t)color.a;
+}
+
 int32_t HwcLayer::GetAcquireFence() {
   if (!sf_handle_)
     return -1;

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -201,6 +201,9 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
   source_crop_ = layer->GetSourceCrop();
   blending_ = layer->GetBlending();
   surface_damage_ = layer->GetLayerDamage();
+
+  solid_color_ = layer->GetSolidColor();
+
   if (previous_layer && layer->HasZorderChanged()) {
     if (previous_layer->actual_composition_ == kGpu) {
       CalculateRect(previous_layer->display_frame_, surface_damage_);
@@ -491,6 +494,7 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   layer_index_ = z_order;
   z_order_ = z_order;
   blending_ = layer->blending_;
+  solid_color_ = layer->solid_color_;
 }
 
 void OverlayLayer::Dump() {

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -227,6 +227,14 @@ struct OverlayLayer {
     return state_ & kForcePartialClear;
   }
 
+  uint32_t GetSolidColor() {
+    return solid_color_;
+  }
+
+  uint8_t* GetSolidColorArray() {
+    return (uint8_t*)&solid_color_;
+  }
+
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
                   ResourceManager* resource_manager, uint32_t z_order,
                   FrameBufferManager* frame_buffer_manager);
@@ -278,6 +286,9 @@ struct OverlayLayer {
   uint32_t display_frame_width_ = 0;
   uint32_t display_frame_height_ = 0;
   uint8_t alpha_ = 0xff;
+
+  uint32_t solid_color_ = 0;
+
   HwcRect<float> source_crop_;
   HwcRect<int> display_frame_;
   HwcRect<int> surface_damage_;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -867,14 +867,12 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerBuffer(buffer_handle_t buffer,
 }
 
 HWC2::Error IAHWC2::Hwc2Layer::SetLayerColor(hwc_color_t color) {
-  // We only support Opaque colors so far.
-  if (color.r == 0 && color.g == 0 && color.b == 0 && color.a == 255) {
-    sf_type_ = HWC2::Composition::SolidColor;
+  if (sf_type_ == HWC2::Composition::SolidColor) {
     hwc_layer_.SetLayerCompositionType(hwcomposer::Composition_SolidColor);
-    return HWC2::Error::None;
+    hwc_layer_.SetSolidColor(color);
+  } else {
+    sf_type_ = HWC2::Composition::Client;
   }
-
-  sf_type_ = HWC2::Composition::Client;
   return HWC2::Error::None;
 }
 

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -234,6 +234,18 @@ struct HwcLayer {
     return z_order_;
   }
 
+  /**
+   * API for setting SolidColor for this layer.
+   */
+  void SetSolidColor(hwc_color_t color);
+
+  /**
+   * API for getting SolidColor.
+   */
+  uint32_t GetSolidColor() {
+    return solid_color_;
+  }
+
   bool HasZorderChanged() const {
     return state_ & kZorderChanged;
   }
@@ -323,6 +335,8 @@ struct HwcLayer {
       kVisible | kSurfaceDamageChanged | kVisibleRegionChanged | kZorderChanged;
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
+  uint32_t solid_color_ = 0;
+
   HWCLayerCompositionType composition_type_ = Composition_Device;
 };
 


### PR DESCRIPTION
The layer without buffer handler will be filled by HWC
with the color assigned from iahwc2/SetLayerColor.

Change-Id: I64cce2acdd6af3582328dba2fda13741a0163dd3
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71643
Tests: Compile sucessful for Android, Pass feature validating.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>