### PR TITLE
Fix two marjor issues blocking PAVP playback in HWC

### DIFF
--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -82,17 +82,12 @@ void CompositorThread::Wait() {
 
 bool CompositorThread::Draw(std::vector<DrawState> &states,
                             std::vector<DrawState> &media_states,
-                            const std::vector<OverlayLayer> &layers) {
+                            const std::vector<OverlayBuffer *> &buffers) {
   states_.swap(states);
   tasks_lock_.lock();
 
   if (!states_.empty()) {
-    std::vector<OverlayBuffer *>().swap(buffers_);
-    buffers_.reserve(layers.size());
-    for (auto &layer : layers) {
-      buffers_.emplace_back(layer.GetBuffer());
-    }
-
+    buffers_ = buffers;
     tasks_ |= kRender3D;
   }
 

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -48,7 +48,7 @@ class CompositorThread : public HWCThread {
 
   bool Draw(std::vector<DrawState>& states,
             std::vector<DrawState>& media_states,
-            const std::vector<OverlayLayer>& layers);
+            const std::vector<OverlayBuffer*>& buffers);
 
   void SetExplicitSyncSupport(bool disable_explicit_sync);
   void FreeResources();

--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -233,6 +233,7 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   CTRACE();
   // TODO: Clear surface ?
   surface->SetClearSurface(NativeSurface::kNone);
+  surface->GetLayer()->SetVideoLayer(true);
 
   OverlayBuffer* buffer_out = surface->GetLayer()->GetBuffer();
   int rt_format = DrmFormatToRTFormat(buffer_out->GetFormat());

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -172,6 +172,13 @@ struct OverlayLayer {
     return type_ == kLayerCursor;
   }
 
+  void SetVideoLayer(bool isVideo) {
+    if (isVideo)
+      type_ = kLayerVideo;
+    else
+      type_ = kLayerNormal;
+  }
+
   bool IsVideoLayer() const {
     return (type_ == kLayerVideo || type_ == kLayerProtected);
   }

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -154,8 +154,10 @@ bool DisplayPlaneManager::ValidateLayers(
 #endif
 
     // Handle layers for overlays.
-    for (auto j = overlay_begin; j < overlay_end; ++j) {
+    auto j = overlay_begin;
+    while (j < overlay_end) {
       DisplayPlane *plane = j->get();
+      j++;
       if (previous_layer && !composition.empty()) {
         DisplayPlaneState &last_plane = composition.back();
         if (last_plane.NeedsOffScreenComposition()) {
@@ -278,6 +280,36 @@ bool DisplayPlaneManager::ValidateLayers(
           }
         }
       }
+
+      /* NeedSquash
+           * 1) last plane is video plane, but has source layer left unsigned,
+         then need to squash due to
+              can't add left layers to video plane, that will make it go to 3D
+           * 2) Same reason if all planes are signed, but sitll left video
+         planes
+           */
+      if (j == overlay_end) {
+        bool needsquash =
+            composition.back().IsVideoPlane() && (layer_begin != layer_end);
+        if (!needsquash) {
+          auto temp_iter = layer_begin;
+          while (temp_iter != layer_end) {
+            if ((*temp_iter).IsVideoLayer()) {
+              needsquash = true;
+              break;
+            }
+            temp_iter++;
+          }
+        }
+        if (needsquash) {
+          // squash no video plane and return the
+          ITRACE("ValidateLayers Squash non video planes need");
+          size_t squashed_planes =
+              SquashNonVideoPlanes(layers, composition, commit_planes,
+                                   mark_later, &validate_final_layers);
+          j -= squashed_planes;
+        }
+      }
     }
 
     if ((layer_begin != layer_end) && (!composition.empty())) {
@@ -359,7 +391,6 @@ bool DisplayPlaneManager::ValidateLayers(
   bool render_layers = false;
   FinalizeValidation(composition, commit_planes, &render_layers,
                      re_validation_needed);
-
   *commit_checked = test_commit_done;
   return render_layers;
 }
@@ -1101,6 +1132,59 @@ void DisplayPlaneManager::FinalizeValidation(
 
   if (render_layers)
     *render_layers = needs_gpu;
+}
+
+size_t DisplayPlaneManager::SquashNonVideoPlanes(
+    const std::vector<OverlayLayer> &layers, DisplayPlaneStateList &composition,
+    std::vector<OverlayPlane> &commit_planes,
+    std::vector<NativeSurface *> &mark_later, bool *validate_final_layers) {
+  size_t composition_index = composition.size() - 1;
+  size_t squashed_count = 0;
+
+  while (composition_index > 0) {
+    DisplayPlaneState &last_plane = composition.at(composition_index);
+    DisplayPlaneState &scanout_plane = composition.at(composition_index - 1);
+
+    if (!last_plane.IsVideoPlane() && !scanout_plane.IsVideoPlane()) {
+#ifdef SURFACE_TRACING
+      ISURFACETRACE("Squasing non video planes. \n");
+#endif
+      const std::vector<size_t> &new_layers = last_plane.GetSourceLayers();
+      for (const size_t &index : new_layers) {
+        scanout_plane.AddLayer(&(layers.at(index)));
+      }
+
+      scanout_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
+      last_plane.GetDisplayPlane()->SetInUse(false);
+      MarkSurfacesForRecycling(&last_plane, mark_later, true);
+      size_t top = composition.size() - 1;
+
+      while (top > composition_index) {
+        DisplayPlaneState &temp = composition.at(top);
+        DisplayPlaneState &temp1 = composition.at(top - 1);
+        temp.SetDisplayPlane(temp1.GetDisplayPlane());
+        top--;
+      }
+      composition.erase(composition.begin() + composition_index);
+      squashed_count++;
+      if (scanout_plane.NeedsSurfaceAllocation()) {
+        SetOffScreenPlaneTarget(scanout_plane);
+        *validate_final_layers = true;
+      }
+    }
+    composition_index--;
+  }
+
+  if (!commit_planes.empty() && squashed_count) {
+    // Layer for the plane should have changed, reset commit planes.
+    std::vector<OverlayPlane>().swap(commit_planes);
+    for (DisplayPlaneState &temp : composition) {
+      commit_planes.emplace_back(
+          OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
+    }
+  }
+
+  return squashed_count;
 }
 
 bool DisplayPlaneManager::SquashPlanesAsNeeded(

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -110,6 +110,12 @@ class DisplayPlaneManager {
                             std::vector<NativeSurface *> &mark_later,
                             bool *validate_final_layers);
 
+  size_t SquashNonVideoPlanes(const std::vector<OverlayLayer> &layers,
+                              DisplayPlaneStateList &composition,
+                              std::vector<OverlayPlane> &commit_planes,
+                              std::vector<NativeSurface *> &mark_later,
+                              bool *validate_final_layers);
+
   // Returns true if we want to force target_layer to a separate plane than
   // adding it to
   // last_plane.

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -457,6 +457,10 @@ DisplayPlane *DisplayPlaneState::GetDisplayPlane() const {
   return private_data_->plane_;
 }
 
+void DisplayPlaneState::SetDisplayPlane(DisplayPlane *plane) {
+  private_data_->plane_ = plane;
+}
+
 const std::vector<size_t> &DisplayPlaneState::GetSourceLayers() const {
   return private_data_->source_layers_;
 }

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -459,6 +459,7 @@ DisplayPlane *DisplayPlaneState::GetDisplayPlane() const {
 
 void DisplayPlaneState::SetDisplayPlane(DisplayPlane *plane) {
   private_data_->plane_ = plane;
+  plane->SetInUse(true);
 }
 
 const std::vector<size_t> &DisplayPlaneState::GetSourceLayers() const {

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -115,6 +115,8 @@ class DisplayPlaneState {
 
   DisplayPlane *GetDisplayPlane() const;
 
+  void SetDisplayPlane(DisplayPlane *plane);
+
   // Returns source layers for this plane.
   const std::vector<size_t> &GetSourceLayers() const;
 

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -180,7 +180,8 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
              GRALLOC1_PRODUCER_USAGE_GPU_RENDER_TARGET |
              GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE;
     layer_type = hwcomposer::kLayerNormal;
-  } else if (layer_type == hwcomposer::kLayerVideo) {
+  } else if (layer_type == hwcomposer::kLayerVideo ||
+             layer_type == hwcomposer::kLayerProtected) {
     switch (pixel_format) {
       case HAL_PIXEL_FORMAT_YCbCr_422_I:
       case HAL_PIXEL_FORMAT_Y8:


### PR DESCRIPTION
1) When video is on top layers, there is no ganrantee that video get a separate plane.
Video can be assign to be composited. Add logic to squash non-video planes to make video
to get a seperate plane
2) When layers are scanout, or be processed as video plane, there is no necessary to
getGPUResources from them. It is a reductant operation and may result in error then video is
protected

Change-Id: I379ce5ecf3944230580734ac8317e6c6e3f7f8e1
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71887
Signed-off-by: Lin Johnson <johnson.lin@intel.com>