### PR TITLE
Fix the error in non-black SolidColor patch

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -198,9 +198,8 @@ void HwcLayer::SetAcquireFence(int32_t fd) {
   acquire_fence_ = fd;
 }
 
-void HwcLayer::SetSolidColor(hwc_color_t color) {
-  solid_color_ = (uint32_t)color.r << 24 | (uint32_t)color.g << 16 |
-                 (uint32_t)color.b << 8 | (uint32_t)color.a;
+void HwcLayer::SetSolidColor(uint32_t color) {
+  solid_color_ = color;
 }
 
 int32_t HwcLayer::GetAcquireFence() {

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -869,7 +869,10 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerBuffer(buffer_handle_t buffer,
 HWC2::Error IAHWC2::Hwc2Layer::SetLayerColor(hwc_color_t color) {
   if (sf_type_ == HWC2::Composition::SolidColor) {
     hwc_layer_.SetLayerCompositionType(hwcomposer::Composition_SolidColor);
-    hwc_layer_.SetSolidColor(color);
+    uint32_t hwc_layer_color = (uint32_t)color.r << 24 |
+                               (uint32_t)color.g << 16 |
+                               (uint32_t)color.b << 8 | (uint32_t)color.a;
+    hwc_layer_.SetSolidColor(hwc_layer_color);
   } else {
     sf_type_ = HWC2::Composition::Client;
   }

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -237,7 +237,7 @@ struct HwcLayer {
   /**
    * API for setting SolidColor for this layer.
    */
-  void SetSolidColor(hwc_color_t color);
+  void SetSolidColor(uint32_t color);
 
   /**
    * API for getting SolidColor.


### PR DESCRIPTION
The android type 'hwc_color_t' should not be used outside of
'os/android/'

Change-Id: I87dc20d1d2e7e9566b0ea74f9e1316378242fb55
Tracked-On: None
Tests: Compile sucessful for Android.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>