### PR TITLE
Fix Alpha calculation error

### DIFF
--- a/common/compositor/gl/glprogram.cpp
+++ b/common/compositor/gl/glprogram.cpp
@@ -102,7 +102,8 @@ static std::string GenerateFragmentShader(int layer_count) {
                          << "  vec3 color = vec3(0.0, 0.0, 0.0);\n"
                          << "  float alphaCover = 1.0;\n"
                          << "  vec4 texSample;\n"
-                         << "  vec3 multRgb;\n";
+                         << "  vec3 multRgb;\n"
+                         << "  float tempAlpha;\n";
   for (int i = 0; i < layer_count; ++i) {
     if (i > 0)
       fragment_shader_stream << "  if (alphaCover > 0.5/255.0) {\n";
@@ -111,10 +112,12 @@ static std::string GenerateFragmentShader(int layer_count) {
                            << ",\n"
                            << "                        fTexCoords[" << i
                            << "]);\n"
-                           << "  texSample = texSample + uLayerColor[" << i
-                           << "];\n"
+                           << "  texSample.rgb = texSample.rgb + uLayerColor[" << i
+                           << "].rgb;\n"
+                           << "  tempAlpha = min(texSample.a, uLayerColor[" << i
+                           << "].a);\n"
                            << "  multRgb = texSample.rgb *\n"
-                           << "            max(texSample.a, uLayerPremult[" << i
+                           << "            max(tempAlpha, uLayerPremult[" << i
                            << "]);\n"
                            << "  color += multRgb * uLayerAlpha[" << i
                            << "] * alphaCover;\n"


### PR DESCRIPTION
The Alpha of layer should be calculated with texture Alpha alone.
Instead of plus with RGB.

Change-Id: I848e0f1060a87e1a2b54f07a4f353cf0b4e453b4
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-72398
Tests: Compile sucessful for Android. Check the issue is fixed
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>