### PR TITLE
Check null point before using DRM property_set pointer

### DIFF
--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -283,6 +283,11 @@ bool DrmPlane::UpdateProperties(drmModeAtomicReqPtr property_set,
 
   IDISPLAYMANAGERTRACE("buffer->GetFb() ---------------------- STARTS %d",
                        buffer->GetFb());
+  if (!property_set) {
+    ETRACE("Failed to allocate property set %d", -ENOMEM);
+    return false;
+  }
+
   int success =
       drmModeAtomicAddProperty(property_set, id_, crtc_prop_.id, crtc_id) < 0;
   success |= drmModeAtomicAddProperty(property_set, id_, fb_prop_.id,


### PR DESCRIPTION
Add a checking for the pointer of DRM property_set to avoid Null pointer dereference
Once DRM is crashed, or some property of DRM is denied to access, such as "drm.gpu.
vendor_name"

Change-Id: Ibcf63425f510c0462d8b89fe9c6e1656b1c15a4b
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-72208
Tests: Compile sucessful for Android
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>