### PR TITLE
Fixed the HWC crash caused by map iterator erase.

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -88,7 +88,10 @@ VirtualDisplay::~VirtualDisplay() {
     resource_manager_->MarkResourceForDeletion(temp, false);
   }
 
-  delete output_handle_;
+  if (output_handle_) {
+    delete output_handle_;
+  }
+
   std::vector<OverlayLayer>().swap(in_flight_layers_);
 
   resource_manager_->PurgeBuffer();
@@ -111,9 +114,12 @@ VirtualDisplay::~VirtualDisplay() {
       } else {
         ITRACE("Hyper DmaBuf: IOCTL_HYPER_DMABUF_UNEXPORT ioctl Done [0x%x]!\n",
                it->second.hyper_dmabuf_id.id);
-        mHyperDmaExportedBuffers.erase(it);
       }
     }
+    /* Clear up the map of exported buffers whatever if the ioctl of
+     * IOCTL_HYPER_DMABUF_UNEXPORTED success or fail.
+     */
+    mHyperDmaExportedBuffers.clear();
 
     close(mHyperDmaBuf_Fd);
     mHyperDmaBuf_Fd = -1;


### PR DESCRIPTION
Erase map iterator during iterating a map caused the crash.
The fix is to avoid erase itator in the interating loop and clear
the iterator after the loop end.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71721
Tests: Trigger VirtualDisplay destructor condition and no HWC crash.
Signed-off-by: Wan Shuang <shuang.wan@intel.com>