### PR TITLE
optimize the 1st display frame commit 

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -649,7 +649,9 @@ void GpuDevice::HandleRoutine() {
       ITRACE("Successfully grabbed the hwc lock.");
     }
 
+	ETRACE("hwc before  set master.");
     display_manager_->setDrmMaster();
+	ETRACE("hwc after  set master.");
 
     close(lock_fd_);
     lock_fd_ = -1;

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -919,9 +919,10 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
 
   int32_t fence = 0;
   bool fence_released = false;
-  composition_passed = display_->Commit(
-      current_composition_planes, previous_plane_state_, disable_explictsync,
-      kms_fence_, &fence, &fence_released);
+  if (!IsIgnoreUpdates())
+    composition_passed = display_->Commit(
+        current_composition_planes, previous_plane_state_, disable_explictsync,
+        kms_fence_, &fence, &fence_released);
 
   if (fence_released) {
     kms_fence_ = 0;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -37,6 +37,7 @@
 #define CTA_EXTENSION_TAG 0x02
 #define CTA_EXTENDED_TAG_CODE 0x07
 #define CTA_COLORIMETRY_CODE 0x05
+int FirstFrame=1;
 
 namespace hwcomposer {
 
@@ -590,6 +591,13 @@ bool DrmDisplay::CommitFrame(
   if (ret) {
     ETRACE("Failed to commit pset ret=%s\n", PRINTERROR());
     return false;
+  }
+  else
+  {
+    if (FirstFrame) {
+      FirstFrame = 0;
+	  ETRACE(" hwc first frame commited \n");
+    }
   }
 
   return true;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -365,9 +365,7 @@ void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
 
   for (auto &display : displays_) {
     display->NotifyDisplayWA(disable_last_plane_usage);
-    if (!ignore_updates_) {
-      display->ForceRefresh();
-    }
+    display->ForceRefresh();
   }
 
   for (auto &display : displays_) {
@@ -446,10 +444,14 @@ void DrmDisplayManager::IgnoreUpdates() {
 }
 
 void DrmDisplayManager::setDrmMaster() {
-  int ret = drmSetMaster(fd_);
-  if (ret) {
-    ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
-  }
+    int ret = drmSetMaster(fd_);
+    while (ret) {
+        usleep(10000);
+        ret = drmSetMaster(fd_);
+        if (ret) {
+        ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
+      }
+    }
 }
 
 void DrmDisplayManager::HandleLazyInitialization() {


### PR DESCRIPTION
After the earlyEvs exit, the HWC will get the hwc.lock
and begin rendering, but the initialize for the
1st frame will use about 150ms, this patch will let
the initialize done before hwc.lock.

