### PR TITLE
HWC: optimize the 1st display frame commit

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -919,9 +919,10 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
 
   int32_t fence = 0;
   bool fence_released = false;
-  composition_passed = display_->Commit(
-      current_composition_planes, previous_plane_state_, disable_explictsync,
-      kms_fence_, &fence, &fence_released);
+  if (!IsIgnoreUpdates())
+    composition_passed = display_->Commit(
+        current_composition_planes, previous_plane_state_, disable_explictsync,
+        kms_fence_, &fence, &fence_released);
 
   if (fence_released) {
     kms_fence_ = 0;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -365,9 +365,7 @@ void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
 
   for (auto &display : displays_) {
     display->NotifyDisplayWA(disable_last_plane_usage);
-    if (!ignore_updates_) {
-      display->ForceRefresh();
-    }
+    display->ForceRefresh();
   }
 
   for (auto &display : displays_) {
@@ -447,8 +445,12 @@ void DrmDisplayManager::IgnoreUpdates() {
 
 void DrmDisplayManager::setDrmMaster() {
   int ret = drmSetMaster(fd_);
-  if (ret) {
-    ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
+  while (ret) {
+    usleep(10000);
+    ret = drmSetMaster(fd_);
+    if (ret) {
+      ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
+    }
   }
 }
 


### PR DESCRIPTION
After the earlyEvs exit, the HWC will get the hwc.lock
and begin rendering, but the initialize for the
1st frame will take ~150ms, this patch will let
the initialize done before taken hwc.lock.

Signed-off-by: Yang, Dong <dong.yang@intel.com>