### PR TITLE
Zoom in or out the rendering damage for different display

### DIFF
--- a/common/utils/hwctrace.h
+++ b/common/utils/hwctrace.h
@@ -43,6 +43,7 @@ extern "C" {
 // #define SURFACE_DUPLICATE_LAYER_TRACING 1
 // #define SURFACE_BASIC_TRACING 1
 // #define COMPOSITOR_TRACING 1
+// #define RECT_DAMAGE_TRACING 1
 
 // Function call tracing
 #ifdef FUNCTION_CALL_TRACING
@@ -116,6 +117,12 @@ class TraceFunc {
 #define ICOMPOSITORTRACE ITRACE
 #else
 #define ICOMPOSITORTRACE(fmt, ...) ((void)0)
+#endif
+
+#ifdef RECT_DAMAGE_TRACING
+#define IRECTDAMAGETRACE ITRACE
+#else
+#define IRECTDAMAGETRACE(fmt, ...) ((void)0)
 #endif
 
 #ifdef RESOURCE_CACHE_TRACING

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -929,9 +929,12 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerSurfaceDamage(hwc_region_t damage) {
   hwcomposer::HwcRegion hwc_region;
 
   for (size_t rect = 0; rect < num_rects; ++rect) {
-    hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
-                            damage.rects[rect].right,
-                            damage.rects[rect].bottom);
+    if (!(damage.rects[rect].left == 0 && damage.rects[rect].top == 0 &&
+          damage.rects[rect].right == 0 && damage.rects[rect].bottom == 0)) {
+      hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
+                              damage.rects[rect].right,
+                              damage.rects[rect].bottom);
+    }
   }
 
   hwc_layer_.SetSurfaceDamage(hwc_region);


### PR DESCRIPTION
Add the "zoom in and out" code back for connecting 2 display with different
resolution. In the bug case, 2K and 1080P display are connected. the Rect
should be enlarged for 2K when the rect is calculated with 1080P
coordinates.

Change-Id: I60cdd681895e8fa4907a89c2450c6da410ba208b
Tests: Verified on Celadon with 2 displays and mosaic on GP
Tracked-On: https://jira.devtools.intel.com/browse/OAM-73581
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>