### PR TITLE
Correct overlay alpha blending value setting

### DIFF
--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -269,7 +269,7 @@ bool DrmPlane::Initialize(uint32_t gpu_fd, const std::vector<uint32_t>& formats,
 bool DrmPlane::UpdateProperties(drmModeAtomicReqPtr property_set,
                                 uint32_t crtc_id, const OverlayLayer* layer,
                                 bool test_commit) const {
-  uint64_t alpha = 0xFF;
+  uint32_t alpha = 0xFFFF;
   OverlayBuffer* buffer = layer->GetBuffer();
   if (!buffer) {
     ETRACE("Fail to allocate buffer memory for layer!");
@@ -283,8 +283,9 @@ bool DrmPlane::UpdateProperties(drmModeAtomicReqPtr property_set,
     fence = layer->GetAcquireFence();
   }
 
+  // i915 driver reads high 8bit of 16bit value
   if (layer->GetBlending() == HWCBlending::kBlendingPremult)
-    alpha = layer->GetAlpha();
+    alpha = static_cast<uint32_t>(layer->GetAlpha()) << 8;
 
   IDISPLAYMANAGERTRACE("buffer->GetFb() ---------------------- STARTS %d",
                        buffer->GetFb());


### PR DESCRIPTION
Correct Alpha value setting to align with i915 kernel driver
in which overlay Alpha blending is first time being enabled
from kernel 4.20.

In driver it takes high 8bit of 16bit value.

Tracked-On: None
Test: boot to Android UI with kernel 4.20
Signed-off-by: Yuanjun Huang <yuanjun.huang@intel.com>