### PR TITLE
drmBuffer: wrap CreateFrameBuffer in GetFb

### DIFF
--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -146,7 +146,7 @@ void NativeSurface::SetPlaneTarget(const DisplayPlaneState &plane) {
   on_screen_ = false;
   surface_age_ = 0;
   if (layer_.GetBuffer()->GetFb() == 0) {
-    layer_.GetBuffer()->CreateFrameBuffer();
+    ETRACE("SetPlaneTarget unable to create framebuffer for nativesurface");
   }
 }
 

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -833,9 +833,7 @@ bool DisplayPlaneManager::FallbacktoGPU(
     return true;
 
   if (layer->GetBuffer()->GetFb() == 0) {
-    if (!layer->GetBuffer()->CreateFrameBuffer()) {
-      return true;
-    }
+    return true;
   }
 
   // TODO(kalyank): Take relevant factors into consideration to determine if

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -433,19 +433,14 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
       }
 
       OverlayBuffer* buffer = layer->GetBuffer();
-      if (buffer->GetFb() == 0) {
-        buffer->CreateFrameBuffer();
-
-        // FB creation failed, we need to re-validate the
-        // whole commit.
-        if (buffer->GetFb() == 0) {
-          *force_full_validation = true;
-          *can_ignore_commit = false;
-          return;
-        }
-
-        reset_composition_regions = true;
+      bool isNewCreated = false;
+      if (buffer->GetFb(&isNewCreated) == 0) {
+        *force_full_validation = true;
+        *can_ignore_commit = false;
+        return;
       }
+      if (isNewCreated)
+        reset_composition_regions = true;
 
       last_plane.SetOverlayLayer(layer);
       if (layer->HasLayerContentChanged()) {

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -60,7 +60,13 @@ class DrmBuffer : public OverlayBuffer {
     return METADATA(usage_);
   }
 
-  uint32_t GetFb() const override {
+  uint32_t GetFb(bool* isNewCreated = NULL) override {
+    if (image_.drm_fd_ == 0) {
+      CreateFrameBuffer();
+      if (isNewCreated && image_.drm_fd_)
+        *isNewCreated = true;
+    } else if (isNewCreated)
+      *isNewCreated = false;
     return image_.drm_fd_;
   }
 
@@ -101,8 +107,6 @@ class DrmBuffer : public OverlayBuffer {
                                               uint32_t width,
                                               uint32_t height) override;
 
-  bool CreateFrameBuffer() override;
-
   bool CreateFrameBufferWithModifier(uint64_t modifier) override;
 
   HWCNativeHandle GetOriginalHandle() const override {
@@ -115,6 +119,7 @@ class DrmBuffer : public OverlayBuffer {
 
  private:
   void Initialize(const HwcMeta& meta);
+  bool CreateFrameBuffer();
   uint32_t format_ = 0;
   uint32_t frame_buffer_format_ = 0;
   uint32_t previous_width_ = 0;   // For Media usage.

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -55,7 +55,7 @@ class OverlayBuffer {
 
   virtual HWCLayerType GetUsage() const = 0;
 
-  virtual uint32_t GetFb() const = 0;
+  virtual uint32_t GetFb(bool* isNewCreated = NULL) = 0;
 
   virtual uint32_t GetPrimeFD() const = 0;
 
@@ -85,8 +85,6 @@ class OverlayBuffer {
   virtual const MediaResourceHandle& GetMediaResource(MediaDisplay display,
                                                       uint32_t width,
                                                       uint32_t height) = 0;
-
-  virtual bool CreateFrameBuffer() = 0;
 
   // Creates Framebuffer taking into account any Modifiers.
   virtual bool CreateFrameBufferWithModifier(uint64_t modifier) = 0;


### PR DESCRIPTION
Since GetFb and CreateFramebuffer are always coupled
This make callers only need to call GetFb

Change-Id: Ifdee963065e92a984205f851db2b2e2c27ae9a4e
Tracked-On: None
Tests: Andriod UI normal
Signed-off-by: Lin Johnson <johnson.lin@intel.com>