### PR TITLE
Return false for none of DrmModeMode

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -342,7 +342,7 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   SPIN_UNLOCK(display_lock_);
 
   if (modes_size == 0) {
-    return PhysicalDisplay::GetDisplayConfigs(num_configs, configs);
+    return false;
   }
 
   if (!configs) {


### PR DESCRIPTION
Return false for none of DrmModeModeInfo, rather than invoking physical
display to get the config.

Change-Id: Ib171c387ab3c9c0963277fc0a1de053632c6d2a0
Tracked-On:https://jira.devtools.intel.com/browse/OAM-73760
Tests: Compile sucessful for Android, 3000 round reboot testing.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>