### PR TITLE
HWC, modify the connected display calculate logic

### DIFF
--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -149,18 +149,17 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
 
   set_format_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_, pixel_format);
 #ifdef ENABLE_RBC
+  uint64_t modifier = 0;
   if (set_modifier_) {
-    uint64_t modifier = 0;
     if (preferred_modifier != -1) {
       modifier = preferred_modifier;
     } else {
       modifier = choose_drm_modifier(format);
     }
-
     set_modifier_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_, modifier);
   }
 
-  if (modifier_used) {
+  if (modifier_used && modifier != DRM_FORMAT_MOD_NONE) {
     *modifier_used = true;
   }
 #else

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -219,9 +219,23 @@ bool DrmDisplayManager::UpdateDisplayState() {
     display->MarkForDisconnect();
   }
 
+  connected_display_count_ = 0;
   std::vector<NativeDisplay *> connected_displays;
   std::vector<uint32_t> no_encoder;
   uint32_t total_connectors = res->count_connectors;
+  for (uint32_t i = 0; i < total_connectors; ++i) {
+    ScopedDrmConnectorPtr connector(
+        drmModeGetConnector(fd_, res->connectors[i]));
+    if (!connector) {
+      ETRACE("Failed to get connector %d", res->connectors[i]);
+      break;
+    }
+    // check if a monitor is connected.
+    if (connector->connection != DRM_MODE_CONNECTED)
+      continue;
+    connected_display_count_++;
+  }
+
   for (uint32_t i = 0; i < total_connectors; ++i) {
     ScopedDrmConnectorPtr connector(
         drmModeGetConnector(fd_, res->connectors[i]));
@@ -464,14 +478,7 @@ void DrmDisplayManager::HandleLazyInitialization() {
 }
 
 uint32_t DrmDisplayManager::GetConnectedPhysicalDisplayCount() {
-  size_t size = displays_.size();
-  uint32_t count = 0;
-  for (size_t i = 0; i < size; i++) {
-    if (displays_[i]->IsConnected()) {
-      count++;
-    }
-  }
-  return count;
+  return connected_display_count_;
 }
 
 DisplayManager *DisplayManager::CreateDisplayManager(GpuDevice *device) {

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -103,6 +103,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   bool notify_client_ = false;
   bool release_lock_ = false;
   SpinLock spin_lock_;
+  int connected_display_count_ = 0;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
The conneted display count should be calculated before the
drmdisplaymanager try to connect the physical display,
the original method will count a logical connected display,
only already conneted by drmdisplaymanager will be counted,
but since the number will be used during the diaplay
connection, so it will get the wrong display number.

Change-Id: I9f0a96bd34b7c3ef4ea040c798cebfa0f332796a
Tracked-On: https://jira.devtools.intel.com/browse/OAM-73655
Signed-off-by: Yang, Dong <dong.yang@intel.com>