### PR TITLE
Remove choose_drm_modifier

### DIFF
--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -153,8 +153,6 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
     uint64_t modifier = 0;
     if (preferred_modifier != -1) {
       modifier = preferred_modifier;
-    } else {
-      modifier = choose_drm_modifier(format);
     }
 
     set_modifier_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_, modifier);

--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -115,8 +115,6 @@ bool GbmBufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
 #ifdef ENABLE_RBC
   if (preferred_modifier != -1) {
     modifier = preferred_modifier;
-  } else {
-    modifier = choose_drm_modifier(gbm_format);
   }
 
   if (modifier_used) {

--- a/wsi/drm/commondrmutils.h
+++ b/wsi/drm/commondrmutils.h
@@ -87,21 +87,4 @@ static size_t drm_bo_get_num_planes(uint32_t format) {
   return 0;
 }
 
-static uint64_t choose_drm_modifier(uint32_t format) {
-#ifdef ENABLE_RBC
-  switch (format) {
-    case DRM_FORMAT_XRGB8888:
-    case DRM_FORMAT_XBGR8888:
-    case DRM_FORMAT_ARGB8888:
-    case DRM_FORMAT_ABGR8888:
-      // FIXME: When to choose I915_FORMAT_MOD_Yf_TILED_CCS?
-      return I915_FORMAT_MOD_Y_TILED_CCS;
-    default:
-      return DRM_FORMAT_MOD_NONE;
-  }
-#else
-  return DRM_FORMAT_MOD_NONE;
-#endif
-}
-
 #endif  // WSI_COMMONDRMUTILS_H_


### PR DESCRIPTION
We should not relay on a simple util functions to choose CCS
modificators. That could be risky if one drm plane does not support
CCS modificator. We should let drmplane tell us which kind of modifier
the plane preferred

Change-Id: Ia9b3c9d0a7a1f05694635e12aaa97a70b880cb9b
Tracked-On: None
Tests: Android UI normal and RBC working
Signed-off-by: Lin Johnson <johnson.lin@intel.com>