### PR TITLE
Revert "Return false for none of DrmModeMode"

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -342,7 +342,7 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   SPIN_UNLOCK(display_lock_);
 
   if (modes_size == 0) {
-    return false;
+    return PhysicalDisplay::GetDisplayConfigs(num_configs, configs);
   }
 
   if (!configs) {


### PR DESCRIPTION
This patch could cause a boot issue. revert it for time being
    This reverts commit a1a54397597cf078a649724f85f6414aabaee198.

    Change-Id: I8030db728056341c638340725ce661791e7bf99f
    Tracked-On:https://jira.devtools.intel.com/browse/OAM-73760
    Tests: Compile sucessful for Android.
    Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>