### PR TITLE
Replace SetExplicitSyncSupport with SetDisableExplicitSync

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -49,7 +49,7 @@ void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd,
 }
 
 void Compositor::BeginFrame(bool disable_explicit_sync) {
-  thread_->SetExplicitSyncSupport(disable_explicit_sync);
+  thread_->SetDisableExplicitSync(disable_explicit_sync);
 }
 
 void Compositor::Reset() {

--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -56,7 +56,7 @@ void CompositorThread::Initialize(ResourceManager *resource_manager,
   }
 }
 
-void CompositorThread::SetExplicitSyncSupport(bool disable_explicit_sync) {
+void CompositorThread::SetDisableExplicitSync(bool disable_explicit_sync) {
   disable_explicit_sync_ = disable_explicit_sync;
 }
 
@@ -213,7 +213,7 @@ void CompositorThread::Handle3DDrawRequest() {
     return;
   }
 
-  gl_renderer_->SetExplicitSyncSupport(disable_explicit_sync_);
+  gl_renderer_->SetDisableExplicitSync(disable_explicit_sync_);
 
   if (!gpu_resource_handler_->PrepareResources(buffers_)) {
     ETRACE(

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -50,7 +50,7 @@ class CompositorThread : public HWCThread {
             std::vector<DrawState>& media_states,
             const std::vector<OverlayBuffer*>& buffers);
 
-  void SetExplicitSyncSupport(bool disable_explicit_sync);
+  void SetDisableExplicitSync(bool disable_explicit_sync);
   void FreeResources();
 
   void HandleRoutine() override;

--- a/common/compositor/gl/glrenderer.cpp
+++ b/common/compositor/gl/glrenderer.cpp
@@ -207,7 +207,7 @@ void GLRenderer::InsertFence(int32_t kms_fence) {
   }
 }
 
-void GLRenderer::SetExplicitSyncSupport(bool disable_explicit_sync) {
+void GLRenderer::SetDisableExplicitSync(bool disable_explicit_sync) {
   disable_explicit_sync_ = disable_explicit_sync;
 }
 

--- a/common/compositor/gl/glrenderer.h
+++ b/common/compositor/gl/glrenderer.h
@@ -38,7 +38,7 @@ class GLRenderer : public Renderer {
 
   void InsertFence(int32_t kms_fence) override;
 
-  void SetExplicitSyncSupport(bool disable_explicit_sync) override;
+  void SetDisableExplicitSync(bool disable_explicit_sync) override;
 
  private:
   GLProgram *GetProgram(unsigned texture_count);

--- a/common/compositor/renderer.h
+++ b/common/compositor/renderer.h
@@ -63,7 +63,7 @@ class Renderer {
 
   virtual void InsertFence(int32_t kms_fence) = 0;
 
-  virtual void SetExplicitSyncSupport(bool disable_explicit_sync) = 0;
+  virtual void SetDisableExplicitSync(bool disable_explicit_sync) = 0;
 };
 
 }  // namespace hwcomposer

--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -88,10 +88,10 @@ class VARenderer : public Renderer {
   ~VARenderer();
 
   bool Init(int gpu_fd) override;
-  bool Draw(const MediaState &state, NativeSurface *surface) override;
+  bool Draw(const MediaState& state, NativeSurface* surface) override;
   void InsertFence(int32_t /*kms_fence*/) override {
   }
-  void SetExplicitSyncSupport(bool /*disable_explicit_sync*/) override {
+  void SetDisableExplicitSync(bool /*disable_explicit_sync*/) override {
   }
 
   bool DestroyMediaResources(std::vector<struct media_import>&) override;

--- a/common/compositor/vk/vkrenderer.cpp
+++ b/common/compositor/vk/vkrenderer.cpp
@@ -685,7 +685,7 @@ bool VKRenderer::Draw(const std::vector<RenderState> &render_states,
 void VKRenderer::InsertFence(int32_t kms_fence) {
 }
 
-void VKRenderer::SetExplicitSyncSupport(bool disable_explicit_sync) {
+void VKRenderer::SetDisableExplicitSync(bool disable_explicit_sync) {
 }
 
 VKProgram *VKRenderer::GetProgram(unsigned texture_count) {

--- a/common/compositor/vk/vkrenderer.h
+++ b/common/compositor/vk/vkrenderer.h
@@ -32,7 +32,7 @@ class VKRenderer : public Renderer {
   bool Draw(const std::vector<RenderState> &commands,
             NativeSurface *surface) override;
   void InsertFence(int32_t kms_fence) override;
-  void SetExplicitSyncSupport(bool disable_explicit_sync) override;
+  void SetDisableExplicitSync(bool disable_explicit_sync) override;
 
  private:
   VKProgram *GetProgram(unsigned texture_count);

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -156,8 +156,8 @@ void LogicalDisplay::SetBrightness(uint32_t red, uint32_t green,
   physical_display_->SetBrightness(red, green, blue);
 }
 
-void LogicalDisplay::SetExplicitSyncSupport(bool disable_explicit_sync) {
-  physical_display_->SetExplicitSyncSupport(disable_explicit_sync);
+void LogicalDisplay::SetDisableExplicitSync(bool disable_explicit_sync) {
+  physical_display_->SetDisableExplicitSync(disable_explicit_sync);
 }
 
 void LogicalDisplay::SetVideoScalingMode(uint32_t mode) {

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -76,7 +76,7 @@ class LogicalDisplay : public NativeDisplay {
   void SetGamma(float red, float green, float blue) override;
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue) override;
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue) override;
-  void SetExplicitSyncSupport(bool disable_explicit_sync) override;
+  void SetDisableExplicitSync(bool disable_explicit_sync) override;
   void SetVideoScalingMode(uint32_t mode) override;
   void SetVideoColor(HWCColorControl color, float value) override;
   void GetVideoColor(HWCColorControl color, float *value, float *start,

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -393,10 +393,10 @@ void MosaicDisplay::SetBrightness(uint32_t red, uint32_t green, uint32_t blue) {
   }
 }
 
-void MosaicDisplay::SetExplicitSyncSupport(bool disable_explicit_sync) {
+void MosaicDisplay::SetDisableExplicitSync(bool disable_explicit_sync) {
   uint32_t size = physical_displays_.size();
   for (uint32_t i = 0; i < size; i++) {
-    physical_displays_.at(i)->SetExplicitSyncSupport(disable_explicit_sync);
+    physical_displays_.at(i)->SetDisableExplicitSync(disable_explicit_sync);
   }
 }
 

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -69,7 +69,7 @@ class MosaicDisplay : public NativeDisplay {
   void SetGamma(float red, float green, float blue) override;
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue) override;
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue) override;
-  void SetExplicitSyncSupport(bool disable_explicit_sync) override;
+  void SetDisableExplicitSync(bool disable_explicit_sync) override;
   void SetVideoScalingMode(uint32_t mode) override;
   void SetVideoColor(HWCColorControl color, float value) override;
   void GetVideoColor(HWCColorControl color, float *value, float *start,

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -1467,7 +1467,7 @@ void DisplayQueue::SetBrightness(uint32_t red, uint32_t green, uint32_t blue) {
   state_ |= kNeedsColorCorrection;
 }
 
-void DisplayQueue::SetExplicitSyncSupport(bool disable_explicit_sync) {
+void DisplayQueue::SetDisableExplicitSync(bool disable_explicit_sync) {
   if (disable_explicit_sync) {
     state_ |= kDisableExplictSync;
   } else {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -74,7 +74,7 @@ class DisplayQueue {
   void SetColorTransform(const float* matrix, HWCColorTransform hint);
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue);
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue);
-  void SetExplicitSyncSupport(bool disable_explicit_sync);
+  void SetDisableExplicitSync(bool disable_explicit_sync);
   void SetVideoScalingMode(uint32_t mode);
   void SetVideoColor(HWCColorControl color, float value);
   void GetVideoColor(HWCColorControl color, float* value, float* start,

--- a/os/alios/hwf_alioshal.cpp
+++ b/os/alios/hwf_alioshal.cpp
@@ -578,14 +578,14 @@ int32_t hwf_open(struct hwf_device_t **device, const VendorModule *module) {
   // virtual display
   hwf_device->virtual_display_.display_ =
       p_gpu_device->CreateVirtualDisplay(HWF_DISPLAY_VIRTUAL);
-  hwf_device->virtual_display_.display_->SetExplicitSyncSupport(
+  hwf_device->virtual_display_.display_->SetDisableExplicitSync(
       hwf_device->disable_explicit_sync_);
 
   // primary display
   size_t size = displays.size();
   hwcomposer::NativeDisplay *primary_display = displays.at(0);
   hwf_device->primary_display_.display_ = primary_display;
-  hwf_device->primary_display_.display_->SetExplicitSyncSupport(
+  hwf_device->primary_display_.display_->SetDisableExplicitSync(
       hwf_device->disable_explicit_sync_);
 
   // Grab the first mode, we'll choose this as the active mode
@@ -603,7 +603,7 @@ int32_t hwf_open(struct hwf_device_t **device, const VendorModule *module) {
     hwf_device->extended_displays_.emplace_back();
     HwfDisplay &temp = hwf_device->extended_displays_.back();
     temp.display_ = displays.at(i);
-    temp.display_->SetExplicitSyncSupport(hwf_device->disable_explicit_sync_);
+    temp.display_->SetDisableExplicitSync(hwf_device->disable_explicit_sync_);
   }
 
   hwf_device->base.common.module = module;

--- a/os/android/iahwc1.cpp
+++ b/os/android/iahwc1.cpp
@@ -603,7 +603,7 @@ static int hwc_device_open(const struct hw_module_t *module, const char *name,
   const std::vector<hwcomposer::NativeDisplay *> &displays =
       ctx->device_.GetAllDisplays();
   ctx->virtual_display_.display_ = ctx->device_.CreateVirtualDisplay(0);
-  ctx->virtual_display_.display_->SetExplicitSyncSupport(
+  ctx->virtual_display_.display_->SetDisableExplicitSync(
       ctx->disable_explicit_sync_);
   ctx->virtual_display_.timeline_.Init();
 
@@ -611,7 +611,7 @@ static int hwc_device_open(const struct hw_module_t *module, const char *name,
   hwcomposer::NativeDisplay *primary_display = displays.at(0);
   ctx->primary_display_.display_ = primary_display;
   ctx->primary_display_.display_id_ = 0;
-  ctx->primary_display_.display_->SetExplicitSyncSupport(
+  ctx->primary_display_.display_->SetDisableExplicitSync(
       ctx->disable_explicit_sync_);
   ctx->primary_display_.timeline_.Init();
   // Fetch the number of modes from the display
@@ -636,7 +636,7 @@ static int hwc_device_open(const struct hw_module_t *module, const char *name,
     temp.display_ = displays.at(i);
     temp.display_id_ = i;
     temp.timeline_.Init();
-    temp.display_->SetExplicitSyncSupport(ctx->disable_explicit_sync_);
+    temp.display_->SetDisableExplicitSync(ctx->disable_explicit_sync_);
   }
 
   ctx->device.common.tag = HARDWARE_DEVICE_TAG;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -305,7 +305,7 @@ HWC2::Error IAHWC2::HwcDisplay::InitVirtualDisplay(
   handle_ = display_index + HWC_DISPLAY_VIRTUAL + VDS_OFFSET;
   display_->InitVirtualDisplay(width, height);
   disable_explicit_sync_ = disable_explicit_sync;
-  display_->SetExplicitSyncSupport(disable_explicit_sync_);
+  display_->SetDisableExplicitSync(disable_explicit_sync_);
   return HWC2::Error::None;
 }
 
@@ -320,7 +320,7 @@ HWC2::Error IAHWC2::HwcDisplay::Init(hwcomposer::NativeDisplay *display,
 
   disable_explicit_sync_ = disable_explicit_sync;
   scaling_mode_ = scaling_mode;
-  display_->SetExplicitSyncSupport(disable_explicit_sync_);
+  display_->SetDisableExplicitSync(disable_explicit_sync_);
   display_->SetVideoScalingMode(scaling_mode_);
 
   if (!display_->IsConnected()) {

--- a/os/linux/linux_frontend.cpp
+++ b/os/linux/linux_frontend.cpp
@@ -397,12 +397,12 @@ int IAHWC::IAHWCDisplay::PresentDisplay(int32_t* release_fd) {
 }
 
 int IAHWC::IAHWCDisplay::DisableOverlayUsage() {
-  native_display_->SetExplicitSyncSupport(false);
+  native_display_->SetDisableExplicitSync(false);
   return 0;
 }
 
 int IAHWC::IAHWCDisplay::EnableOverlayUsage() {
-  native_display_->SetExplicitSyncSupport(true);
+  native_display_->SetDisableExplicitSync(true);
   return 0;
 }
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -293,7 +293,7 @@ class NativeDisplay {
    */
   virtual bool CheckPlaneFormat(uint32_t format) = 0;
 
-  virtual void SetExplicitSyncSupport(bool /*explicit_sync_enabled*/) {
+  virtual void SetDisableExplicitSync(bool /*explicit_sync_enabled*/) {
   }
 
   /**

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -432,8 +432,8 @@ void PhysicalDisplay::SetBrightness(uint32_t red, uint32_t green,
   display_queue_->SetBrightness(red, green, blue);
 }
 
-void PhysicalDisplay::SetExplicitSyncSupport(bool disable_explicit_sync) {
-  display_queue_->SetExplicitSyncSupport(disable_explicit_sync);
+void PhysicalDisplay::SetDisableExplicitSync(bool disable_explicit_sync) {
+  display_queue_->SetDisableExplicitSync(disable_explicit_sync);
 }
 
 void PhysicalDisplay::SetVideoScalingMode(uint32_t mode) {

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -87,7 +87,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   void SetContrast(uint32_t red, uint32_t green, uint32_t blue) override;
   void SetColorTransform(const float *matrix, HWCColorTransform hint) override;
   void SetBrightness(uint32_t red, uint32_t green, uint32_t blue) override;
-  void SetExplicitSyncSupport(bool disable_explicit_sync) override;
+  void SetDisableExplicitSync(bool disable_explicit_sync) override;
   void SetVideoScalingMode(uint32_t mode) override;
   void SetVideoColor(HWCColorControl color, float value) override;
   void GetVideoColor(HWCColorControl color, float *value, float *start,


### PR DESCRIPTION
SetExplicitSyncSupport is misleading. The actually meaning is to disable ExplicitSync

Change-Id: Ic6d12cdc52c1ee6355382a03dea58560fdd1e281
Tracked-On: None
Tests: Android UI normal
Signed-off-by: Lin Johnson <johnson.lin@intel.com>