### PR TITLE
Trying to avoid unecessary composition on 2 planes

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -1271,12 +1271,18 @@ bool DisplayPlaneManager::ForceSeparatePlane(
   HwcRect<int> target_display_frame = display_frame;
   uint32_t total_width = 0;
   uint32_t total_height = 0;
-  if (target_layer) {
-    total_width = target_layer->GetDisplayFrameWidth();
-    total_height = target_layer->GetDisplayFrameHeight();
-    target_display_frame = target_layer->GetDisplayFrame();
-    CalculateRect(display_frame, target_display_frame);
+
+  if (!target_layer) {
+    if (!(last_plane.IsVideoPlane() || last_plane.IsCursorPlane()))
+      return false;
+    else
+      return true;
   }
+
+  total_width = target_layer->GetDisplayFrameWidth();
+  total_height = target_layer->GetDisplayFrameHeight();
+  target_display_frame = target_layer->GetDisplayFrame();
+  CalculateRect(display_frame, target_display_frame);
 
   bool force_separate = false;
   for (const size_t &index : new_layers) {


### PR DESCRIPTION
We observed this situation in ACRN
When the displayframe of 2 planes overlaps
composition on separate plane is not necessary

Change-Id: Iefa948785191ecd6516a7503cd449f4d2e26696d
Tracked-On: None
Tests: Android UI normal
Signed-off-by: Lin Johnson <johnson.lin@intel.com>