### PR TITLE
PAVP:  tear down discard layer before import buffers

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -552,8 +552,7 @@ void DisplayQueue::InitializeOverlayLayers(
     // Discard protected video for tear down
     if (state_ & kVideoDiscardProtected) {
       if (layer->GetNativeHandle() != NULL &&
-          (layer->GetNativeHandle()->meta_data_.usage_ &
-           hwcomposer::kLayerProtected))
+          IsBufferProtected(layer->GetNativeHandle()))
         continue;
     }
 

--- a/os/alios/platformdefines.h
+++ b/os/alios/platformdefines.h
@@ -106,6 +106,14 @@ inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle) {
   return id;
 }
 
+inline bool IsBufferProtected(HWCNativeHandle handle) {
+  native_array_t* attrib_array = &native_handle->target_->attributes;
+  if (attrib_array->data[4] & YALLOC_FLAG_PROTECTED) {
+    return true;
+  }
+  return false;
+}
+
 // _cplusplus
 #ifdef _cplusplus
 }

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -27,6 +27,7 @@
 
 #include <android/log.h>
 #include <cros_gralloc_handle.h>
+#include <hardware/gralloc1.h>
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer.h>
 #include <system/graphics.h>
@@ -66,6 +67,14 @@ inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle) {
     ETRACE("Error generate handle from prime fd %d", prime_fd);
   }
   return id;
+}
+
+inline bool IsBufferProtected(HWCNativeHandle handle) {
+  auto gr_handle = (struct cros_gralloc_handle*)handle->handle_;
+  if (gr_handle->consumer_usage & GRALLOC1_PRODUCER_USAGE_PROTECTED) {
+    return true;
+  }
+  return false;
 }
 
 // _cplusplus

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -77,6 +77,10 @@ inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle) {
   return id;
 }
 
+inline bool IsBufferProtected(HWCNativeHandle handle) {
+  return false;
+}
+
 // _cplusplus
 #ifdef _cplusplus
 }


### PR DESCRIPTION
So the meta flags after import is not set yet, it
should not be used to judge the original buffer is
protected or not. Instead, use IsBufferProtected to
judge the original buffer is protected or not

Change-Id: Ibe38def41c9bfb56a02cac398132776e8cfe988e
Tracked-On: None
Tests: Android UI normal
Signed-off-by: Lin Johnson <johnson.lin@intel.com>