### PR TITLE
Calculate damage rect for secondary display

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -290,6 +290,13 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
     }
 
     // Handle case where we might be using logical and Mosaic together.
+    IMOSAICDISPLAYTRACE("-------Layer[%d]", z_order_);
+    IMOSAICDISPLAYTRACE(
+        "Original display_frame_ %d %d %d %d  left_source_constraint: %d "
+        "left_constraint: %d \n",
+        display_frame_.left, display_frame_.right, display_frame_.top,
+        display_frame_.bottom, left_source_constraint, left_constraint);
+
     display_frame_.left =
         (display_frame_.left - left_source_constraint) + left_constraint;
     display_frame_.right =
@@ -300,10 +307,21 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
         display_frame_.left, display_frame_.right, display_frame_.top,
         display_frame_.bottom, left_source_constraint, left_constraint);
 
+    IMOSAICDISPLAYTRACE(
+        "Original surface_damage_ %d %d %d %d  left_source_constraint: %d "
+        "left_constraint: %d \n",
+        surface_damage_.left, surface_damage_.right, surface_damage_.top,
+        surface_damage_.bottom, left_source_constraint, left_constraint);
+
     display_frame_.bottom =
         std::min(max_height, static_cast<uint32_t>(display_frame_.bottom));
     display_frame_width_ = display_frame_.right - display_frame_.left;
     display_frame_height_ = display_frame_.bottom - display_frame_.top;
+
+    surface_damage_.left =
+        (surface_damage_.left - left_source_constraint) + left_constraint;
+    surface_damage_.right =
+        (surface_damage_.right - left_source_constraint) + left_constraint;
 
     if ((surface_damage_.left < display_frame_.left) &&
         (surface_damage_.right > display_frame_.left)) {


### PR DESCRIPTION
The coordinate of damage rect should be calculated according to the
display order in overlaylayer.

Change-Id: I5f7a9a6cf471ee081d86877b6bff830b896662e8
Tests: Compile sucessful for Android.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-74960
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>