### PR TITLE
Set the active config as the fake config when no display is connected

### DIFF
--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -634,7 +634,8 @@ bool PhysicalDisplay::GetDisplayConfigs(uint32_t *num_configs,
     return false;
   *num_configs = 1;
   if (configs) {
-    configs[0] = 1;
+    configs[0] = FAKE_DISPLAY_CONFIG_ID;
+    config_ = FAKE_DISPLAY_CONFIG_ID;
   }
   return true;
 }

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -17,6 +17,8 @@
 #ifndef WSI_PHYSICALDISPLAY_H_
 #define WSI_PHYSICALDISPLAY_H_
 
+#define FAKE_DISPLAY_CONFIG_ID 0
+
 #include <stdint.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
When no display is connected, the fake config id(0) must be set as
active config. otherwise SF will crash when invoking GetActiveConfig
SF only invoke SetActiveConfig when configs.size > 1. In no-display case,
only 1 fake config is return.
1 known issue: if the primary display(2k/4k) is not 1080p, and no
connected in booting. once the primary display is hotpluged. only
1080p will be shown.

Change-Id: I55b6ed900fe77339a8fc4bbbf5435ed9321e76b2
Tests: Compile done. No SF crash happen with no-display, and hotplug
Tracked-On: https://jira.devtools.intel.com/browse/OAM-73760
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>