### PR TITLE
ActiveConfig member should not be reset in ConnectDisplay

### DIFF
--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -95,6 +95,7 @@ class DrmDisplay : public PhysicalDisplay {
 
   void SetDrmModeInfo(const std::vector<drmModeModeInfo> &mode_info);
   void SetDisplayAttribute(const drmModeModeInfo &mode_info);
+  void SetFakeAttribute(const drmModeModeInfo &mode_info);
 
   bool TestCommit(
       const std::vector<OverlayPlane> &commit_planes) const override;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -84,7 +84,6 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
 
 void PhysicalDisplay::NotifyClientOfDisConnectedState() {
   SPIN_LOCK(modeset_lock_);
-
   if (hotplug_callback_ && !(connection_state_ & kConnected) &&
       (display_state_ & kNotifyClient)) {
     IHOTPLUGEVENTTRACE(
@@ -632,8 +631,9 @@ bool PhysicalDisplay::GetDisplayConfigs(uint32_t *num_configs,
     return false;
   *num_configs = 1;
   if (configs) {
-    configs[0] = 1;
+    configs[0] = DEFAULT_CONFIG_ID;
   }
+  connection_state_ |= kFakeConnected;
   return true;
 }
 

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -17,6 +17,10 @@
 #ifndef WSI_PHYSICALDISPLAY_H_
 #define WSI_PHYSICALDISPLAY_H_
 
+#ifndef DEFAULT_CONFIG_ID
+#define DEFAULT_CONFIG_ID 0
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -260,6 +264,10 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   virtual void HandleLazyInitialization() {
   }
 
+  bool IsFakeConnected() {
+    return connection_state_ & kFakeConnected;
+  }
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();
@@ -269,7 +277,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   enum DisplayConnectionStatus {
     kDisconnected = 1 << 0,
     kConnected = 1 << 1,
-    kDisconnectionInProgress = 1 << 2
+    kDisconnectionInProgress = 1 << 2,
+    kFakeConnected = 1 << 3
   };
 
   enum DisplayState {
@@ -286,11 +295,6 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   };
 
   uint32_t pipe_;
-#ifdef ENABLE_ANDROID_WA
-  uint32_t config_ = 1;
-#else
-  uint32_t config_ = 0;
-#endif
   int32_t width_;
   int32_t height_;
   HwcRect<int32_t> rect_;
@@ -310,6 +314,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
+  uint32_t config_ = DEFAULT_CONFIG_ID;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
ActiveConfig is sent from SF. should not be reset in connecting
display. The default config will be used as Fake config ID too

Known issue: SF expects primary display to be always connected.
Once the primary display is set with fake(1080p). it can not be
updated with disconnect-connect hotplug event again. otherwise, SF
will crash with "null point" when invoking the erased display.
no way to re-fresh the pri-display config except reboot.

Change-Id: I4517a715d68fd4c9da227a17937da91db442f5df
Tests: Compile sucessful for Android. No crash in headless and hotplug
Tracked-On: https://jira.devtools.intel.com/browse/OAM-73760
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>