### PR TITLE
Add GetFrameBufferManager function in GpuDevice

### DIFF
--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -40,12 +40,11 @@ Compositor::Compositor() {
 Compositor::~Compositor() {
 }
 
-void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd,
-                      FrameBufferManager *frame_buffer_manager) {
+void Compositor::Init(ResourceManager *resource_manager, uint32_t gpu_fd) {
   if (!thread_)
     thread_.reset(new CompositorThread());
 
-  thread_->Initialize(resource_manager, gpu_fd, frame_buffer_manager);
+  thread_->Initialize(resource_manager, gpu_fd);
 }
 
 void Compositor::BeginFrame(bool disable_explicit_sync) {
@@ -175,7 +174,6 @@ bool Compositor::DrawOffscreen(std::vector<OverlayLayer> &layers,
                                const std::vector<HwcRect<int>> &display_frame,
                                const std::vector<size_t> &source_layers,
                                ResourceManager *resource_manager,
-                               FrameBufferManager *framebuffer_manager,
                                uint32_t width, uint32_t height,
                                HWCNativeHandle output_handle,
                                int32_t acquire_fence, int32_t *retire_fence) {
@@ -200,8 +198,7 @@ bool Compositor::DrawOffscreen(std::vector<OverlayLayer> &layers,
   }
 
   NativeSurface *surface = Create3DSurface(width, height);
-  surface->InitializeForOffScreenRendering(output_handle, resource_manager,
-                                           framebuffer_manager);
+  surface->InitializeForOffScreenRendering(output_handle, resource_manager);
   std::vector<DrawState> draw;
   std::vector<DrawState> media;
   draw.emplace_back();

--- a/common/compositor/compositor.h
+++ b/common/compositor/compositor.h
@@ -41,8 +41,7 @@ class Compositor {
   Compositor &operator=(const Compositor &) = delete;
   ~Compositor();
 
-  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd,
-            FrameBufferManager *frame_buffer_manager);
+  void Init(ResourceManager *buffer_manager, uint32_t gpu_fd);
   void Reset();
   void BeginFrame(bool disable_explicit_sync);
   bool Draw(DisplayPlaneStateList &planes, std::vector<OverlayLayer> &layers,
@@ -50,8 +49,7 @@ class Compositor {
   bool DrawOffscreen(std::vector<OverlayLayer> &layers,
                      const std::vector<HwcRect<int>> &display_frame,
                      const std::vector<size_t> &source_layers,
-                     ResourceManager *resource_manager,
-                     FrameBufferManager *framebuffer_manager, uint32_t width,
+                     ResourceManager *resource_manager, uint32_t width,
                      uint32_t height, HWCNativeHandle output_handle,
                      int32_t acquire_fence, int32_t *retire_fence);
   void FreeResources();

--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -16,8 +16,10 @@
 
 #include "compositorthread.h"
 
+#include <nativebufferhandler.h>
 #include "displayplanemanager.h"
 #include "framebuffermanager.h"
+#include "gpudevice.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "nativegpuresource.h"
@@ -25,8 +27,6 @@
 #include "overlaylayer.h"
 #include "renderer.h"
 #include "resourcemanager.h"
-
-#include <nativebufferhandler.h>
 
 namespace hwcomposer {
 
@@ -41,9 +41,8 @@ CompositorThread::~CompositorThread() {
 }
 
 void CompositorThread::Initialize(ResourceManager *resource_manager,
-                                  uint32_t gpu_fd,
-                                  FrameBufferManager *frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+                                  uint32_t gpu_fd) {
+  fb_manager_ = GpuDevice::getInstance().GetFrameBufferManager();
   tasks_lock_.lock();
   if (!gpu_resource_handler_)
     gpu_resource_handler_.reset(CreateNativeGpuResourceHandler());

--- a/common/compositor/compositorthread.h
+++ b/common/compositor/compositorthread.h
@@ -43,8 +43,7 @@ class CompositorThread : public HWCThread {
   CompositorThread();
   ~CompositorThread() override;
 
-  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd,
-                  FrameBufferManager* frame_buffer_manager);
+  void Initialize(ResourceManager* resource_manager, uint32_t gpu_fd);
 
   bool Draw(std::vector<DrawState>& states,
             std::vector<DrawState>& media_states,

--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -18,6 +18,7 @@
 
 #include "displayplane.h"
 #include "displayplanestate.h"
+#include "gpudevice.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "nativebufferhandler.h"
@@ -44,9 +45,7 @@ NativeSurface::~NativeSurface() {
 
 bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
                          uint32_t usage, uint64_t modifier,
-                         bool *modifier_succeeded,
-                         FrameBufferManager *frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+                         bool *modifier_succeeded) {
   const NativeBufferHandler *handler =
       resource_manager->GetNativeBufferHandler();
   resource_manager_ = resource_manager;
@@ -94,10 +93,8 @@ bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
 }
 
 bool NativeSurface::InitializeForOffScreenRendering(
-    HWCNativeHandle native_handle, ResourceManager *resource_manager,
-    FrameBufferManager *framebuffer_manager) {
+    HWCNativeHandle native_handle, ResourceManager *resource_manager) {
   resource_manager_ = resource_manager;
-  fb_manager_ = framebuffer_manager;
   InitializeLayer(native_handle);
   layer_.SetSourceCrop(HwcRect<float>(0, 0, width_, height_));
   layer_.SetDisplayFrame(HwcRect<int>(0, 0, width_, height_));
@@ -214,7 +211,7 @@ void NativeSurface::ResetDamage() {
 
 void NativeSurface::InitializeLayer(HWCNativeHandle native_handle) {
   layer_.SetBlending(HWCBlending::kBlendingPremult);
-  layer_.SetBuffer(native_handle, -1, resource_manager_, false, fb_manager_);
+  layer_.SetBuffer(native_handle, -1, resource_manager_, false);
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/nativesurface.h
+++ b/common/compositor/nativesurface.h
@@ -44,12 +44,10 @@ class NativeSurface {
   virtual ~NativeSurface();
 
   bool Init(ResourceManager* resource_manager, uint32_t format, uint32_t usage,
-            uint64_t modifier, bool* modifier_succeeded,
-            FrameBufferManager* frame_buffer_manager);
+            uint64_t modifier, bool* modifier_succeeded);
 
-  bool InitializeForOffScreenRendering(
-      HWCNativeHandle native_handle, ResourceManager* resource_manager,
-      FrameBufferManager* frame_buffer_manager);
+  bool InitializeForOffScreenRendering(HWCNativeHandle native_handle,
+                                       ResourceManager* resource_manager);
 
   virtual bool MakeCurrent() {
     return false;
@@ -153,7 +151,6 @@ class NativeSurface {
   bool on_screen_ = false;
   HwcRect<int> previous_damage_;
   HwcRect<int> previous_nc_damage_;
-  FrameBufferManager* fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -69,6 +69,10 @@ bool GpuDevice::Initialize() {
   return true;
 }
 
+FrameBufferManager *GpuDevice::GetFrameBufferManager() {
+  return display_manager_->GetFrameBufferManager();
+}
+
 uint32_t GpuDevice::GetFD() const {
   return display_manager_->GetFD();
 }

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -35,8 +35,7 @@ LogicalDisplay::LogicalDisplay(LogicalDisplayManager *display_manager,
 LogicalDisplay::~LogicalDisplay() {
 }
 
-bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
-                                FrameBufferManager * /*frame_buffer_manager*/) {
+bool LogicalDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
   return true;
 }
 

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -35,8 +35,7 @@ class LogicalDisplay : public NativeDisplay {
                  uint32_t index);
   ~LogicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler,
-                  FrameBufferManager * /*frame_buffer_manager*/) override;
+  bool Initialize(NativeBufferHandler *buffer_handler) override;
 
   DisplayType Type() const override {
     return DisplayType::kLogical;

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -77,8 +77,7 @@ MosaicDisplay::MosaicDisplay(const std::vector<NativeDisplay *> &displays)
 MosaicDisplay::~MosaicDisplay() {
 }
 
-bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/,
-                               FrameBufferManager * /*frame_buffer_manager*/) {
+bool MosaicDisplay::Initialize(NativeBufferHandler * /*buffer_handler*/) {
   return true;
 }
 

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -32,8 +32,7 @@ class MosaicDisplay : public NativeDisplay {
   MosaicDisplay(const std::vector<NativeDisplay *> &displays);
   ~MosaicDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler,
-                  FrameBufferManager * /*frame_buffer_manager*/) override;
+  bool Initialize(NativeBufferHandler *buffer_handler) override;
 
   DisplayType Type() const override {
     return DisplayType::kMosaic;

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -87,8 +87,7 @@ std::shared_ptr<OverlayBuffer>& OverlayLayer::GetSharedBuffer() const {
 
 void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
                              ResourceManager* resource_manager,
-                             bool register_buffer,
-                             FrameBufferManager* frame_buffer_manager) {
+                             bool register_buffer) {
   std::shared_ptr<OverlayBuffer> buffer(NULL);
 
   uint32_t id;
@@ -101,8 +100,7 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
 
   if (buffer == NULL) {
     buffer = OverlayBuffer::CreateOverlayBuffer();
-    buffer->InitializeFromNativeHandle(handle, resource_manager,
-                                       frame_buffer_manager);
+    buffer->InitializeFromNativeHandle(handle, resource_manager);
     if (resource_manager && register_buffer) {
       resource_manager->RegisterBuffer(id, buffer);
     }
@@ -186,8 +184,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
                                    OverlayLayer* previous_layer,
                                    uint32_t z_order, uint32_t layer_index,
                                    uint32_t max_height, uint32_t rotation,
-                                   bool handle_constraints,
-                                   FrameBufferManager* frame_buffer_manager) {
+                                   bool handle_constraints) {
   transform_ = layer->GetTransform();
   if (rotation != kRotateNone) {
     ValidateTransform(layer->GetTransform(), rotation);
@@ -228,7 +225,7 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
 
   if (layer->GetNativeHandle()) {
     SetBuffer(layer->GetNativeHandle(), layer->GetAcquireFence(),
-              resource_manager, true, frame_buffer_manager);
+              resource_manager, true);
   } else if (Composition_SolidColor == layer->GetLayerCompositionType()) {
     type_ = kLayerSolidColor;
     source_crop_width_ = layer->GetDisplayFrameWidth();
@@ -374,25 +371,22 @@ void OverlayLayer::InitializeState(HwcLayer* layer,
 void OverlayLayer::InitializeFromHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
-    uint32_t max_height, uint32_t rotation, bool handle_constraints,
-    FrameBufferManager* frame_buffer_manager) {
+    uint32_t max_height, uint32_t rotation, bool handle_constraints) {
   display_frame_width_ = layer->GetDisplayFrameWidth();
   display_frame_height_ = layer->GetDisplayFrameHeight();
   display_frame_ = layer->GetDisplayFrame();
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints,
-                  frame_buffer_manager);
+                  max_height, rotation, handle_constraints);
 }
 
 void OverlayLayer::InitializeFromScaledHwcLayer(
     HwcLayer* layer, ResourceManager* resource_manager,
     OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
     const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
-    bool handle_constraints, FrameBufferManager* frame_buffer_manager) {
+    bool handle_constraints) {
   SetDisplayFrame(display_frame);
   InitializeState(layer, resource_manager, previous_layer, z_order, layer_index,
-                  max_height, rotation, handle_constraints,
-                  frame_buffer_manager);
+                  max_height, rotation, handle_constraints);
 }
 
 void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
@@ -496,8 +490,7 @@ void OverlayLayer::ValidateForOverlayUsage() {
 void OverlayLayer::CloneLayer(const OverlayLayer* layer,
                               const HwcRect<int>& display_frame,
                               ResourceManager* resource_manager,
-                              uint32_t z_order,
-                              FrameBufferManager* frame_buffer_manager) {
+                              uint32_t z_order) {
   int32_t fence = layer->GetAcquireFence();
   int32_t aquire_fence = 0;
   if (fence > 0) {
@@ -506,7 +499,7 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   SetDisplayFrame(display_frame);
   SetSourceCrop(layer->GetSourceCrop());
   SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
-            resource_manager, true, frame_buffer_manager);
+            resource_manager, true);
   ValidateForOverlayUsage();
   surface_damage_ = layer->GetSurfaceDamage();
   transform_ = layer->transform_;

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -49,14 +49,15 @@ struct OverlayLayer {
   void InitializeFromHwcLayer(HwcLayer* layer, ResourceManager* buffer_manager,
                               OverlayLayer* previous_layer, uint32_t z_order,
                               uint32_t layer_index, uint32_t max_height,
-                              uint32_t rotation, bool handle_constraints,
-                              FrameBufferManager* frame_buffer_manager);
+                              uint32_t rotation, bool handle_constraints);
 
-  void InitializeFromScaledHwcLayer(
-      HwcLayer* layer, ResourceManager* buffer_manager,
-      OverlayLayer* previous_layer, uint32_t z_order, uint32_t layer_index,
-      const HwcRect<int>& display_frame, uint32_t max_height, uint32_t rotation,
-      bool handle_constraints, FrameBufferManager* frame_buffer_manager);
+  void InitializeFromScaledHwcLayer(HwcLayer* layer,
+                                    ResourceManager* buffer_manager,
+                                    OverlayLayer* previous_layer,
+                                    uint32_t z_order, uint32_t layer_index,
+                                    const HwcRect<int>& display_frame,
+                                    uint32_t max_height, uint32_t rotation,
+                                    bool handle_constraints);
   // Get z order of this layer.
   uint32_t GetZorder() const {
     return z_order_;
@@ -100,8 +101,7 @@ struct OverlayLayer {
   OverlayBuffer* GetBuffer() const;
 
   void SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
-                 ResourceManager* buffer_manager, bool register_buffer,
-                 FrameBufferManager* frame_buffer_manager);
+                 ResourceManager* buffer_manager, bool register_buffer);
 
   std::shared_ptr<OverlayBuffer>& GetSharedBuffer() const;
 
@@ -243,8 +243,7 @@ struct OverlayLayer {
   }
 
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
-                  ResourceManager* resource_manager, uint32_t z_order,
-                  FrameBufferManager* frame_buffer_manager);
+                  ResourceManager* resource_manager, uint32_t z_order);
 
   void Dump();
 
@@ -281,8 +280,7 @@ struct OverlayLayer {
   void InitializeState(HwcLayer* layer, ResourceManager* buffer_manager,
                        OverlayLayer* previous_layer, uint32_t z_order,
                        uint32_t layer_index, uint32_t max_height,
-                       uint32_t rotation, bool handle_constraints,
-                       FrameBufferManager* frame_buffer_manager);
+                       uint32_t rotation, bool handle_constraints);
 
   uint32_t transform_ = 0;
   uint32_t plane_transform_ = 0;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -64,9 +64,7 @@ void DisplayPlaneManager::ResizeOverlays() {
   }
 }
 
-bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height,
-                                     FrameBufferManager *frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height) {
   width_ = width;
   height_ = height;
   bool status = plane_handler_->PopulatePlanes(overlay_planes_);
@@ -827,7 +825,7 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 
     bool modifer_succeeded = false;
     new_surface->Init(resource_manager_, preferred_format, usage, modifier,
-                      &modifer_succeeded, fb_manager_);
+                      &modifer_succeeded);
 
     if (modifer_succeeded) {
       plane.GetDisplayPlane()->PreferredFormatModifierValidated();

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -41,8 +41,7 @@ class DisplayPlaneManager {
 
   virtual ~DisplayPlaneManager();
 
-  bool Initialize(uint32_t width, uint32_t height,
-                  FrameBufferManager *frame_buffer_manager);
+  bool Initialize(uint32_t width, uint32_t height);
 
   bool ValidateLayers(std::vector<OverlayLayer> &layers, int add_index,
                       bool disable_overlay, bool *commit_checked,
@@ -203,7 +202,6 @@ class DisplayPlaneManager {
 #ifdef DISABLE_CURSOR_PLANE
   bool enable_last_plane_;
 #endif
-  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -71,9 +71,7 @@ DisplayQueue::~DisplayQueue() {
 }
 
 bool DisplayQueue::Initialize(uint32_t pipe, uint32_t width, uint32_t height,
-                              DisplayPlaneHandler* plane_handler,
-                              FrameBufferManager* frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+                              DisplayPlaneHandler* plane_handler) {
   if (!resource_manager_) {
     ETRACE("Failed to construct hwc layer buffer manager");
     return false;
@@ -81,7 +79,7 @@ bool DisplayQueue::Initialize(uint32_t pipe, uint32_t width, uint32_t height,
 
   display_plane_manager_.reset(
       new DisplayPlaneManager(plane_handler, resource_manager_.get()));
-  if (!display_plane_manager_->Initialize(width, height, fb_manager_)) {
+  if (!display_plane_manager_->Initialize(width, height)) {
     ETRACE("Failed to initialize DisplayPlane Manager.");
     return false;
   }
@@ -112,7 +110,7 @@ bool DisplayQueue::SetPowerMode(uint32_t power_mode) {
       vblank_handler_->SetPowerMode(kOn);
       power_mode_lock_.lock();
       state_ &= ~kIgnoreIdleRefresh;
-      compositor_.Init(resource_manager_.get(), gpu_fd_, fb_manager_);
+      compositor_.Init(resource_manager_.get(), gpu_fd_);
       power_mode_lock_.unlock();
       break;
     default:
@@ -582,12 +580,12 @@ void DisplayQueue::InitializeOverlayLayers(
       overlay_layer->InitializeFromScaledHwcLayer(
           layer, resource_manager_.get(), previous_layer, z_order, layer_index,
           display_frame, display_plane_manager_->GetHeight(), plane_transform_,
-          handle_constraints, fb_manager_);
+          handle_constraints);
     } else {
       overlay_layer->InitializeFromHwcLayer(
           layer, resource_manager_.get(), previous_layer, z_order, layer_index,
           display_plane_manager_->GetHeight(), plane_transform_,
-          handle_constraints, fb_manager_);
+          handle_constraints);
     }
 
     if (!overlay_layer->IsVisible()) {
@@ -1049,7 +1047,7 @@ void DisplayQueue::PresentClonedCommit(DisplayQueue* queue) {
     }
 
     layer.CloneLayer(previous_plane.GetOverlayLayer(), display_frame,
-                     resource_manager_.get(), layers.size() - 1, fb_manager_);
+                     resource_manager_.get(), layers.size() - 1);
 
     if (add_index != 0 && layer.IsVideoLayer()) {
       if ((previous_layer && !previous_layer->IsVideoLayer()) ||

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -62,8 +62,7 @@ class DisplayQueue {
   ~DisplayQueue();
 
   bool Initialize(uint32_t pipe, uint32_t width, uint32_t height,
-                  DisplayPlaneHandler* plane_manager,
-                  FrameBufferManager* frame_buffer_manager);
+                  DisplayPlaneHandler* plane_manager);
 
   bool QueueUpdate(std::vector<HwcLayer*>& source_layers, int32_t* retire_fence,
                    bool* ignore_clone_update, PixelUploaderCallback* call_back,
@@ -402,7 +401,6 @@ class DisplayQueue {
   // need to be marked as not in use during next
   // frame.
   std::vector<NativeSurface*> surfaces_not_inuse_;
-  FrameBufferManager* fb_manager_ = NULL;
   std::vector<HwcLayer*>* source_layers_ = NULL;
 };
 

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -36,8 +36,7 @@ class NativeBufferHandler;
 class VirtualDisplay : public NativeDisplay {
  public:
   VirtualDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
-                 FrameBufferManager *framebuffermanager, uint32_t pipe_id,
-                 uint32_t crtc_id);
+                 uint32_t pipe_id, uint32_t crtc_id);
   VirtualDisplay(const VirtualDisplay &) = delete;
   VirtualDisplay &operator=(const VirtualDisplay &) = delete;
   ~VirtualDisplay() override;
@@ -54,8 +53,7 @@ class VirtualDisplay : public NativeDisplay {
 
   void SetOutputBuffer(HWCNativeHandle buffer, int32_t acquire_fence) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler,
-                  FrameBufferManager *frame_buffer_manager) override;
+  bool Initialize(NativeBufferHandler *buffer_handler) override;
 
   DisplayType Type() const override {
     return DisplayType::kVirtual;
@@ -105,7 +103,6 @@ class VirtualDisplay : public NativeDisplay {
   std::vector<OverlayLayer> in_flight_layers_;
   HWCNativeHandle handle_ = 0;
   std::unique_ptr<ResourceManager> resource_manager_;
-  FrameBufferManager *fb_manager_ = NULL;
   uint32_t display_index_ = 0;
   bool discard_protected_video_ = false;
 

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -32,8 +32,7 @@
 namespace hwcomposer {
 
 VirtualPanoramaDisplay::VirtualPanoramaDisplay(
-    uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
-    FrameBufferManager *frame_buffer_manager, uint32_t pipe_id,
+    uint32_t gpu_fd, NativeBufferHandler *buffer_handler, uint32_t pipe_id,
     uint32_t /*crtc_id*/)
     : output_handle_(0),
       acquire_fence_(-1),
@@ -44,8 +43,7 @@ VirtualPanoramaDisplay::VirtualPanoramaDisplay(
   if (!resource_manager_) {
     ETRACE("Failed to construct hwc layer buffer manager");
   }
-  fb_manager_ = frame_buffer_manager;
-  compositor_.Init(resource_manager_.get(), gpu_fd, fb_manager_);
+  compositor_.Init(resource_manager_.get(), gpu_fd);
 }
 
 void VirtualPanoramaDisplay::InitHyperDmaBuf() {
@@ -177,8 +175,7 @@ void VirtualPanoramaDisplay::HyperDmaExport() {
 
   if (buffer == NULL) {
     buffer = OverlayBuffer::CreateOverlayBuffer();
-    buffer->InitializeFromNativeHandle(output_handle_, resource_manager_.get(),
-                                       fb_manager_);
+    buffer->InitializeFromNativeHandle(output_handle_, resource_manager_.get());
     resource_manager_->RegisterBuffer(id, buffer);
     imported_fd = buffer->GetPrimeFD();
     if (mHyperDmaBuf_Fd > 0 && imported_fd > 0) {
@@ -322,7 +319,7 @@ bool VirtualPanoramaDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
     overlay_layer.InitializeFromHwcLayer(
         layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-        height_, kIdentity, handle_constraints, fb_manager_);
+        height_, kIdentity, handle_constraints);
     index.emplace_back(z_order);
     layers_rects.emplace_back(overlay_layer.GetDisplayFrame());
 
@@ -427,8 +424,7 @@ void VirtualPanoramaDisplay::SetOutputBuffer(HWCNativeHandle buffer,
 }
 
 bool VirtualPanoramaDisplay::Initialize(
-    NativeBufferHandler * /*buffer_manager*/,
-    FrameBufferManager *frame_buffer_manager) {
+    NativeBufferHandler * /*buffer_manager*/) {
   return true;
 }
 

--- a/common/display/virtualpanoramadisplay.h
+++ b/common/display/virtualpanoramadisplay.h
@@ -36,7 +36,6 @@ class NativeBufferHandler;
 class VirtualPanoramaDisplay : public NativeDisplay {
  public:
   VirtualPanoramaDisplay(uint32_t gpu_fd, NativeBufferHandler *buffer_handler,
-                         FrameBufferManager *framebuffermanager,
                          uint32_t pipe_id, uint32_t crtc_id);
   VirtualPanoramaDisplay(const VirtualPanoramaDisplay &) = delete;
   VirtualPanoramaDisplay &operator=(const VirtualPanoramaDisplay &) = delete;
@@ -54,8 +53,7 @@ class VirtualPanoramaDisplay : public NativeDisplay {
 
   void SetOutputBuffer(HWCNativeHandle buffer, int32_t acquire_fence) override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler,
-                  FrameBufferManager *frame_buffer_manager) override;
+  bool Initialize(NativeBufferHandler *buffer_handler) override;
 
   bool IsConnected() const override {
     return true;
@@ -114,7 +112,6 @@ class VirtualPanoramaDisplay : public NativeDisplay {
   std::vector<OverlayLayer> in_flight_layers_;
   HWCNativeHandle handle_ = 0;
   std::unique_ptr<ResourceManager> resource_manager_;
-  FrameBufferManager *fb_manager_ = NULL;
   uint32_t display_index_ = 0;
   bool discard_protected_video_ = false;
   bool hyper_dmabuf_initialized = false;

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "displaymanager.h"
+#include "framebuffermanager.h"
 #include "hwcthread.h"
 #include "logicaldisplaymanager.h"
 #include "nativedisplay.h"
@@ -40,6 +41,8 @@ class GpuDevice : public HWCThread {
 
   // Open device.
   bool Initialize();
+
+  FrameBufferManager* GetFrameBufferManager();
 
   uint32_t GetFD() const;
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -72,8 +72,7 @@ class NativeDisplay {
   NativeDisplay(const NativeDisplay &rhs) = delete;
   NativeDisplay &operator=(const NativeDisplay &rhs) = delete;
 
-  virtual bool Initialize(NativeBufferHandler *buffer_handler,
-                          FrameBufferManager *frame_buffer_manager) = 0;
+  virtual bool Initialize(NativeBufferHandler *buffer_handler) = 0;
 
   virtual DisplayType Type() const = 0;
 

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -83,6 +83,8 @@ class DisplayManager {
   virtual void SetHDCPSRMForDisplay(uint32_t connector, const int8_t *SRM,
                                     uint32_t SRMLength) = 0;
   virtual void RemoveUnreservedPlanes() = 0;
+
+  virtual FrameBufferManager *GetFrameBufferManager() = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -23,8 +23,8 @@
 
 #include <hwcdefs.h>
 #include <nativebufferhandler.h>
-
 #include "framebuffermanager.h"
+#include "gpudevice.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "resourcemanager.h"
@@ -95,10 +95,9 @@ void DrmBuffer::Initialize(const HwcMeta& meta) {
                                   METADATA(gem_handles_));
 }
 
-void DrmBuffer::InitializeFromNativeHandle(
-    HWCNativeHandle handle, ResourceManager* resource_manager,
-    FrameBufferManager* frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
+                                           ResourceManager* resource_manager) {
+  fb_manager_ = GpuDevice::getInstance().GetFrameBufferManager();
   resource_manager_ = resource_manager;
   const NativeBufferHandler* handler =
       resource_manager_->GetNativeBufferHandler();

--- a/wsi/drm/drmbuffer.h
+++ b/wsi/drm/drmbuffer.h
@@ -36,9 +36,8 @@ class DrmBuffer : public OverlayBuffer {
 
   ~DrmBuffer() override;
 
-  void InitializeFromNativeHandle(
-      HWCNativeHandle handle, ResourceManager* buffer_manager,
-      FrameBufferManager* frame_buffer_manager) override;
+  void InitializeFromNativeHandle(HWCNativeHandle handle,
+                                  ResourceManager* buffer_manager) override;
 
   uint32_t GetDataSpace() const override {
     return METADATA(dataspace_);

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -170,15 +170,16 @@ void DrmDisplayManager::HandleWait() {
 void DrmDisplayManager::InitializeDisplayResources() {
   buffer_handler_.reset(NativeBufferHandler::CreateInstance(fd_));
   frame_buffer_manager_.reset(new FrameBufferManager(fd_));
+  ETRACE("frame buffer manager is %d", frame_buffer_manager_.get());
   if (!buffer_handler_) {
     ETRACE("Failed to create native buffer handler instance");
     return;
   }
 
   int size = displays_.size();
+  ETRACE("display size is %d", size);
   for (int i = 0; i < size; ++i) {
-    if (!displays_.at(i)->Initialize(buffer_handler_.get(),
-                                     frame_buffer_manager_.get())) {
+    if (!displays_.at(i)->Initialize(buffer_handler_.get())) {
       ETRACE("Failed to Initialize Display %d", i);
     }
   }
@@ -406,8 +407,7 @@ NativeDisplay *DrmDisplayManager::CreateVirtualDisplay(uint32_t display_index) {
   spin_lock_.lock();
   NativeDisplay *latest_display;
   std::unique_ptr<VirtualDisplay> display(
-      new VirtualDisplay(fd_, buffer_handler_.get(),
-                         frame_buffer_manager_.get(), display_index, 0));
+      new VirtualDisplay(fd_, buffer_handler_.get(), display_index, 0));
   virtual_displays_.emplace_back(std::move(display));
   size_t size = virtual_displays_.size();
   latest_display = virtual_displays_.at(size - 1).get();
@@ -556,6 +556,10 @@ void DrmDisplayManager::RemoveUnreservedPlanes() {
       displays_.at(i)->ReleaseUnreservedPlanes(reserved_planes);
     displays_.at(i)->SetPlanesUpdated(true);
   }
+}
+
+FrameBufferManager *DrmDisplayManager::GetFrameBufferManager() {
+  return frame_buffer_manager_.get();
 }
 
 #ifdef ENABLE_PANORAMA

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -93,6 +93,8 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
                             uint32_t SRMLength) override;
   void RemoveUnreservedPlanes() override;
 
+  FrameBufferManager *GetFrameBufferManager() override;
+
  protected:
   void HandleWait() override;
   void HandleRoutine() override;

--- a/wsi/overlaybuffer.h
+++ b/wsi/overlaybuffer.h
@@ -41,9 +41,8 @@ class OverlayBuffer {
   virtual ~OverlayBuffer() {
   }
 
-  virtual void InitializeFromNativeHandle(
-      HWCNativeHandle handle, ResourceManager* buffer_manager,
-      FrameBufferManager* frame_buffer_manager) = 0;
+  virtual void InitializeFromNativeHandle(HWCNativeHandle handle,
+                                          ResourceManager* buffer_manager) = 0;
 
   virtual uint32_t GetDataSpace() const = 0;
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -45,9 +45,7 @@ PhysicalDisplay::PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id)
 PhysicalDisplay::~PhysicalDisplay() {
 }
 
-bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler,
-                                 FrameBufferManager *frame_buffer_manager) {
-  fb_manager_ = frame_buffer_manager;
+bool PhysicalDisplay::Initialize(NativeBufferHandler *buffer_handler) {
   display_queue_.reset(new DisplayQueue(gpu_fd_, false, buffer_handler, this));
   InitializeDisplay();
   return true;
@@ -167,7 +165,7 @@ void PhysicalDisplay::Connect() {
   display_state_ |= kNotifyClient;
   IHOTPLUGEVENTTRACE("PhysicalDisplay::Connect recieved. %p \n", this);
 
-  if (!display_queue_->Initialize(pipe_, width_, height_, this, fb_manager_)) {
+  if (!display_queue_->Initialize(pipe_, width_, height_, this)) {
     ETRACE("Failed to initialize Display Queue.");
   } else {
     display_state_ |= kInitialized;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -43,8 +43,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   PhysicalDisplay(uint32_t gpu_fd, uint32_t pipe_id);
   ~PhysicalDisplay() override;
 
-  bool Initialize(NativeBufferHandler *buffer_handler,
-                  FrameBufferManager *frame_buffer_manager) override;
+  bool Initialize(NativeBufferHandler *buffer_handler) override;
 
   DisplayType Type() const override {
     return DisplayType::kInternal;
@@ -311,7 +310,6 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   NativeDisplay *source_display_ = NULL;
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
-  FrameBufferManager *fb_manager_ = NULL;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
Reduce pass FrameBufferManager as parameter, use this
function to get FrameBufferManager.

Change-Id: I0c6d8b085332e1c01162e98d1744cfcf5f359644
Tracked-On: None
Tests: Compile success and system without any issue.
Signed-off-by: HeYue <yue.he@intel.com>