### PR TITLE
Suppress const cast warnings restricted to source line number

### DIFF
--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -69,6 +69,8 @@ inline uint32_t GetNativeBuffer(uint32_t gpu_fd, HWCNativeHandle handle) {
   return id;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 inline bool IsBufferProtected(HWCNativeHandle handle) {
   auto gr_handle = (const struct cros_gralloc_handle*)handle->handle_;
   if (gr_handle->consumer_usage & GRALLOC1_PRODUCER_USAGE_PROTECTED) {
@@ -76,6 +78,7 @@ inline bool IsBufferProtected(HWCNativeHandle handle) {
   }
   return false;
 }
+#pragma GCC diagnostic pop
 
 // _cplusplus
 #ifdef _cplusplus


### PR DESCRIPTION
This patch suppresses the following warning:
"warning: cast from 'const native_handle *' to 'cros_gralloc_handle *' drops const qualifier"

Fix suppresses repeated occurrences of above warning, including the corresponding details
related to the warning.  This restricts the suppression of the warning only to the line number
where the warning is being generated in the source file, and effectively cleans the build output.

Change-Id: None
Tracked-On:https://jira.devtools.intel.com/browse/OAM-75948
Tests: Confirmed warning is suppressed only on targeted source line number
Signed-off-by: Michele Lim <michele.lim@intel.com>