### PR TITLE
Only invoke VPP when video layer exist

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -143,7 +143,8 @@ bool DisplayPlaneManager::ValidateLayers(
     avail_planes--;
   // If video layers is more than available planes
   // We are going to force all the layers bo be composited by VA path
-  if (video_layers >= avail_planes) {
+  // cursor layer should not be handle by VPP
+  if (video_layers >= avail_planes && video_layers > 0) {
     ForceVppForAllLayers(commit_planes, composition, layers, add_index,
                          mark_later, false);
     *re_validation_needed = false;


### PR DESCRIPTION
When validating layer for cursor. Both size of video layer and overlay plane
are 0. and meet 0 >= 0 error to invoke VPP

Change-Id: I5224b85dd90ff3f4ef3d679a6a19e51f33754145
Test: Cursor layer show correct in video playing
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>