### PR TITLE
Fix the Rect size in play video with overlay plane

### DIFF
--- a/common/compositor/va/varenderer.h
+++ b/common/compositor/va/varenderer.h
@@ -114,6 +114,16 @@ class VARenderer : public Renderer {
   void DestroyContext();
   bool LoadCaps();
   bool UpdateCaps();
+
+  bool GetVideoLayerRect(OverlayLayer* layer_out, OverlayLayer* layer_in,
+                         VARectangle* surface_region,
+                         VARectangle* output_region);
+  bool GetNormalLayerRect(OverlayLayer* layer_out, OverlayLayer* layer_in,
+                          VARectangle* surface_region,
+                          VARectangle* output_region);
+  bool GetLayerRect(OverlayLayer* layer_out, OverlayLayer* layer_in,
+                    VARectangle* surface_region, VARectangle* output_region);
+
 #if VA_MAJOR_VERSION >= 1
   void HWCTransformToVA(uint32_t transform, uint32_t& rotation,
                         uint32_t& mirror);


### PR DESCRIPTION
With overlay plane, the output region need to be same with displayframe
for normal layer. and need to be assigned with source_crop for video layer

Change-Id: If6e021653671b8b202bda9ae2a10bed7009c00da
Tests: Play video correct with/without overlay plane
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>