### PR TITLE
Disable PlaneScale for video plane

### DIFF
--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -249,11 +249,16 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   HwcRect<int> layer_out_disp_frame = layer_out->GetDisplayFrame();
   int xtranslation = layer_out_disp_frame.left;
   int ytranslation = layer_out_disp_frame.top;
+  HwcRect<float> source_rect;
+  source_rect.top = source_rect.left = 0.0;
+  source_rect.right = layer_out->GetDisplayFrameWidth();
+  source_rect.bottom = layer_out->GetDisplayFrameHeight();
+  layer_out->SetSourceCrop(source_rect);
 
   const MediaResourceHandle& out_resource =
       layer_out->GetBuffer()->GetMediaResource(
           va_display_, layer_out->GetDisplayFrameWidth(),
-          layer_out->GetDisplayFrameWidth());
+          layer_out->GetDisplayFrameHeight());
   VASurfaceID surface_out = out_resource.surface_;
   if (surface_out == VA_INVALID_ID) {
     ETRACE("Failed to create Va Output Surface. \n");

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -660,7 +660,10 @@ void DisplayPlaneManager::ValidateForDisplayScaling(
 
   // Display frame and Source rect are different, let's check if
   // we can take advantage of scalars attached to this plane.
-  last_plane.UsePlaneScalar(true, false);
+  if (last_plane.IsVideoPlane())
+    last_plane.UsePlaneScalar(false, false);
+  else
+    last_plane.UsePlaneScalar(true, false);
 
   OverlayPlane &last_overlay_plane = commit_planes.back();
   last_overlay_plane.layer = last_plane.GetOverlayLayer();


### PR DESCRIPTION
Video plane can be scaled by VAAPI. set false in UsePlaneScale.

Change-Id: I305ac6c419c8bcd7c86a3eafe60481cdc15baf01
Tests: Play video correct with/without overlay plane
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>