### PR TITLE
Fix the null pointer and out-of array issues found by kclocwork

### DIFF
--- a/common/compositor/gl/glsurface.cpp
+++ b/common/compositor/gl/glsurface.cpp
@@ -33,6 +33,10 @@ GLSurface::~GLSurface() {
 bool GLSurface::InitializeGPUResources() {
   EGLDisplay egl_display = eglGetCurrentDisplay();
   // Create EGLImage.
+  if (!layer_.GetBuffer()) {
+    ETRACE("Failed to get layer buffer for EGL image");
+    return false;
+  }
   const ResourceHandle& import =
       layer_.GetBuffer()->GetGpuResource(egl_display, false);
 

--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -67,7 +67,8 @@ bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
   InitializeLayer(native_handle);
 
   if (modifier_used && modifier > 0) {
-    if (!layer_.GetBuffer()->CreateFrameBufferWithModifier(modifier)) {
+    if (!layer_.GetBuffer() ||
+        !layer_.GetBuffer()->CreateFrameBufferWithModifier(modifier)) {
       WTRACE("FB creation failed with modifier, removing modifier usage\n");
       ResourceHandle temp;
       temp.handle_ = native_handle;
@@ -142,7 +143,7 @@ void NativeSurface::SetPlaneTarget(const DisplayPlaneState &plane) {
   damage_changed_ = true;
   on_screen_ = false;
   surface_age_ = 0;
-  if (layer_.GetBuffer()->GetFb() == 0) {
+  if (layer_.GetBuffer() && layer_.GetBuffer()->GetFb() == 0) {
     ETRACE("SetPlaneTarget unable to create framebuffer for nativesurface");
   }
 }

--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -255,6 +255,10 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   source_rect.bottom = layer_out->GetDisplayFrameHeight();
   layer_out->SetSourceCrop(source_rect);
 
+  if (!layer_out->GetBuffer()) {
+    ETRACE("Failed to get layer_out Buffer.");
+    return false;
+  }
   const MediaResourceHandle& out_resource =
       layer_out->GetBuffer()->GetMediaResource(
           va_display_, layer_out->GetDisplayFrameWidth(),

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -498,8 +498,10 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   }
   SetDisplayFrame(display_frame);
   SetSourceCrop(layer->GetSourceCrop());
-  SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
-            resource_manager, true);
+  if (layer->GetBuffer()) {
+    SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
+              resource_manager, true);
+  }
   ValidateForOverlayUsage();
   surface_damage_ = layer->GetSurfaceDamage();
   transform_ = layer->transform_;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -860,6 +860,9 @@ bool DisplayPlaneManager::FallbacktoGPU(
   if (!target_plane->ValidateLayer(layer))
     return true;
 
+  if (!layer->GetBuffer())
+    return true;
+
   if (layer->GetBuffer()->GetFb() == 0) {
     return true;
   }

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -91,8 +91,9 @@ VirtualPanoramaDisplay::~VirtualPanoramaDisplay() {
     temp.handle_ = handle_;
     resource_manager_->MarkResourceForDeletion(temp, false);
   }
-
-  delete output_handle_;
+  if (output_handle_) {
+    delete output_handle_;
+  }
   std::vector<OverlayLayer>().swap(in_flight_layers_);
 
   resource_manager_->PurgeBuffer();
@@ -213,7 +214,7 @@ void VirtualPanoramaDisplay::HyperDmaExport() {
   char index[15];
   mHyperDmaExportedBuffers[buffer->GetPrimeFD()].surf_index = surf_index;
   memset(index, 0, sizeof(index));
-  sprintf(index, "Cluster_%d", surf_index);
+  snprintf(index, sizeof(index), "Cluster_%d", surf_index);
   strncpy(mHyperDmaExportedBuffers[buffer->GetPrimeFD()].surface_name, index,
           SURFACE_NAME_LENGTH);
   mHyperDmaExportedBuffers[buffer->GetPrimeFD()].hyper_dmabuf_id =

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -467,6 +467,11 @@ bool DrmPlane::ValidateLayer(const OverlayLayer* layer) {
     return false;
   }
 
+  if (!layer->GetBuffer()) {
+    IDISPLAYMANAGERTRACE("Layer buffer is not available for using Overlay");
+    return false;
+  }
+
   if (!IsSupportedFormat(layer->GetBuffer()->GetFormat())) {
     IDISPLAYMANAGERTRACE(
         "Layer cannot be supported as format is not supported.");


### PR DESCRIPTION
Add null pointer checking and correct the array format for fixing
the issues found by kclocwork on https://kw-jenkins.ostc.intel.com/
job/AndroidKW181_pmr0_bxtp_ivi_acrn_stable_gordon_peak/8/artifact/
BuildData/HTML/kw_issues_GFXOpenSourceDisplay.html

Change-Id: Ie7b51975cd0c20062b5da089da3ce275b772c11b
Tracked-On: https://jira.devtools.intel.com/browse/OAM-76317
Tests: Compile sucessful for Android. Pass dev testing.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>