### PR TITLE
Reuse last overlay plane on ACRN when multi monitors connected

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -165,11 +165,6 @@ ifeq ($(shell test $(ANDROID_VERSION) -ge 9; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += libnativewindow
 endif
 
-ifeq ($(strip $(BOARD_CURSOR_WA)), true)
-LOCAL_CPPFLAGS += \
-	-DDISABLE_CURSOR_PLANE
-endif
-
 LOCAL_CPPFLAGS += \
        -DMODIFICATOR_WA
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -53,11 +53,6 @@ LOCAL_CFLAGS += \
 	-DUSE_VNDK
 endif
 
-ifeq ($(strip $(BOARD_CURSOR_WA)), true)
-LOCAL_CPPFLAGS += \
-	-DDISABLE_CURSOR_PLANE
-endif
-
 #LOCAL_CPPFLAGS += \
 #	-DENABLE_DOWNSCALING
 

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -48,17 +48,11 @@ void DisplayPlaneManager::ResizeOverlays() {
     total_overlays_ = overlay_planes_.size();
     if (total_overlays_ > 1) {
       cursor_plane_ = overlay_planes_.back().get();
-      bool needs_cursor_wa = false;
-#ifdef DISABLE_CURSOR_PLANE
-      needs_cursor_wa = overlay_planes_.size() > 3;
-#endif
       // If this is a universal plane, let's not restrict it to
       // cursor usage only.
-      if (!needs_cursor_wa && cursor_plane_->IsUniversal()) {
+      if (cursor_plane_->IsUniversal()) {
         cursor_plane_ = NULL;
-      }
-
-      if (needs_cursor_wa || (cursor_plane_ && !cursor_plane_->IsUniversal())) {
+      } else {
         total_overlays_--;
       }
     }
@@ -163,13 +157,7 @@ bool DisplayPlaneManager::ValidateLayers(
   if (layer_begin != layer_end) {
     auto overlay_end = overlay_planes_.end();
     if (cursor_plane_) {
-#ifdef DISABLE_CURSOR_PLANE
       overlay_end = overlay_planes_.end() - 1;
-#else
-      if (!cursor_plane_->IsUniversal()) {
-        overlay_end = overlay_planes_.end() - 1;
-      }
-#endif
     }
 
     // Handle layers for overlays.
@@ -467,11 +455,6 @@ void DisplayPlaneManager::ValidateCursorLayer(
     overlay_begin = overlay_planes_.begin() + composition.size();
   }
 
-#ifdef DISABLE_CURSOR_PLANE
-  overlay_end = overlay_planes_.end() - 1;
-  if (total_size == 1)
-    overlay_begin = overlay_planes_.begin() + composition.size();
-#endif
   for (auto j = overlay_begin; j < overlay_end; ++j) {
     if (cursor_index == total_size)
       break;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -37,12 +37,7 @@ DisplayPlaneManager::DisplayPlaneManager(DisplayPlaneHandler *plane_handler,
       height_(0),
       total_overlays_(0),
       display_transform_(kIdentity),
-#ifdef DISABLE_CURSOR_PLANE
-      release_surfaces_(false),
-      enable_last_plane_(true) {
-#else
       release_surfaces_(false) {
-#endif
 }
 
 DisplayPlaneManager::~DisplayPlaneManager() {
@@ -53,11 +48,17 @@ void DisplayPlaneManager::ResizeOverlays() {
     total_overlays_ = overlay_planes_.size();
     if (total_overlays_ > 1) {
       cursor_plane_ = overlay_planes_.back().get();
+      bool needs_cursor_wa = false;
+#ifdef DISABLE_CURSOR_PLANE
+      needs_cursor_wa = overlay_planes_.size() > 3;
+#endif
       // If this is a universal plane, let's not restrict it to
       // cursor usage only.
-      if (cursor_plane_->IsUniversal()) {
+      if (!needs_cursor_wa && cursor_plane_->IsUniversal()) {
         cursor_plane_ = NULL;
-      } else {
+      }
+
+      if (needs_cursor_wa || (cursor_plane_ && !cursor_plane_->IsUniversal())) {
         total_overlays_--;
       }
     }
@@ -161,15 +162,15 @@ bool DisplayPlaneManager::ValidateLayers(
 
   if (layer_begin != layer_end) {
     auto overlay_end = overlay_planes_.end();
-#ifdef DISABLE_CURSOR_PLANE
-    if (!enable_last_plane_ || cursor_plane_) {
-      overlay_end = overlay_planes_.end() - 1;
-    }
-#else
     if (cursor_plane_) {
+#ifdef DISABLE_CURSOR_PLANE
       overlay_end = overlay_planes_.end() - 1;
-    }
+#else
+      if (!cursor_plane_->IsUniversal()) {
+        overlay_end = overlay_planes_.end() - 1;
+      }
 #endif
+    }
 
     // Handle layers for overlays.
     auto j = overlay_begin;
@@ -413,7 +414,8 @@ DisplayPlaneState *DisplayPlaneManager::GetLastUsedOverlay(
   size_t size = composition.size();
   for (size_t i = size; i > 0; i--) {
     DisplayPlaneState &plane = composition.at(i - 1);
-    if (cursor_plane_ && (cursor_plane_ == plane.GetDisplayPlane()))
+    if (cursor_plane_ && (cursor_plane_ == plane.GetDisplayPlane()) &&
+        (!cursor_plane_->IsUniversal()))
       continue;
 
     last_plane = &plane;
@@ -466,11 +468,9 @@ void DisplayPlaneManager::ValidateCursorLayer(
   }
 
 #ifdef DISABLE_CURSOR_PLANE
-  if (!enable_last_plane_) {
-    overlay_end = overlay_planes_.end() - 1;
-    if (total_size == 1)
-      overlay_begin = overlay_planes_.begin() + composition.size();
-  }
+  overlay_end = overlay_planes_.end() - 1;
+  if (total_size == 1)
+    overlay_begin = overlay_planes_.begin() + composition.size();
 #endif
   for (auto j = overlay_begin; j < overlay_end; ++j) {
     if (cursor_index == total_size)
@@ -479,8 +479,6 @@ void DisplayPlaneManager::ValidateCursorLayer(
     DisplayPlane *plane = j->get();
     if (plane->InUse()) {
       ITRACE("Trying to use a plane for cursor which is already in use. \n");
-      last_plane = NULL;
-      break;
     }
 
     OverlayLayer *cursor_layer = cursor_layers.at(cursor_index);
@@ -734,39 +732,6 @@ void DisplayPlaneManager::ReleaseFreeOffScreenTargets(bool forced) {
 
   surfaces.swap(surfaces_);
   release_surfaces_ = false;
-}
-
-void DisplayPlaneManager::SetLastPlaneUsage(bool enable) {
-#ifdef DISABLE_CURSOR_PLANE
-  if (total_overlays_ < 3 && enable_last_plane_) {
-    // If planes are less than 3, we don't need to enable any W/A.
-    // enable_last_plane_ needs to be checked to handle case where
-    // we manually decremented total_overlays_ in any previous
-    // calls.
-    return;
-  }
-
-  if (enable_last_plane_ != enable) {
-    enable_last_plane_ = enable;
-    // If we have cursor plane, we can use all overlays and just
-    // ignore cursor plane in case  W/A need's to be enabled.
-    if (cursor_plane_) {
-      return;
-    }
-
-    // We are running on a hypervisor. We could
-    // be sharing plane with others.
-    if (enable) {
-      total_overlays_++;
-      enable_last_plane_ = true;
-    } else {
-      total_overlays_--;
-      enable_last_plane_ = false;
-    }
-  }
-#else
-  HWC_UNUSED(enable);
-#endif
 }
 
 void DisplayPlaneManager::SetDisplayTransform(uint32_t transform) {

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -92,8 +92,6 @@ class DisplayPlaneManager {
     return total_overlays_;
   }
 
-  void SetLastPlaneUsage(bool enable);
-
   // Transform to be applied to all planes associated
   // with pipe of this displayplanemanager.
   void SetDisplayTransform(uint32_t transform);
@@ -199,9 +197,6 @@ class DisplayPlaneManager {
   uint32_t total_overlays_;
   uint32_t display_transform_;
   bool release_surfaces_;
-#ifdef DISABLE_CURSOR_PLANE
-  bool enable_last_plane_;
-#endif
 };
 
 }  // namespace hwcomposer

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -85,7 +85,6 @@ bool DisplayQueue::Initialize(uint32_t pipe, uint32_t width, uint32_t height,
   }
 
   display_plane_manager_->SetDisplayTransform(plane_transform_);
-  display_plane_manager_->SetLastPlaneUsage(!enable_wa_);
   ResetQueue();
   vblank_handler_->SetPowerMode(kOff);
   vblank_handler_->Init(gpu_fd_, pipe);
@@ -1219,15 +1218,6 @@ void DisplayQueue::PresentClonedCommit(DisplayQueue* queue) {
     if (source_layers != NULL)
       SetReleaseFenceToLayers(kms_fence_, *source_layers);
   }
-}
-
-void DisplayQueue::NotifyDisplayWA(bool enable_wa) {
-  if (enable_wa_ == enable_wa)
-    return;
-
-  enable_wa_ = enable_wa;
-  if (display_plane_manager_)
-    display_plane_manager_->SetLastPlaneUsage(!enable_wa_);
 }
 
 void DisplayQueue::SetCloneMode(bool cloned) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -112,8 +112,6 @@ class DisplayQueue {
 
   void PresentClonedCommit(DisplayQueue* queue);
 
-  void NotifyDisplayWA(bool enable_wa);
-
   const DisplayPlaneStateList& GetCurrentCompositionPlanes() const {
     return previous_plane_state_;
   }
@@ -381,7 +379,6 @@ class DisplayQueue {
   SpinLock power_mode_lock_;
   // to disable hwclock monitoring.
   bool handle_display_initializations_ = true;
-  bool enable_wa_ = false;
   uint32_t plane_transform_ = kIdentity;
   SpinLock video_lock_;
   bool requested_video_effect_ = false;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -367,24 +367,6 @@ bool DrmDisplayManager::UpdateDisplayState() {
 
 void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
   spin_lock_.lock();
-  bool disable_last_plane_usage = false;
-  uint32_t total_connected_displays = 0;
-  for (auto &display : displays_) {
-    if (display->IsConnected()) {
-      display->NotifyClientOfDisConnectedState();
-      total_connected_displays++;
-    }
-
-    if (total_connected_displays > 1) {
-      disable_last_plane_usage = true;
-      break;
-    }
-  }
-
-  for (auto &display : displays_) {
-    display->NotifyDisplayWA(disable_last_plane_usage);
-    display->ForceRefresh();
-  }
 
   for (auto &display : displays_) {
     if (!display->IsConnected()) {

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -70,6 +70,7 @@ void PhysicalDisplay::MarkForDisconnect() {
 
 void PhysicalDisplay::NotifyClientOfConnectedState() {
   SPIN_LOCK(modeset_lock_);
+  bool refresh_needed = false;
   if (hotplug_callback_ && (connection_state_ & kConnected) &&
       (display_state_ & kNotifyClient)) {
     IHOTPLUGEVENTTRACE(
@@ -78,8 +79,19 @@ void PhysicalDisplay::NotifyClientOfConnectedState() {
         this, hot_plug_display_id_);
     hotplug_callback_->Callback(hot_plug_display_id_, true);
     display_state_ &= ~kNotifyClient;
+#ifdef ENABLE_ANDROID_WA
+    if (ordered_display_id_ == 0) {
+      refresh_needed = true;
+    }
+#endif
   }
   SPIN_UNLOCK(modeset_lock_);
+
+  if (refresh_needed) {
+    if (!display_queue_->IsIgnoreUpdates()) {
+      display_queue_->ForceRefresh();
+    }
+  }
 }
 
 void PhysicalDisplay::NotifyClientOfDisConnectedState() {
@@ -118,21 +130,6 @@ void PhysicalDisplay::DisConnect() {
 
   connection_state_ &= ~kConnected;
   display_state_ &= ~kUpdateDisplay;
-  SPIN_UNLOCK(modeset_lock_);
-}
-
-void PhysicalDisplay::NotifyDisplayWA(bool enable_wa) {
-  SPIN_LOCK(modeset_lock_);
-  display_queue_->NotifyDisplayWA(enable_wa);
-  SPIN_UNLOCK(modeset_lock_);
-}
-
-void PhysicalDisplay::ForceRefresh() {
-  SPIN_LOCK(modeset_lock_);
-  if ((connection_state_ & kConnected) &&
-      (!display_queue_->IsIgnoreUpdates())) {
-    display_queue_->ForceRefresh();
-  }
   SPIN_UNLOCK(modeset_lock_);
 }
 

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -241,17 +241,6 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   void NotifyClientOfDisConnectedState();
 
   /**
-  * API for ensuring DisplayQueue can handle any W/A needed for
-  * Multi plane/multi port cases.
-  */
-  void NotifyDisplayWA(bool enable_wa);
-
-  /**
-  * API to refresh display in case of hot plug event.
-  */
-  void ForceRefresh();
-
-  /**
   * API to disconnect the display. This is called when this display
   * is physically disconnected.
   */


### PR DESCRIPTION
The last overlay plane is disabled in past due to APL not
reboot when multi monitors are connected. Now this issue
is not reproduced any more. We add the last overlay plane
back, which could help improve browser kinetic panning frame
rate with 2 displays.

Change-Id: I6a27202d822dc80433f4b5d20048472cf37f4ed8
Tracked-On: OAM-76190
Signed-off-by: Lin Johnson <johnson.lin@intel.com>
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Signed-off-by: HeYue <yue.he@intel.com>