### PR TITLE
Delete the output buffer when it is same as output_handle_

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -436,6 +436,8 @@ void VirtualDisplay::SetOutputBuffer(HWCNativeHandle buffer,
     if (output_handle_) {
       handler->CopyHandle(output_handle_, &handle_);
     }
+  } else {
+    delete buffer;
   }
 
   if (acquire_fence_ > 0) {

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -412,6 +412,8 @@ void VirtualPanoramaDisplay::SetOutputBuffer(HWCNativeHandle buffer,
     if (output_handle_) {
       handler->CopyHandle(output_handle_, &handle_);
     }
+  } else {
+    delete buffer;
   }
 
   if (acquire_fence_ > 0) {


### PR DESCRIPTION
In ACRN virtualdisplay setoutput buffer, if the buffer is same as output_handle_
and output_handle_ is not null, delete the buffer to prevent memory leak.

Change-Id: I558f31aea3315481f3a00c1fef1202bb7eb124f1
Tracked-On: None
Tests: Compile sucess for ACRN and baremetal. System without issue.
Signed-off-by: HeYue <yue.he@intel.com>