### PR TITLE
Last_plane should not be handled as cursor plane when cursor_plane is…

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -451,7 +451,7 @@ void DisplayPlaneManager::ValidateCursorLayer(
   uint32_t cursor_index = 0;
   auto overlay_end = overlay_planes_.end();
   auto overlay_begin = overlay_end - 1;
-  if (total_size > 1) {
+  if (total_size > 1 || !cursor_plane_) {
     overlay_begin = overlay_planes_.begin() + composition.size();
   }
 


### PR DESCRIPTION
… not available

On ACRN, cursor plane is not available. if the last plane still be handled as
cursor plane. funtion 'FallbacktoGPU' will return false. and the cursor layer will
not be added.

Change-Id: I5f97fb5edf66c3423d8d54c5dd26eb8bcf9b3f91
Tracked-On: None
Tests: Compile sucessful for Android.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>