### PR TITLE
Follow klocwork coding guide for null checking.

### DIFF
--- a/common/compositor/gl/glsurface.cpp
+++ b/common/compositor/gl/glsurface.cpp
@@ -32,13 +32,14 @@ GLSurface::~GLSurface() {
 
 bool GLSurface::InitializeGPUResources() {
   EGLDisplay egl_display = eglGetCurrentDisplay();
+  OverlayBuffer* layer_buffer = layer_.GetBuffer();
   // Create EGLImage.
-  if (!layer_.GetBuffer()) {
+  if (!layer_buffer) {
     ETRACE("Failed to get layer buffer for EGL image");
     return false;
   }
   const ResourceHandle& import =
-      layer_.GetBuffer()->GetGpuResource(egl_display, false);
+      layer_buffer->GetGpuResource(egl_display, false);
 
   if (import.image_ == EGL_NO_IMAGE_KHR) {
     ETRACE("Failed to make EGL image.");

--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -67,8 +67,9 @@ bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
   InitializeLayer(native_handle);
 
   if (modifier_used && modifier > 0) {
-    if (!layer_.GetBuffer() ||
-        !layer_.GetBuffer()->CreateFrameBufferWithModifier(modifier)) {
+    OverlayBuffer *layer_buffer = layer_.GetBuffer();
+    if (!layer_buffer ||
+        !layer_buffer->CreateFrameBufferWithModifier(modifier)) {
       WTRACE("FB creation failed with modifier, removing modifier usage\n");
       ResourceHandle temp;
       temp.handle_ = native_handle;
@@ -143,7 +144,8 @@ void NativeSurface::SetPlaneTarget(const DisplayPlaneState &plane) {
   damage_changed_ = true;
   on_screen_ = false;
   surface_age_ = 0;
-  if (layer_.GetBuffer() && layer_.GetBuffer()->GetFb() == 0) {
+  OverlayBuffer *layer_buffer = layer_.GetBuffer();
+  if (layer_buffer && layer_buffer->GetFb() == 0) {
     ETRACE("SetPlaneTarget unable to create framebuffer for nativesurface");
   }
 }

--- a/common/compositor/renderstate.cpp
+++ b/common/compositor/renderstate.cpp
@@ -127,9 +127,10 @@ void RenderState::ConstructState(std::vector<OverlayLayer> &layers,
 
     float tex_width = 0;
     float tex_height = 0;
-    if (layer.GetBuffer()) {
-      tex_width = static_cast<float>(layer.GetBuffer()->GetWidth());
-      tex_height = static_cast<float>(layer.GetBuffer()->GetHeight());
+    OverlayBuffer *layer_buffer = layer.GetBuffer();
+    if (layer_buffer) {
+      tex_width = static_cast<float>(layer_buffer->GetWidth());
+      tex_height = static_cast<float>(layer_buffer->GetHeight());
     } else {
       tex_width = static_cast<float>(layer.GetSourceCropWidth());
       tex_height = static_cast<float>(layer.GetSourceCropHeight());

--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -255,14 +255,14 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   source_rect.bottom = layer_out->GetDisplayFrameHeight();
   layer_out->SetSourceCrop(source_rect);
 
-  if (!layer_out->GetBuffer()) {
+  OverlayBuffer* layer_out_buffer = layer_out->GetBuffer();
+  if (!layer_out_buffer) {
     ETRACE("Failed to get layer_out Buffer.");
     return false;
   }
-  const MediaResourceHandle& out_resource =
-      layer_out->GetBuffer()->GetMediaResource(
-          va_display_, layer_out->GetDisplayFrameWidth(),
-          layer_out->GetDisplayFrameHeight());
+  const MediaResourceHandle& out_resource = layer_out_buffer->GetMediaResource(
+      va_display_, layer_out->GetDisplayFrameWidth(),
+      layer_out->GetDisplayFrameHeight());
   VASurfaceID surface_out = out_resource.surface_;
   if (surface_out == VA_INVALID_ID) {
     ETRACE("Failed to create Va Output Surface. \n");

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -498,9 +498,10 @@ void OverlayLayer::CloneLayer(const OverlayLayer* layer,
   }
   SetDisplayFrame(display_frame);
   SetSourceCrop(layer->GetSourceCrop());
-  if (layer->GetBuffer()) {
-    SetBuffer(layer->GetBuffer()->GetOriginalHandle(), aquire_fence,
-              resource_manager, true);
+  OverlayBuffer* layer_buffer = layer->GetBuffer();
+  if (layer_buffer) {
+    SetBuffer(layer_buffer->GetOriginalHandle(), aquire_fence, resource_manager,
+              true);
   }
   ValidateForOverlayUsage();
   surface_damage_ = layer->GetSurfaceDamage();

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -808,10 +808,11 @@ bool DisplayPlaneManager::FallbacktoGPU(
   if (!target_plane->ValidateLayer(layer))
     return true;
 
-  if (!layer->GetBuffer())
+  OverlayBuffer *layer_buffer = layer->GetBuffer();
+  if (!layer_buffer)
     return true;
 
-  if (layer->GetBuffer()->GetFb() == 0) {
+  if (layer_buffer->GetFb() == 0) {
     return true;
   }
 

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -467,12 +467,13 @@ bool DrmPlane::ValidateLayer(const OverlayLayer* layer) {
     return false;
   }
 
-  if (!layer->GetBuffer()) {
+  OverlayBuffer* layer_buffer = layer->GetBuffer();
+  if (!layer_buffer) {
     IDISPLAYMANAGERTRACE("Layer buffer is not available for using Overlay");
     return false;
   }
 
-  if (!IsSupportedFormat(layer->GetBuffer()->GetFormat())) {
+  if (!IsSupportedFormat(layer_buffer->GetFormat())) {
     IDISPLAYMANAGERTRACE(
         "Layer cannot be supported as format is not supported.");
     return false;


### PR DESCRIPTION
Secure coding guidelines (and the reason Klocwork flagged this) state
that you should never assume multiple calls to a function will return
the same result, even if it is highly unlikely to change.

Change-Id: I710d34eeb767dcf5f83ba91bf637d1cf367f3baf
Tracked-On: https://jira.devtools.intel.com/browse/OAM-76669
Tests: Compile sucessful for Android.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>