### PR TITLE
An API for dropping DrmMaster and ignoring DRM commit

### DIFF
--- a/os/android/hwcservice.cpp
+++ b/os/android/hwcservice.cpp
@@ -409,6 +409,10 @@ bool HwcService::Controls::EnableDRMCommit(bool enable, uint32_t display_id) {
   return mHwc.EnableDRMCommit(enable, display_id);
 }
 
+bool HwcService::Controls::ResetDrmMaster(bool drop_master) {
+  return mHwc.ResetDrmMaster(drop_master);
+}
+
 status_t HwcService::Controls::VideoEnableEncryptedSession(
     uint32_t sessionID, uint32_t instanceID) {
   mHwc.SetPAVPSessionStatus(true, sessionID, instanceID);

--- a/os/android/hwcservice.h
+++ b/os/android/hwcservice.h
@@ -103,6 +103,7 @@ class HwcService : public BnService {
                                   uint32_t SRMLength);
     uint32_t GetDisplayIDFromConnectorID(uint32_t connector_id);
     bool EnableDRMCommit(bool enable, uint32_t display_id);
+    bool ResetDrmMaster(bool drop_master);
     status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                          uint32_t instanceID);
     status_t VideoDisableAllEncryptedSessions(uint32_t sessionID);

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1281,6 +1281,10 @@ bool IAHWC2::EnableDRMCommit(bool enable, uint32_t display_id) {
   return device_.EnableDRMCommit(enable, display_id);
 }
 
+bool IAHWC2::ResetDrmMaster(bool drop_master) {
+  return device_.ResetDrmMaster(drop_master);
+}
+
 void IAHWC2::SetHDCPSRMForDisplay(uint32_t connector, const int8_t *SRM,
                                   uint32_t SRMLength) {
   if (SRM == NULL) {

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -70,6 +70,8 @@ class IAHWC2 : public hwc2_device_t {
 
   bool EnableDRMCommit(bool enable, uint32_t display_id);
 
+  bool ResetDrmMaster(bool drop_master);
+
  public:
   class Hwc2Layer {
    public:

--- a/os/android/libhwcservice/hwcserviceapi.cpp
+++ b/os/android/libhwcservice/hwcserviceapi.cpp
@@ -295,6 +295,15 @@ status_t HwcService_EnableDRMCommit(HWCSHANDLE hwcs, uint32_t enable,
   return pContext->mControls->EnableDRMCommit(enable, display_id);
 }
 
+status_t HwcService_ResetDrmMaster(HWCSHANDLE hwcs, uint32_t drop_master) {
+  HwcsContext* pContext = static_cast<HwcsContext*>(hwcs);
+  if (!pContext) {
+    return android::BAD_VALUE;
+  }
+
+  return pContext->mControls->ResetDrmMaster(drop_master);
+}
+
 status_t HwcService_Video_DisableHDCPSession_AllDisplays(HWCSHANDLE hwcs) {
   HwcsContext* pContext = static_cast<HwcsContext*>(hwcs);
   if (!pContext) {

--- a/os/android/libhwcservice/hwcserviceapi.h
+++ b/os/android/libhwcservice/hwcserviceapi.h
@@ -217,6 +217,8 @@ uint32_t HwcService_GetDisplayIDFromConnectorID(HWCSHANDLE hwcs,
 status_t HwcService_EnableDRMCommit(HWCSHANDLE hwcs, uint32_t enable,
                                     uint32_t display_id);
 
+status_t HwcService_ResetDrmMaster(HWCSHANDLE hwcs, uint32_t drop_master);
+
 // The control enables a the protected video subsystem to control when to
 // replace any
 // encrypted content with a default bitmap (usually black).

--- a/os/android/libhwcservice/icontrols.cpp
+++ b/os/android/libhwcservice/icontrols.cpp
@@ -58,6 +58,7 @@ class BpControls : public BpInterface<IControls> {
     TRANSACT_VIDEO_SET_HDCP_SRM_FOR_DISPLAY,
     TRANSACT_GET_DISPLAYID_FROM_CONNECTORID,
     TRANSACT_ENABLE_DRM_COMMIT,
+    TRANSACT_RESET_DRM_MASTER,
     TRANSACT_VIDEO_ENABLE_ENCRYPTED_SESSION,
     TRANSACT_VIDEO_DISABLE_ENCRYPTED_SESSION,
     TRANSACT_VIDEO_DISABLE_ALL_ENCRYPTED_SESSIONS,
@@ -428,6 +429,19 @@ class BpControls : public BpInterface<IControls> {
     return (uint32_t)(reply.readInt32());
   }
 
+  bool ResetDrmMaster(bool drop_master) override {
+    Parcel data;
+    Parcel reply;
+    data.writeInterfaceToken(IControls::getInterfaceDescriptor());
+    data.writeInt32(drop_master);
+
+    status_t ret = remote()->transact(TRANSACT_RESET_DRM_MASTER, data, &reply);
+    if (ret != NO_ERROR) {
+      ALOGW("%s() transact failed: %d", __FUNCTION__, ret);
+    }
+    return (uint32_t)(reply.readInt32());
+  }
+
   status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                        uint32_t instanceID) override {
     Parcel data;
@@ -768,6 +782,13 @@ status_t BnControls::onTransact(uint32_t code, const Parcel &data,
       bool enable = data.readInt32();
       uint32_t display_id = data.readInt32();
       bool ret = this->EnableDRMCommit(enable, display_id);
+      reply->writeInt32(ret);
+      return NO_ERROR;
+    }
+    case BpControls::TRANSACT_RESET_DRM_MASTER: {
+      CHECK_INTERFACE(IControls, data, reply);
+      bool drop_master = data.readInt32();
+      bool ret = this->ResetDrmMaster(drop_master);
       reply->writeInt32(ret);
       return NO_ERROR;
     }

--- a/os/android/libhwcservice/icontrols.h
+++ b/os/android/libhwcservice/icontrols.h
@@ -75,6 +75,8 @@ class IControls : public android::IInterface {
 
   virtual bool EnableDRMCommit(bool enable, uint32_t display_id) = 0;
 
+  virtual bool ResetDrmMaster(bool drop_master) = 0;
+
   virtual status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                                uint32_t instanceID) = 0;
   virtual status_t VideoDisableAllEncryptedSessions(uint32_t sessionID) = 0;

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -17,6 +17,10 @@
 #ifndef PUBLIC_GPUDEVICE_H_
 #define PUBLIC_GPUDEVICE_H_
 
+#ifndef HWC_LOCK_FILE
+#define HWC_LOCK_FILE "/vendor/hwc.lock"
+#endif
+
 #include <stdint.h>
 #include <fstream>
 #include <sstream>
@@ -97,10 +101,14 @@ class GpuDevice : public HWCThread {
 
   bool EnableDRMCommit(bool enable, uint32_t display_id);
 
+  bool ResetDrmMaster(bool drop_master);
+
   std::vector<uint32_t> GetDisplayReservedPlanes(uint32_t display_id);
 
  private:
   GpuDevice();
+
+  void ResetAllDisplayCommit(bool enable);
 
   enum InitializationType {
     kUnInitialized = 0,    // Nothing Initialized.
@@ -132,9 +140,11 @@ class GpuDevice : public HWCThread {
   std::vector<NativeDisplay*> total_displays_;
 
   bool reserve_plane_ = false;
+  bool enable_all_display_ = true;
   std::map<uint8_t, std::vector<uint32_t>> reserved_drm_display_planes_map_;
   uint32_t initialization_state_ = kUnInitialized;
   SpinLock initialization_state_lock_;
+  SpinLock drm_master_lock_;
   int lock_fd_ = -1;
   friend class DrmDisplayManager;
 };

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -53,7 +53,11 @@ class DisplayManager {
   // manager until ForceRefresh is called.
   virtual void IgnoreUpdates() = 0;
 
-  virtual void setDrmMaster() = 0;
+  virtual void setDrmMaster(bool must_set) = 0;
+
+  virtual void DropDrmMaster() = 0;
+
+  virtual bool IsDrmMaster() = 0;
 
   // Get FD associated with this DisplayManager.
   virtual uint32_t GetFD() const = 0;

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -71,7 +71,13 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void IgnoreUpdates() override;
 
-  void setDrmMaster() override;
+  void setDrmMaster(bool must_set) override;
+
+  void DropDrmMaster() override;
+
+  bool IsDrmMaster() override {
+    return drm_master_;
+  }
 
   uint32_t GetFD() const override {
     return fd_;
@@ -115,6 +121,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   bool release_lock_ = false;
   SpinLock spin_lock_;
   int connected_display_count_ = 0;
+  bool drm_master_ = false;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
New API 'ResetDrmMaster' is added for dropping DrmMaster and
ignoring DRM commit when the parameter is true. otherwise, setting
DrmMaster and force refreshing. After dropping DrmMaster, the thread
of GpuDevice will be resume to monitor 'hwc.lock'. Once the file
lock is grabbed. DrmMaster will be set, and stop ignoring vblank.

Change-Id: Ie31937d710c3813d42770d38c8c80de05ae661dd
Tests: Compile sucessful for Android. Work well with KMSCube
Tracked-On: https://jira.devtools.intel.com/browse/OAM-76578
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>