### PR TITLE
Should not change ignoreUpdate status in GpuDevice Thread

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -1022,8 +1022,6 @@ void GpuDevice::HandleRoutine() {
   //    we need to take control.
   // TODO: Add splash screen support.
   if (lock_fd_ != -1) {
-    display_manager_->IgnoreUpdates();
-
     if (flock(lock_fd_, LOCK_EX) != 0) {
       ITRACE("Fail to grab the hwc lock.");
     } else {


### PR DESCRIPTION
Already use 'ForceIgnore' to control ignore/update here.
No need to invoke it again. and it will block to show UI
on Mosaic and logical mode.

Change-Id: I3b77628094df3c2971a50abf3ade00949e2f0947
Tracked-On: None
Tests: Work well with Mosaic and logical mode.
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>