### PR TITLE
Implement EnableDRMCommit in Mosaic and logical display

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -152,6 +152,7 @@ bool GpuDevice::ResetDrmMaster(bool drop_master) {
   display_manager_->setDrmMaster(false);
   ResetAllDisplayCommit(true);
   DisableWatch();
+
   if (drop_master)
     ret = !display_manager_->IsDrmMaster();
   else
@@ -1024,8 +1025,6 @@ void GpuDevice::HandleRoutine() {
   //    we need to take control.
   // TODO: Add splash screen support.
   if (lock_fd_ != -1) {
-    display_manager_->IgnoreUpdates();
-
     if (flock(lock_fd_, LOCK_EX) != 0) {
       ITRACE("Fail to grab the hwc lock.");
     } else {

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -29,6 +29,21 @@ GpuDevice::GpuDevice() : HWCThread(-8, "GpuDevice") {
 
 GpuDevice::~GpuDevice() {
   display_manager_.reset(nullptr);
+  HWCThread::Exit();
+
+  if (-1 != lock_fd_) {
+    close(lock_fd_);
+    lock_fd_ = -1;
+  }
+}
+
+void GpuDevice::ResetAllDisplayCommit(bool enable) {
+  if (enable == enable_all_display_)
+    return;
+  enable_all_display_ = enable;
+  size_t size = total_displays_.size();
+  for (size_t i = 0; i < size; i++)
+    total_displays_.at(i)->EnableDRMCommit(enable);
 }
 
 bool GpuDevice::Initialize() {
@@ -57,13 +72,19 @@ bool GpuDevice::Initialize() {
     display_manager_->RemoveUnreservedPlanes();
   }
 
-  lock_fd_ = open("/vendor/hwc.lock", O_RDONLY);
+  // Ignore all updates by default
+  ResetAllDisplayCommit(false);
+  lock_fd_ = open(HWC_LOCK_FILE, O_RDONLY);
   if (-1 != lock_fd_) {
     if (!InitWorker()) {
       ETRACE("Failed to initalize thread for GpuDevice. %s", PRINTERROR());
     }
   } else {
-    ITRACE("Failed to open " LOCK_DIR_PREFIX "/hwc.lock file!");
+    ITRACE("Failed to open %s", HWC_LOCK_FILE);
+    // HWC should become drm master and start to commit.
+    // if hwc.lock is not available
+    display_manager_->setDrmMaster(true);
+    ResetAllDisplayCommit(true);
   }
 
   return true;
@@ -103,11 +124,38 @@ void GpuDevice::GetConnectedPhysicalDisplays(
 }
 
 bool GpuDevice::EnableDRMCommit(bool enable, uint32_t display_id) {
-  // TODO clean all display for commit status
   size_t size = total_displays_.size();
   bool ret = false;
   if (size > display_id)
     ret = total_displays_.at(display_id)->EnableDRMCommit(enable);
+  return ret;
+}
+
+bool GpuDevice::ResetDrmMaster(bool drop_master) {
+  bool ret = true;
+  if (drop_master) {
+    ResetAllDisplayCommit(false);
+    display_manager_->DropDrmMaster();
+    ITRACE("locking %s and monitoring if %s is unlocked.", HWC_LOCK_FILE,
+           HWC_LOCK_FILE);
+    // Resume GpuDevice thread to check hwc.lock and re-apply drm master.
+    lock_fd_ = open(HWC_LOCK_FILE, O_RDONLY);
+    if (-1 != lock_fd_) {
+      // Only resume GpuDevice thread for dropping DRM Master and
+      // the lock file exist.
+      Resume();
+      return !display_manager_->IsDrmMaster();
+    }
+  }
+  // In case of setDrmMaster or the lock file is not exist.
+  // Re-set DRM Master true.
+  display_manager_->setDrmMaster(false);
+  ResetAllDisplayCommit(true);
+  DisableWatch();
+  if (drop_master)
+    ret = !display_manager_->IsDrmMaster();
+  else
+    ret = display_manager_->IsDrmMaster();
   return ret;
 }
 
@@ -965,8 +1013,6 @@ uint32_t GpuDevice::GetDisplayIDFromConnectorID(const uint32_t connector_id) {
 }
 
 void GpuDevice::HandleRoutine() {
-  bool update_ignored = false;
-
   // Iniitialize resources to monitor external events.
   // These can be two types:
   // 1) We are showing splash screen and another App
@@ -977,22 +1023,21 @@ void GpuDevice::HandleRoutine() {
   // TODO: Add splash screen support.
   if (lock_fd_ != -1) {
     display_manager_->IgnoreUpdates();
-    update_ignored = true;
 
     if (flock(lock_fd_, LOCK_EX) != 0) {
-      ETRACE("Failed to wait on the hwc lock.");
+      ITRACE("Fail to grab the hwc lock.");
     } else {
       ITRACE("Successfully grabbed the hwc lock.");
+      // Set DRM master
+      if (!display_manager_->IsDrmMaster())
+        display_manager_->setDrmMaster(true);
+      // stop ignoring and force refresh
+      ResetAllDisplayCommit(true);
+      flock(lock_fd_, LOCK_UN);
+      close(lock_fd_);
+      lock_fd_ = -1;
     }
-
-    display_manager_->setDrmMaster();
-
-    close(lock_fd_);
-    lock_fd_ = -1;
   }
-
-  if (update_ignored)
-    display_manager_->ForceRefresh();
 }
 
 void GpuDevice::HandleWait() {
@@ -1002,7 +1047,10 @@ void GpuDevice::HandleWait() {
 }
 
 void GpuDevice::DisableWatch() {
-  HWCThread::Exit();
+  if (lock_fd_ != -1) {
+    close(lock_fd_);
+    lock_fd_ = -1;
+  }
 }
 
 GpuDevice &GpuDevice::getInstance() {

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -666,8 +666,8 @@ void GpuDevice::InitializeLogicalDisplay(
 void GpuDevice::InitializeMosaicDisplay(
     std::vector<NativeDisplay *> &total_displays_,
     std::vector<std::vector<uint32_t>> &mosaic_displays,
-    std::vector<NativeDisplay *> &temp_displays) {
-  std::vector<bool> available_displays(temp_displays.size(), true);
+    std::vector<NativeDisplay *> &temp_displays,
+    std::vector<bool> &available_displays) {
   size_t displays_size = temp_displays.size();
   for (size_t t = 0; t < displays_size; t++) {
     // Skip the displays which already be marked in other mosaic
@@ -933,8 +933,10 @@ void GpuDevice::HandleHWCSettings() {
   InitializeLogicalDisplay(logical_displays, displays, temp_displays,
                            use_logical);
 
+  std::vector<bool> available_displays(temp_displays.size(), true);
   if (use_mosaic) {
-    InitializeMosaicDisplay(total_displays_, mosaic_displays, temp_displays);
+    InitializeMosaicDisplay(total_displays_, mosaic_displays, temp_displays,
+                            available_displays);
   } else {
     total_displays_.swap(temp_displays);
   }

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -51,6 +51,10 @@ int LogicalDisplay::GetDisplayPipe() {
   return physical_display_->GetDisplayPipe();
 }
 
+bool LogicalDisplay::EnableDRMCommit(bool enable) {
+  return physical_display_->EnableDRMCommit(enable);
+}
+
 bool LogicalDisplay::SetActiveConfig(uint32_t config) {
   bool success = physical_display_->SetActiveConfig(config);
   width_ = (physical_display_->Width()) / total_divisions_;

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -103,6 +103,8 @@ class LogicalDisplay : public NativeDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  bool EnableDRMCommit(bool enable) override;
+
   uint32_t GetXTranslation() override {
     return (((physical_display_->Width()) / total_divisions_) * index_);
   }

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -110,6 +110,13 @@ int MosaicDisplay::GetDisplayPipe() {
   return physical_displays_.at(0)->GetDisplayPipe();
 }
 
+bool MosaicDisplay::EnableDRMCommit(bool enable) {
+  uint32_t size = physical_displays_.size();
+  for (uint32_t i = 0; i < size; i++)
+    physical_displays_.at(i)->EnableDRMCommit(enable);
+  return true;
+}
+
 bool MosaicDisplay::SetActiveConfig(uint32_t config) {
   config_ = config;
   width_ = 0;

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -94,6 +94,8 @@ class MosaicDisplay : public NativeDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  bool EnableDRMCommit(bool enable) override;
+
   uint32_t GetXTranslation() override {
     return 0;
   }

--- a/os/android/hwcservice.cpp
+++ b/os/android/hwcservice.cpp
@@ -409,6 +409,10 @@ bool HwcService::Controls::EnableDRMCommit(bool enable, uint32_t display_id) {
   return mHwc.EnableDRMCommit(enable, display_id);
 }
 
+bool HwcService::Controls::ResetDrmMaster(bool drop_master) {
+  return mHwc.ResetDrmMaster(drop_master);
+}
+
 status_t HwcService::Controls::VideoEnableEncryptedSession(
     uint32_t sessionID, uint32_t instanceID) {
   mHwc.SetPAVPSessionStatus(true, sessionID, instanceID);

--- a/os/android/hwcservice.h
+++ b/os/android/hwcservice.h
@@ -103,6 +103,7 @@ class HwcService : public BnService {
                                   uint32_t SRMLength);
     uint32_t GetDisplayIDFromConnectorID(uint32_t connector_id);
     bool EnableDRMCommit(bool enable, uint32_t display_id);
+    bool ResetDrmMaster(bool drop_master);
     status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                          uint32_t instanceID);
     status_t VideoDisableAllEncryptedSessions(uint32_t sessionID);

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1281,6 +1281,10 @@ bool IAHWC2::EnableDRMCommit(bool enable, uint32_t display_id) {
   return device_.EnableDRMCommit(enable, display_id);
 }
 
+bool IAHWC2::ResetDrmMaster(bool drop_master) {
+  return device_.ResetDrmMaster(drop_master);
+}
+
 void IAHWC2::SetHDCPSRMForDisplay(uint32_t connector, const int8_t *SRM,
                                   uint32_t SRMLength) {
   if (SRM == NULL) {

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -70,6 +70,8 @@ class IAHWC2 : public hwc2_device_t {
 
   bool EnableDRMCommit(bool enable, uint32_t display_id);
 
+  bool ResetDrmMaster(bool drop_master);
+
  public:
   class Hwc2Layer {
    public:

--- a/os/android/libhwcservice/hwcserviceapi.cpp
+++ b/os/android/libhwcservice/hwcserviceapi.cpp
@@ -295,6 +295,15 @@ status_t HwcService_EnableDRMCommit(HWCSHANDLE hwcs, uint32_t enable,
   return pContext->mControls->EnableDRMCommit(enable, display_id);
 }
 
+status_t HwcService_ResetDrmMaster(HWCSHANDLE hwcs, uint32_t drop_master) {
+  HwcsContext* pContext = static_cast<HwcsContext*>(hwcs);
+  if (!pContext) {
+    return android::BAD_VALUE;
+  }
+
+  return pContext->mControls->ResetDrmMaster(drop_master);
+}
+
 status_t HwcService_Video_DisableHDCPSession_AllDisplays(HWCSHANDLE hwcs) {
   HwcsContext* pContext = static_cast<HwcsContext*>(hwcs);
   if (!pContext) {

--- a/os/android/libhwcservice/hwcserviceapi.h
+++ b/os/android/libhwcservice/hwcserviceapi.h
@@ -217,6 +217,8 @@ uint32_t HwcService_GetDisplayIDFromConnectorID(HWCSHANDLE hwcs,
 status_t HwcService_EnableDRMCommit(HWCSHANDLE hwcs, uint32_t enable,
                                     uint32_t display_id);
 
+status_t HwcService_ResetDrmMaster(HWCSHANDLE hwcs, uint32_t drop_master);
+
 // The control enables a the protected video subsystem to control when to
 // replace any
 // encrypted content with a default bitmap (usually black).

--- a/os/android/libhwcservice/icontrols.cpp
+++ b/os/android/libhwcservice/icontrols.cpp
@@ -58,6 +58,7 @@ class BpControls : public BpInterface<IControls> {
     TRANSACT_VIDEO_SET_HDCP_SRM_FOR_DISPLAY,
     TRANSACT_GET_DISPLAYID_FROM_CONNECTORID,
     TRANSACT_ENABLE_DRM_COMMIT,
+    TRANSACT_RESET_DRM_MASTER,
     TRANSACT_VIDEO_ENABLE_ENCRYPTED_SESSION,
     TRANSACT_VIDEO_DISABLE_ENCRYPTED_SESSION,
     TRANSACT_VIDEO_DISABLE_ALL_ENCRYPTED_SESSIONS,
@@ -428,6 +429,19 @@ class BpControls : public BpInterface<IControls> {
     return (uint32_t)(reply.readInt32());
   }
 
+  bool ResetDrmMaster(bool drop_master) override {
+    Parcel data;
+    Parcel reply;
+    data.writeInterfaceToken(IControls::getInterfaceDescriptor());
+    data.writeInt32(drop_master);
+
+    status_t ret = remote()->transact(TRANSACT_RESET_DRM_MASTER, data, &reply);
+    if (ret != NO_ERROR) {
+      ALOGW("%s() transact failed: %d", __FUNCTION__, ret);
+    }
+    return (uint32_t)(reply.readInt32());
+  }
+
   status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                        uint32_t instanceID) override {
     Parcel data;
@@ -768,6 +782,13 @@ status_t BnControls::onTransact(uint32_t code, const Parcel &data,
       bool enable = data.readInt32();
       uint32_t display_id = data.readInt32();
       bool ret = this->EnableDRMCommit(enable, display_id);
+      reply->writeInt32(ret);
+      return NO_ERROR;
+    }
+    case BpControls::TRANSACT_RESET_DRM_MASTER: {
+      CHECK_INTERFACE(IControls, data, reply);
+      bool drop_master = data.readInt32();
+      bool ret = this->ResetDrmMaster(drop_master);
       reply->writeInt32(ret);
       return NO_ERROR;
     }

--- a/os/android/libhwcservice/icontrols.h
+++ b/os/android/libhwcservice/icontrols.h
@@ -75,6 +75,8 @@ class IControls : public android::IInterface {
 
   virtual bool EnableDRMCommit(bool enable, uint32_t display_id) = 0;
 
+  virtual bool ResetDrmMaster(bool drop_master) = 0;
+
   virtual status_t VideoEnableEncryptedSession(uint32_t sessionID,
                                                uint32_t instanceID) = 0;
   virtual status_t VideoDisableAllEncryptedSessions(uint32_t sessionID) = 0;

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -165,7 +165,8 @@ class GpuDevice : public HWCThread {
   void InitializeMosaicDisplay(
       std::vector<NativeDisplay*>& total_displays_,
       std::vector<std::vector<uint32_t>>& mosaic_displays,
-      std::vector<NativeDisplay*>& temp_displays);
+      std::vector<NativeDisplay*>& temp_displays,
+      std::vector<bool>& available_displays);
   void InitializeCloneDisplay(
       std::vector<NativeDisplay*>& total_displays_,
       std::vector<std::vector<uint32_t>>& cloned_displays);

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -17,6 +17,10 @@
 #ifndef PUBLIC_GPUDEVICE_H_
 #define PUBLIC_GPUDEVICE_H_
 
+#ifndef HWC_LOCK_FILE
+#define HWC_LOCK_FILE "/vendor/hwc.lock"
+#endif
+
 #include <stdint.h>
 #include <fstream>
 #include <sstream>
@@ -97,10 +101,14 @@ class GpuDevice : public HWCThread {
 
   bool EnableDRMCommit(bool enable, uint32_t display_id);
 
+  bool ResetDrmMaster(bool drop_master);
+
   std::vector<uint32_t> GetDisplayReservedPlanes(uint32_t display_id);
 
  private:
   GpuDevice();
+
+  void ResetAllDisplayCommit(bool enable);
 
   enum InitializationType {
     kUnInitialized = 0,    // Nothing Initialized.
@@ -167,9 +175,11 @@ class GpuDevice : public HWCThread {
   std::vector<NativeDisplay*> total_displays_;
 
   bool reserve_plane_ = false;
+  bool enable_all_display_ = true;
   std::map<uint8_t, std::vector<uint32_t>> reserved_drm_display_planes_map_;
   uint32_t initialization_state_ = kUnInitialized;
   SpinLock initialization_state_lock_;
+  SpinLock drm_master_lock_;
   int lock_fd_ = -1;
   friend class DrmDisplayManager;
 };

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -53,7 +53,11 @@ class DisplayManager {
   // manager until ForceRefresh is called.
   virtual void IgnoreUpdates() = 0;
 
-  virtual void setDrmMaster() = 0;
+  virtual void setDrmMaster(bool must_set) = 0;
+
+  virtual void DropDrmMaster() = 0;
+
+  virtual bool IsDrmMaster() = 0;
 
   // Get FD associated with this DisplayManager.
   virtual uint32_t GetFD() const = 0;

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -71,7 +71,13 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void IgnoreUpdates() override;
 
-  void setDrmMaster() override;
+  void setDrmMaster(bool must_set) override;
+
+  void DropDrmMaster() override;
+
+  bool IsDrmMaster() override {
+    return drm_master_;
+  }
 
   uint32_t GetFD() const override {
     return fd_;
@@ -115,6 +121,7 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   bool release_lock_ = false;
   SpinLock spin_lock_;
   int connected_display_count_ = 0;
+  bool drm_master_ = false;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
The method 'EnableDRMCommit' is not implemented in Mosaic and Logical
display. will fail to ignore and refresh commiting in the 2 modes.

Change-Id: Ib0ff2efba1ea469f710e5d95cfcd1d4651de95d2
Tests: Work well with Mosaic and logical mode.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-76578
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>