### PR TITLE
Add nullpoint checking for GetBuffer invoking.

### DIFF
--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -145,7 +145,7 @@ void NativeSurface::SetPlaneTarget(const DisplayPlaneState &plane) {
   on_screen_ = false;
   surface_age_ = 0;
   OverlayBuffer *layer_buffer = layer_.GetBuffer();
-  if (layer_buffer && layer_buffer->GetFb() == 0) {
+  if (!layer_buffer || layer_buffer->GetFb() == 0) {
     ETRACE("SetPlaneTarget unable to create framebuffer for nativesurface");
   }
 }

--- a/common/compositor/va/varenderer.cpp
+++ b/common/compositor/va/varenderer.cpp
@@ -235,6 +235,10 @@ bool VARenderer::Draw(const MediaState& state, NativeSurface* surface) {
   // TODO: Clear surface ?
   surface->SetClearSurface(NativeSurface::kNone);
   OverlayBuffer* buffer_out = surface->GetLayer()->GetBuffer();
+  if (!buffer_out) {
+    ETRACE("Layer buffer is empty. faile to create VA context.\n");
+    return false;
+  }
   int rt_format = DrmFormatToRTFormat(buffer_out->GetFormat());
   if (va_context_ == VA_INVALID_ID || render_target_format_ != rt_format) {
     render_target_format_ = rt_format;

--- a/common/compositor/vk/vksurface.cpp
+++ b/common/compositor/vk/vksurface.cpp
@@ -35,8 +35,12 @@ VKSurface::~VKSurface() {
 bool VKSurface::InitializeGPUResources() {
   VkResult res;
 
-  const struct vk_import& import =
-      layer_.GetBuffer()->GetGpuResource(dev_, false);
+  OverlayBuffer* layer_buffer = layer_.GetBuffer();
+  if (!layer_buffer) {
+    ETRACE("layer_ buffer is null.\n");
+    return false;
+  }
+  const struct vk_import& import = layer_buffer->GetGpuResource(dev_, false);
   if (import.image_ == VK_NULL_HANDLE) {
     ETRACE("Failed to make import image\n");
     return false;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -739,7 +739,10 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
     modifier = 0;
   for (auto &fb : surfaces_) {
     if (fb->GetSurfaceAge() == -1) {
-      uint32_t surface_format = fb->GetLayer()->GetBuffer()->GetFormat();
+      OverlayBuffer *layer_buffer = fb->GetLayer()->GetBuffer();
+      if (!layer_buffer)
+        continue;
+      uint32_t surface_format = layer_buffer->GetFormat();
       if ((preferred_format == surface_format) &&
           (fb->GetModifier() == modifier)) {
         surface = fb.get();

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -428,7 +428,7 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
 
       OverlayBuffer* buffer = layer->GetBuffer();
       bool isNewCreated = false;
-      if (buffer->GetFb(&isNewCreated) == 0) {
+      if (!buffer || buffer->GetFb(&isNewCreated) == 0) {
         *force_full_validation = true;
         *can_ignore_commit = false;
         return;


### PR DESCRIPTION
Checking if the buffer pointer is null before using it.

Change-Id: If2631bb5c28efc0f3e5951104a150c1464008277
Test: Compile sucessful for Android.
Tracked-On:https://jira.devtools.intel.com/browse/OAM-78892
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>