### PR TITLE
Allow drm commit by default

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -72,8 +72,6 @@ bool GpuDevice::Initialize() {
     display_manager_->RemoveUnreservedPlanes();
   }
 
-  // Ignore all updates by default
-  ResetAllDisplayCommit(false);
   lock_fd_ = open(HWC_LOCK_FILE, O_RDONLY);
   if (-1 != lock_fd_) {
     if (!InitWorker()) {

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -187,7 +187,7 @@ class GpuDevice : public HWCThread {
   std::vector<NativeDisplay*> total_displays_;
 
   bool reserve_plane_ = false;
-  bool enable_all_display_ = true;
+  bool enable_all_display_ = false;
   std::map<uint8_t, std::vector<uint32_t>> reserved_drm_display_planes_map_;
   uint32_t initialization_state_ = kUnInitialized;
   SpinLock initialization_state_lock_;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -493,6 +493,10 @@ bool DrmDisplay::Commit(
     const DisplayPlaneStateList &previous_composition_planes,
     bool disable_explicit_fence, int32_t previous_fence, int32_t *commit_fence,
     bool *previous_fence_released) {
+  if (!manager_->IsDrmMaster()) {
+    ETRACE("Failed to commit without DrmMaster");
+    return true;
+  }
   // Do the actual commit.
   ScopedDrmAtomicReqPtr pset(drmModeAtomicAlloc());
   *previous_fence_released = false;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -458,6 +458,7 @@ void DrmDisplayManager::setDrmMaster(bool must_set) {
       retry_times++;
     if (ret) {
       ETRACE("Failed to call drmSetMaster : %s", PRINTERROR());
+      drm_master_ = false;
       usleep(10000);
     } else {
       ITRACE("Successfully set as DRM master.");


### PR DESCRIPTION
Allow DRM commit by default to optimize the switch duration for DRM
master. Checking if hwc is drmmaster before really commit to DRM.

Change-Id: I0a78e51e2359baab65402abd60f46df6940b3592
Tracked-On: https://jira.devtools.intel.com/browse/OAM-79621
Test: Compile success, work well with evs
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>