### PR TITLE
Ensure LogicalDisplay called LogicalDisplayManager::Present()

### DIFF
--- a/common/core/logicaldisplaymanager.cpp
+++ b/common/core/logicaldisplaymanager.cpp
@@ -181,10 +181,7 @@ bool LogicalDisplayManager::Present(std::vector<HwcLayer*>& source_layers,
     }
   }
 
-  uint32_t cursor_layers = cursor_layers_.size();
-  for (uint32_t j = 0; j < cursor_layers; j++) {
-    layers_.emplace_back(cursor_layers_.at(j));
-  }
+  layers_.insert(layers_.end(), cursor_layers_.begin(), cursor_layers_.end());
 
   bool success = physical_display_->Present(layers_, retire_fence, call_back,
                                             handle_constraints);

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -682,8 +682,6 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
     layers.emplace_back(l.second->GetLayer());
   }
 
-  if (layers.empty())
-    return HWC2::Error::None;
 
   IHOTPLUGEVENTTRACE("PhysicalDisplay called for Display: %p \n", display_);
 

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -287,6 +287,9 @@ bool PhysicalDisplay::Present(std::vector<HwcLayer *> &source_layers,
                               PixelUploaderCallback *call_back,
                               bool handle_constraints) {
   CTRACE();
+
+  if (source_layers.empty()) return true;
+
   SPIN_LOCK(modeset_lock_);
 
   bool handle_hotplug_notifications = false;


### PR DESCRIPTION
HWC2Display::PresentDisplay can't return before calling NativeDisplay::Present()
LogicalDisplayManager must confirm all LogicalDisplay have called LogicalDisplayManager::Present()

Signed-off-by: yuzhengyang-li <yu.zhy@neusoft.com>