### PR TITLE
Ensure LogicalDisplay called LogicalDisplayManager::Present()

### DIFF
--- a/common/core/logicaldisplaymanager.cpp
+++ b/common/core/logicaldisplaymanager.cpp
@@ -181,10 +181,10 @@ bool LogicalDisplayManager::Present(std::vector<HwcLayer*>& source_layers,
     }
   }
 
-  uint32_t cursor_layers = cursor_layers_.size();
-  for (uint32_t j = 0; j < cursor_layers; j++) {
-    layers_.emplace_back(cursor_layers_.at(j));
-  }
+  layers_.insert(layers_.end(), cursor_layers_.begin(), cursor_layers_.end());
+
+  if (layers_.empty())
+    return true;
 
   bool success = physical_display_->Present(layers_, retire_fence, call_back,
                                             handle_constraints);

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -682,7 +682,7 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
     layers.emplace_back(l.second->GetLayer());
   }
 
-  if (layers.empty())
+  if (layers.empty() && display_->DisplayType() != DisplayType::kLogical)
     return HWC2::Error::None;
 
   IHOTPLUGEVENTTRACE("PhysicalDisplay called for Display: %p \n", display_);


### PR DESCRIPTION
When layers is empty, will return in PhysicalDisplay::Present.
I also add the checking in VirtualDisplay::present
If return in HWC2Display that is actually LogicalDisplay when layers is empty,
the LogicalDisplayManager can't do the present at right moment.
This will cause Composer process to crash when using LogicalDisplay.

Change-Id: none
Test: test ok
jira: none
Signed-off-by: yuzhengyang <yu.zhy@neusoft.com>