### PR TITLE
The buffer interlace info should change to frame by frame

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -106,6 +106,11 @@ void OverlayLayer::SetBuffer(HWCNativeHandle handle, int32_t acquire_fence,
     }
   } else {
     buffer->SetOriginalHandle(handle);
+    // need to update interlace info since interlace info is update frame by
+    // frame
+    if (buffer->GetUsage() == kLayerVideo)
+      buffer->SetInterlace(
+          resource_manager->GetNativeBufferHandler()->GetInterlace(handle));
   }
 
   buffer->SetDataSpace(dataspace_);

--- a/os/android/utils_android.h
+++ b/os/android/utils_android.h
@@ -39,8 +39,6 @@
 extern "C" {
 #endif
 
-#define GRALLOC_USAGE_PRIVATE_INTERLACE GRALLOC_USAGE_PRIVATE_0
-
 // Conversion from HAL to fourcc-based DRM formats
 static uint32_t GetDrmFormatFromHALFormat(int format) {
   switch (format) {
@@ -221,7 +219,7 @@ static bool ImportGraphicsBuffer(HWCNativeHandle handle, int fd) {
   handle->meta_data_.height_ = gr_handle->height;
   handle->meta_data_.native_format_ = gr_handle->droid_format;
 
-  if (gr_handle->consumer_usage & GRALLOC_USAGE_PRIVATE_INTERLACE) {
+  if (gr_handle->is_interlaced > 0) {
     handle->meta_data_.is_interlaced_ = true;
   } else {
     handle->meta_data_.is_interlaced_ = false;


### PR DESCRIPTION
So far the buffer interlace is set according to GRALLOC_USAGE_PRIVATE_0.
It will cause play some irregular size video has green line in screen bottom.

Change-Id: I2bff0bf84a056c1e313cb79c2762e788598fd7ac
Tests: Video play without issue.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-79458
Signed-off-by: HeYue <yue.he@intel.com>