### PR TITLE
Fix the wrong method name in compiling error

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -682,7 +682,7 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
     layers.emplace_back(l.second->GetLayer());
   }
 
-  if (layers.empty() && display_->DisplayType() != DisplayType::kLogical)
+  if (layers.empty() && display_->Type() != DisplayType::kLogical)
     return HWC2::Error::None;
 
   IHOTPLUGEVENTTRACE("PhysicalDisplay called for Display: %p \n", display_);


### PR DESCRIPTION
The method name for getting display type is typoed.

Change-Id: Idb22f258d3723b69867e055c70a7a7ca6f609400
Tracked-On: None
Test: Compile success
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>