### PR TITLE
fix symbol priority problem

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -682,7 +682,7 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
     layers.emplace_back(l.second->GetLayer());
   }
 
-  if (layers.empty() && display_->Type() != DisplayType::kLogical)
+  if (layers.empty() && (display_->Type() != DisplayType::kLogical))
     return HWC2::Error::None;
 
   IHOTPLUGEVENTTRACE("PhysicalDisplay called for Display: %p \n", display_);


### PR DESCRIPTION
Add parentheses to the right expression of "& &"

Test: test ok
Signed-off-by: yuzhengyang <yu.zhy@neusoft.com>