### PR TITLE
Fix a misstike when LogicalDisplaymanager do present

### DIFF
--- a/common/core/logicaldisplaymanager.cpp
+++ b/common/core/logicaldisplaymanager.cpp
@@ -183,8 +183,10 @@ bool LogicalDisplayManager::Present(std::vector<HwcLayer*>& source_layers,
 
   layers_.insert(layers_.end(), cursor_layers_.begin(), cursor_layers_.end());
 
-  if (layers_.empty())
+  if (layers_.empty()) {
+    queued_displays_ = 0;
     return true;
+  }
 
   bool success = physical_display_->Present(layers_, retire_fence, call_back,
                                             handle_constraints);


### PR DESCRIPTION
When layers_ is empty, missing reset queued_displays_ to 0

Change-Id: None
Tracked-On: None
Test: test ok!
Signed-off-by: yuzhengyang <yu.zhy@neusoft.com>