### PR TITLE
Assign rendering area with Damage size except rotate and display-diff

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -121,6 +121,30 @@ void GpuDevice::GetConnectedPhysicalDisplays(
   }
 }
 
+bool GpuDevice::IsSameResolutionForAllDisplay() {
+  bool same = true;
+  std::vector<NativeDisplay *> connected_displays;
+  GetConnectedPhysicalDisplays(connected_displays);
+  size_t size = connected_displays.size();
+  if (size == 1)
+    return same;
+  int display_width = 0;
+  int display_height = 0;
+  for (size_t i = 0; i < size; i++) {
+    if (i == 0) {
+      display_width = connected_displays.at(i)->Width();
+      display_height = connected_displays.at(i)->Height();
+      continue;
+    }
+    if (display_width != connected_displays.at(i)->Width() ||
+        display_height != connected_displays.at(i)->Height()) {
+      same = false;
+      break;
+    }
+  }
+  return same;
+}
+
 bool GpuDevice::EnableDRMCommit(bool enable, uint32_t display_id) {
   size_t size = total_displays_.size();
   bool ret = false;
@@ -944,6 +968,7 @@ void GpuDevice::HandleHWCSettings() {
   if (rotate_display) {
     InitializeDisplayRotation(display_rotation, rotation_display_index,
                               displays);
+    rotate_mode_ = true;
   }
 
   // Now, we should have all physical displays ordered as required.

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -949,12 +949,9 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerSurfaceDamage(hwc_region_t damage) {
   hwcomposer::HwcRegion hwc_region;
 
   for (size_t rect = 0; rect < num_rects; ++rect) {
-    if (!(damage.rects[rect].left == 0 && damage.rects[rect].top == 0 &&
-          damage.rects[rect].right == 0 && damage.rects[rect].bottom == 0)) {
-      hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
-                              damage.rects[rect].right,
-                              damage.rects[rect].bottom);
-    }
+    hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
+                            damage.rects[rect].right,
+                            damage.rects[rect].bottom);
   }
 
   hwc_layer_.SetSurfaceDamage(hwc_region);

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -64,6 +64,12 @@ class GpuDevice : public HWCThread {
 
   void GetConnectedPhysicalDisplays(std::vector<NativeDisplay*>& displays);
 
+  bool IsSameResolutionForAllDisplay();
+
+  bool IsRotateMode() {
+    return rotate_mode_;
+  }
+
   const std::vector<NativeDisplay*>& GetAllDisplays();
 
   void RegisterHotPlugEventCallback(
@@ -188,6 +194,7 @@ class GpuDevice : public HWCThread {
 
   bool reserve_plane_ = false;
   bool enable_all_display_ = false;
+  bool rotate_mode_ = false;
   std::map<uint8_t, std::vector<uint32_t>> reserved_drm_display_planes_map_;
   uint32_t initialization_state_ = kUnInitialized;
   SpinLock initialization_state_lock_;

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -113,15 +113,6 @@ struct HwcLayer {
   }
 
   /**
-   * API for querying damage region of this layer
-   * has changed from last Present call to
-   * NativeDisplay.
-   */
-  bool HasSurfaceDamageRegionChanged() const {
-    return state_ & kSurfaceDamageChanged;
-  }
-
-  /**
    * API for querying if content of layer has changed
    * for last Present call to NativeDisplay.
    */
@@ -307,13 +298,12 @@ struct HwcLayer {
 #endif
 
   enum LayerState {
-    kSurfaceDamageChanged = 1 << 0,
-    kLayerContentChanged = 1 << 1,
-    kVisibleRegionChanged = 1 << 2,
-    kVisible = 1 << 3,
-    kLayerValidated = 1 << 4,
-    kVisibleRegionSet = 1 << 5,
-    kZorderChanged = 1 << 6
+    kLayerContentChanged = 1 << 0,
+    kVisibleRegionChanged = 1 << 1,
+    kVisible = 1 << 2,
+    kLayerValidated = 1 << 3,
+    kVisibleRegionSet = 1 << 4,
+    kZorderChanged = 1 << 5
   };
 
   enum LayerCache {
@@ -344,8 +334,7 @@ struct HwcLayer {
   std::vector<int32_t> right_source_constraint_;
   int z_order_ = -1;
   uint32_t total_displays_ = 1;
-  int state_ =
-      kVisible | kSurfaceDamageChanged | kVisibleRegionChanged | kZorderChanged;
+  int state_ = kVisible | kVisibleRegionChanged | kZorderChanged;
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
   uint32_t solid_color_ = 0;


### PR DESCRIPTION
SurfaceDamage should be assigned to rendering_area when surface damage
is empty except rotate_mode or the resolution of connected display is
different.

Change-Id: I0c3b1f33c51c3ed2bfaedb5f7d4d73696a00576c
Test: Work well for benchmark T-Rex and Manhattan.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-80208
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>