### PR TITLE
Update rendering area when surface_damage is empty

### DIFF
--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -49,15 +49,16 @@ struct OverlayLayer {
   void InitializeFromHwcLayer(HwcLayer* layer, ResourceManager* buffer_manager,
                               OverlayLayer* previous_layer, uint32_t z_order,
                               uint32_t layer_index, uint32_t max_height,
-                              uint32_t rotation, bool handle_constraints);
+                              uint32_t max_width, uint32_t rotation,
+                              bool handle_constraints);
 
   void InitializeFromScaledHwcLayer(HwcLayer* layer,
                                     ResourceManager* buffer_manager,
                                     OverlayLayer* previous_layer,
                                     uint32_t z_order, uint32_t layer_index,
                                     const HwcRect<int>& display_frame,
-                                    uint32_t max_height, uint32_t rotation,
-                                    bool handle_constraints);
+                                    uint32_t max_height, uint32_t max_width,
+                                    uint32_t rotation, bool handle_constraints);
   // Get z order of this layer.
   uint32_t GetZorder() const {
     return z_order_;
@@ -277,10 +278,14 @@ struct OverlayLayer {
 
   void ValidateTransform(uint32_t transform, uint32_t display_transform);
 
+  void TransformDamage(HwcLayer* layer, uint32_t max_height,
+                       uint32_t max_width);
+
   void InitializeState(HwcLayer* layer, ResourceManager* buffer_manager,
                        OverlayLayer* previous_layer, uint32_t z_order,
                        uint32_t layer_index, uint32_t max_height,
-                       uint32_t rotation, bool handle_constraints);
+                       uint32_t max_width, uint32_t rotation,
+                       bool handle_constraints);
 
   uint32_t transform_ = 0;
   uint32_t plane_transform_ = 0;

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -568,12 +568,14 @@ void DisplayQueue::InitializeOverlayLayers(
 
       overlay_layer->InitializeFromScaledHwcLayer(
           layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-          display_frame, display_plane_manager_->GetHeight(), plane_transform_,
+          display_frame, display_plane_manager_->GetHeight(),
+          display_plane_manager_->GetWidth(), plane_transform_,
           handle_constraints);
     } else {
       overlay_layer->InitializeFromHwcLayer(
           layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-          display_plane_manager_->GetHeight(), plane_transform_,
+          display_plane_manager_->GetHeight(),
+          display_plane_manager_->GetWidth(), plane_transform_,
           handle_constraints);
     }
 

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -349,7 +349,7 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
     overlay_layer.InitializeFromHwcLayer(
         layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-        height_, kIdentity, handle_constraints);
+        height_, width_, kIdentity, handle_constraints);
     index.emplace_back(z_order);
     layers_rects.emplace_back(layer->GetDisplayFrame());
     z_order++;

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -350,7 +350,7 @@ bool VirtualPanoramaDisplay::Present(std::vector<HwcLayer *> &source_layers,
 
     overlay_layer.InitializeFromHwcLayer(
         layer, resource_manager_.get(), previous_layer, z_order, layer_index,
-        height_, kIdentity, handle_constraints);
+        height_, width_, kIdentity, handle_constraints);
     index.emplace_back(z_order);
     layers_rects.emplace_back(overlay_layer.GetDisplayFrame());
 

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -949,12 +949,9 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerSurfaceDamage(hwc_region_t damage) {
   hwcomposer::HwcRegion hwc_region;
 
   for (size_t rect = 0; rect < num_rects; ++rect) {
-    if (!(damage.rects[rect].left == 0 && damage.rects[rect].top == 0 &&
-          damage.rects[rect].right == 0 && damage.rects[rect].bottom == 0)) {
-      hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
-                              damage.rects[rect].right,
-                              damage.rects[rect].bottom);
-    }
+    hwc_region.emplace_back(damage.rects[rect].left, damage.rects[rect].top,
+                            damage.rects[rect].right,
+                            damage.rects[rect].bottom);
   }
 
   hwc_layer_.SetSurfaceDamage(hwc_region);


### PR DESCRIPTION
When surface_damage is empty, it mean the layer is not changed.
the rendering area must be set as empty to avoid re-render a
unchanged layer.

Test: Work well for benchmark T-Rex and Manhattan.
Change-Id: I8abee7408b1338617d85e7af6696e42375e7d788
Tracked-On: https://jira.devtools.intel.com/browse/OAM-80208
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>