### PR TITLE
Check if hwc is drm master by default in initialization

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -81,7 +81,8 @@ bool GpuDevice::Initialize() {
     ETRACE("Failed to open %s", HWC_LOCK_FILE);
     // HWC should become drm master and start to commit.
     // if hwc.lock is not available
-    display_manager_->setDrmMaster(true);
+    if (!display_manager_->IsDrmMasterByDefault())
+      display_manager_->setDrmMaster(true);
     ResetAllDisplayCommit(true);
   }
 

--- a/wsi/displaymanager.h
+++ b/wsi/displaymanager.h
@@ -53,6 +53,8 @@ class DisplayManager {
   // manager until ForceRefresh is called.
   virtual void IgnoreUpdates() = 0;
 
+  virtual bool IsDrmMasterByDefault() = 0;
+
   virtual void setDrmMaster(bool must_set) = 0;
 
   virtual void DropDrmMaster() = 0;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -444,6 +444,28 @@ void DrmDisplayManager::IgnoreUpdates() {
   }
 }
 
+bool DrmDisplayManager::IsDrmMasterByDefault() {
+  spin_lock_.lock();
+  if (drm_master_) {
+    spin_lock_.unlock();
+    return drm_master_;
+  }
+  drm_magic_t magic = 0;
+  int ret = 0;
+  ret = drmGetMagic(fd_, &magic);
+  if (ret)
+    ETRACE("Failed to call drmGetMagic : %s", PRINTERROR());
+  else {
+    ret = drmAuthMagic(fd_, magic);
+    if (ret)
+      ETRACE("Failed to call drmAuthMagic : %s", PRINTERROR());
+    else
+      drm_master_ = true;
+  }
+  spin_lock_.unlock();
+  return drm_master_;
+}
+
 void DrmDisplayManager::setDrmMaster(bool must_set) {
   spin_lock_.lock();
   if (drm_master_) {

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -71,6 +71,8 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
 
   void IgnoreUpdates() override;
 
+  bool IsDrmMasterByDefault() override;
+
   void setDrmMaster(bool must_set) override;
 
   void DropDrmMaster() override;


### PR DESCRIPTION
Check if hwc is drm master by default in initialization

Use the method drmAuthMagic to check if hwc is already DRM master
or not.

Change-Id: I1931017e1223ae550c52816e6b2a64c74bdf9190
Tests: Work well on celadon with kernel 4.19.19
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>