### PR TITLE
Fixed the black stripe issue during video playback control bar popup

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -228,8 +228,15 @@ bool DisplayPlaneManager::ValidateLayers(
               validate_final_layers = !(last_plane.GetOffScreenTarget());
 
             ResetPlaneTarget(last_plane, commit_planes.back());
+          } else {
+            // Plane separation is needed
+            if (!layer->IsSolidColor() && !layer->IsVideoLayer()) {
+              // Current plane is not the video layer and not the solid
+              // color layer as well. Initialize the DisplayPlaneState
+              // object and link it with OverlayPlane object.
+              ResetPlaneTarget(last_plane, commit_planes.back());
+            }
           }
-
           break;
         } else {
           if (composition.empty()) {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -694,6 +694,11 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     }
   }
 
+  if (previous_size != size) {
+    // Validate layers if visible layers changed from last frame.
+    validate_layers = true;
+  }
+
   if (idle_frame) {
     if ((add_index != -1) || (remove_index != -1) || re_validate_commit) {
       idle_frame = false;


### PR DESCRIPTION
Let HWC validate layers if visible layers changed from last frame
and be conservative to use HW overlay if there are layers fallback
to GPU already in current frame

Change-Id: I9b3639b465583f0bf40470bbaeb8a6cfc9dcc462
Tests: Video playback control bar pop up without black flicker
Tracked-On: https://jira.devtools.intel.com/browse/OAM-72226
Signed-off-by: Wan Shuang <shuang.wan@intel.com>