### PR TITLE
When damage is same with display, keep it unchanged

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -223,6 +223,12 @@ int32_t HwcLayer::GetAcquireFence() {
 
 void HwcLayer::SufaceDamageTransfrom() {
   int ox = 0, oy = 0;
+
+  if (surface_damage_ == display_frame_) {
+    current_rendering_damage_ = surface_damage_;
+    return;
+  }
+
   HwcRect<int> translated_damage =
       TranslateRect(surface_damage_, -source_crop_.left, -source_crop_.top);
 


### PR DESCRIPTION
In some case, the damage is out of source_crop and same with
display_frame. then the damage should not be transformed.

Change-Id: I11a9575e9c9e41fb2e1e9f0af09c18c89856c069
Tests: work well with customer's OpenGL App.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-80358
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>