### PR TITLE
Disable all not-in-used plane once DRM Master is reset

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -19,6 +19,7 @@
 #include "displayplanemanager.h"
 
 #include "displayplane.h"
+#include "drm/drmplane.h"
 #include "factory.h"
 #include "hwctrace.h"
 #include "nativesurface.h"
@@ -65,6 +66,15 @@ bool DisplayPlaneManager::Initialize(uint32_t width, uint32_t height) {
   bool status = plane_handler_->PopulatePlanes(overlay_planes_);
   ResizeOverlays();
   return status;
+}
+
+void DisplayPlaneManager::ResetPlanes(drmModeAtomicReqPtr pset) {
+  for (auto j = overlay_planes_.begin(); j < overlay_planes_.end(); j++) {
+    if (!j->get()->InUse()) {
+      DrmPlane *drmplane = (DrmPlane *)(j->get());
+      drmplane->Disable(pset);
+    }
+  }
 }
 
 bool DisplayPlaneManager::ValidateLayers(

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -122,6 +122,8 @@ class DisplayPlaneManager {
 
   void ReleaseUnreservedPlanes(std::vector<uint32_t> &reserved_planes);
 
+  void ResetPlanes(drmModeAtomicReqPtr pset);
+
  private:
   DisplayPlaneState *GetLastUsedOverlay(DisplayPlaneStateList &composition);
   bool FallbacktoGPU(DisplayPlane *target_plane, OverlayLayer *layer,

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -639,14 +639,6 @@ void DisplayQueue::InitializeOverlayLayers(
   }
 }
 
-void DisplayQueue::TraceFirstCommit() {
-  struct timeval te;
-  gettimeofday(&te, NULL);  // get current time
-  long long milliseconds =
-      te.tv_sec * 1000LL + te.tv_usec / 1000;  // calculate milliseconds
-  ITRACE("First frame is Committed at %lld.", milliseconds);
-}
-
 bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
                                int32_t* retire_fence, bool* ignore_clone_update,
                                PixelUploaderCallback* call_back,
@@ -911,10 +903,6 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     composition_passed = display_->Commit(
         current_composition_planes, previous_plane_state_, disable_explictsync,
         kms_fence_, &fence, &fence_released);
-    if (first_commit_) {
-      TraceFirstCommit();
-      first_commit_ = false;
-    }
   }
 
   if (fence_released) {
@@ -1259,6 +1247,10 @@ void DisplayQueue::SetCloneMode(bool cloned) {
 
   clone_mode_ = cloned;
   clone_rendered_ = false;
+}
+
+void DisplayQueue::ResetPlanes(drmModeAtomicReqPtr pset) {
+  display_plane_manager_->ResetPlanes(pset);
 }
 
 void DisplayQueue::IgnoreUpdates() {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -104,15 +104,13 @@ class DisplayQueue {
   void UpdateScalingRatio(uint32_t primary_width, uint32_t primary_height,
                           uint32_t display_width, uint32_t display_height);
 
-  void MarkFirstCommit() {
-    first_commit_ = true;
-  }
-
   void SetCloneMode(bool cloned);
 
   void RotateDisplay(HWCRotation rotation);
 
   void IgnoreUpdates();
+
+  void ResetPlanes(drmModeAtomicReqPtr pset);
 
   void PresentClonedCommit(DisplayQueue* queue);
 
@@ -357,12 +355,9 @@ class DisplayQueue {
                                bool& has_video_layer, bool& has_cursor_layer,
                                bool& re_validate_commit, bool& idle_frame);
 
-  void TraceFirstCommit();
-
   Compositor compositor_;
   uint32_t gpu_fd_;
   uint32_t brightness_;
-  bool first_commit_ = false;
   float color_transform_matrix_[16];
   HWCColorTransform color_transform_hint_;
   uint32_t contrast_;

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -129,7 +129,9 @@ class DrmDisplay : public PhysicalDisplay {
     return planes_updated_;
   }
 
-  void MarkFirstCommit() override;
+  void MarkFirstCommit() override {
+    first_commit_ = true;
+  }
 
  private:
   void ShutDownPipe();
@@ -164,6 +166,8 @@ class DrmDisplay : public PhysicalDisplay {
                                                   uint8_t block_tag);
   void DrmConnectorGetDCIP3Support(const ScopedDrmObjectPropertyPtr &props);
 
+  void TraceFirstCommit();
+
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;
   uint32_t mmHeight_ = 0;
@@ -190,6 +194,7 @@ class DrmDisplay : public PhysicalDisplay {
   int64_t broadcastrgb_automatic_ = -1;
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
   bool planes_updated_ = false;
+  bool first_commit_ = false;
   HWCContentProtection current_protection_support_ =
       HWCContentProtection::kUnSupported;
   HWCContentProtection desired_protection_support_ =

--- a/wsi/drm/drmplane.h
+++ b/wsi/drm/drmplane.h
@@ -22,12 +22,11 @@
 
 #include <xf86drmMode.h>
 
-#include <drmscopedtypes.h>
-
 #include <vector>
 
 #include "displayplane.h"
 #include "drmbuffer.h"
+#include "drmscopedtypes.h"
 
 namespace hwcomposer {
 


### PR DESCRIPTION
A workaround for the plane refresh which is involved by
earlyEvs and AOSP EVS use different plane.

Change-Id: Ia2b28303ea0eaa6deda46e6d3a8d7a04674ea394
Tests: Work well with Kmscube testing APP.
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>