### PR TITLE
Init more program duing HWC initialization period

### DIFF
--- a/common/compositor/gl/glrenderer.cpp
+++ b/common/compositor/gl/glrenderer.cpp
@@ -64,9 +64,11 @@ bool GLRenderer::Init() {
   glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
   glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
 
-  std::unique_ptr<GLProgram> program(new GLProgram());
-  if (program->Init(1)) {
-    programs_.emplace_back(std::move(program));
+  for (int i = 1; i < 5; i++) {
+    std::unique_ptr<GLProgram> program(new GLProgram());
+    if (program->Init(i)) {
+      programs_.emplace_back(std::move(program));
+    }
   }
 
   glEnableVertexAttribArray(0);


### PR DESCRIPTION
More program may needed at runtime, if so the
program will be create at compostion time, it
will result in a very long Frame.

Change-Id: I64470f616777646d6c1d27846c8e7be0f7eb4a75
Tracked-On: https://jira.devtools.intel.com/browse/OAM-76069
Signed-off-by: Yang, Dong <dong.yang@intel.com>