### PR TITLE
Trace timestamp for first commit after DRM-Master is reset

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -130,6 +130,15 @@ bool GpuDevice::EnableDRMCommit(bool enable, uint32_t display_id) {
   return ret;
 }
 
+void GpuDevice::MarkDisplayForFirstCommit() {
+  size_t size = total_displays_.size();
+  for (size_t i = 0; i < size; i++) {
+    if (total_displays_.at(i)->IsConnected()) {
+      total_displays_.at(i)->MarkFirstCommit();
+    }
+  }
+}
+
 bool GpuDevice::ResetDrmMaster(bool drop_master) {
   bool ret = true;
   if (drop_master) {
@@ -149,6 +158,7 @@ bool GpuDevice::ResetDrmMaster(bool drop_master) {
   // In case of setDrmMaster or the lock file is not exist.
   // Re-set DRM Master true.
   display_manager_->setDrmMaster(false);
+  MarkDisplayForFirstCommit();
   ResetAllDisplayCommit(true);
   DisableWatch();
 

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -104,6 +104,10 @@ class DisplayQueue {
   void UpdateScalingRatio(uint32_t primary_width, uint32_t primary_height,
                           uint32_t display_width, uint32_t display_height);
 
+  void MarkFirstCommit() {
+    first_commit_ = true;
+  }
+
   void SetCloneMode(bool cloned);
 
   void RotateDisplay(HWCRotation rotation);
@@ -353,9 +357,12 @@ class DisplayQueue {
                                bool& has_video_layer, bool& has_cursor_layer,
                                bool& re_validate_commit, bool& idle_frame);
 
+  void TraceFirstCommit();
+
   Compositor compositor_;
   uint32_t gpu_fd_;
   uint32_t brightness_;
+  bool first_commit_ = false;
   float color_transform_matrix_[16];
   HWCColorTransform color_transform_hint_;
   uint32_t contrast_;

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -117,6 +117,8 @@ class GpuDevice : public HWCThread {
 
   void ResetAllDisplayCommit(bool enable);
 
+  void MarkDisplayForFirstCommit();
+
   enum InitializationType {
     kUnInitialized = 0,    // Nothing Initialized.
     kInitialized = 1 << 1  // Everything Initialized

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -428,6 +428,9 @@ class NativeDisplay {
     return false;
   }
 
+  virtual void MarkFirstCommit() {
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -77,6 +77,10 @@ bool DrmDisplay::InitializeDisplay() {
   return true;
 }
 
+void DrmDisplay::MarkFirstCommit() {
+  display_queue_->MarkFirstCommit();
+}
+
 std::vector<uint8_t *> DrmDisplay::FindExtendedBlocksForTag(uint8_t *edid,
                                                             uint8_t block_tag) {
   int current_block;
@@ -588,7 +592,6 @@ bool DrmDisplay::CommitFrame(
     DrmPlane *plane = static_cast<DrmPlane *>(comp_plane.GetDisplayPlane());
     if (plane->InUse())
       continue;
-
     plane->Disable(pset);
   }
 

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -129,6 +129,8 @@ class DrmDisplay : public PhysicalDisplay {
     return planes_updated_;
   }
 
+  void MarkFirstCommit() override;
+
  private:
   void ShutDownPipe();
   void GetDrmObjectPropertyValue(const char *name,


### PR DESCRIPTION
Print the timestamp for commiting the first frame after
DRM-Master is reset

Change-Id: I394916e7abf225539e3842dcce813373543ba1d6
Tests: Work well with KMSCube
Tracked-On: https://jira.devtools.intel.com/browse/OAM-79556
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>