### PR TITLE
Refactory code: commit_planes can be avoided

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -198,8 +198,7 @@ bool DisplayPlaneManager::ValidateLayers(
         // safely reset to current layer.
         previous_layer = layer;
 
-        composition.emplace_back(plane, layer, this, layer->GetZorder(),
-                                 display_transform_);
+        composition.emplace_back(plane, layer, this);
         // If we are able to composite buffer with the given plane, lets use
         // it.
         bool fall_back = FallbacktoGPU(plane, layer, composition);
@@ -466,8 +465,7 @@ void DisplayPlaneManager::ValidateCursorLayer(
     }
 
     OverlayLayer *cursor_layer = cursor_layers.at(cursor_index);
-    composition.emplace_back(plane, cursor_layer, this,
-                             cursor_layer->GetZorder(), display_transform_);
+    composition.emplace_back(plane, cursor_layer, this);
     bool fall_back = FallbacktoGPU(plane, cursor_layer, composition);
     *test_commit_done = true;
 
@@ -837,8 +835,7 @@ void DisplayPlaneManager::ForceVppForAllLayers(
   auto layer_end = layers.end();
   OverlayLayer *primary_layer = &(*(layer_begin));
   DisplayPlane *current_plane = overlay_planes_.at(composition.size()).get();
-  composition.emplace_back(current_plane, primary_layer, this,
-                           primary_layer->GetZorder(), display_transform_);
+  composition.emplace_back(current_plane, primary_layer, this);
   DisplayPlaneState &last_plane = composition.back();
   last_plane.ForceGPURendering();
   layer_begin++;
@@ -884,8 +881,7 @@ void DisplayPlaneManager::ForceGpuForAllLayers(
   OverlayLayer *primary_layer = &(*(layers.begin()));
   DisplayPlane *current_plane = overlay_planes_.at(0).get();
 
-  composition.emplace_back(current_plane, primary_layer, this,
-                           primary_layer->GetZorder(), display_transform_);
+  composition.emplace_back(current_plane, primary_layer, this);
   DisplayPlaneState &last_plane = composition.back();
   last_plane.ForceGPURendering();
   layer_begin++;

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -105,19 +105,12 @@ bool DisplayPlaneManager::ValidateLayers(
     }
   }
 
-  std::vector<OverlayPlane> commit_planes;
-
-  for (DisplayPlaneState &temp : composition) {
-    commit_planes.emplace_back(
-        OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
-  }
-
   // In case we are forcing GPU composition for all layers and using a single
   // plane.
   if (disable_overlay) {
     ISURFACETRACE("Forcing GPU For all layers %d %d %d %d \n", disable_overlay,
                   composition.empty(), add_index <= 0, layers.size());
-    ForceGpuForAllLayers(commit_planes, composition, layers, mark_later, false);
+    ForceGpuForAllLayers(composition, layers, mark_later, false);
 
     *re_validation_needed = false;
     *commit_checked = true;
@@ -146,8 +139,7 @@ bool DisplayPlaneManager::ValidateLayers(
   // We are going to force all the layers bo be composited by VA path
   // cursor layer should not be handle by VPP
   if (video_layers >= avail_planes && video_layers > 0) {
-    ForceVppForAllLayers(commit_planes, composition, layers, add_index,
-                         mark_later, false);
+    ForceVppForAllLayers(composition, layers, add_index, mark_later, false);
     *re_validation_needed = false;
     *commit_checked = true;
     return true;
@@ -178,7 +170,7 @@ bool DisplayPlaneManager::ValidateLayers(
       if (previous_layer && !composition.empty()) {
         DisplayPlaneState &last_plane = composition.back();
         if (last_plane.NeedsOffScreenComposition()) {
-          ValidateForDisplayScaling(composition.back(), commit_planes);
+          ValidateForDisplayScaling(composition.back(), composition);
         }
       }
 
@@ -206,10 +198,11 @@ bool DisplayPlaneManager::ValidateLayers(
         // safely reset to current layer.
         previous_layer = layer;
 
-        commit_planes.emplace_back(OverlayPlane(plane, layer));
+        composition.emplace_back(plane, layer, this, layer->GetZorder(),
+                                 display_transform_);
         // If we are able to composite buffer with the given plane, lets use
         // it.
-        bool fall_back = FallbacktoGPU(plane, layer, commit_planes);
+        bool fall_back = FallbacktoGPU(plane, layer, composition);
         test_commit_done = true;
         bool force_separate = false;
         if (fall_back && !prefer_seperate_plane && !composition.empty()) {
@@ -221,8 +214,6 @@ bool DisplayPlaneManager::ValidateLayers(
           if (validate_final_layers)
             validate_final_layers = fall_back;
 
-          composition.emplace_back(plane, layer, this, layer->GetZorder(),
-                                   display_transform_);
           ISURFACETRACE(
               "Added Layer for direct Scanout: layer index: %d "
               "validate_final_layers: %d force_separate: %d fall_back: %d \n",
@@ -237,26 +228,24 @@ bool DisplayPlaneManager::ValidateLayers(
             if (!validate_final_layers)
               validate_final_layers = !(last_plane.GetOffScreenTarget());
 
-            ResetPlaneTarget(last_plane, commit_planes.back());
+            ResetPlaneTarget(last_plane);
           } else {
             // Plane separation is needed
             if (!layer->IsSolidColor() && !layer->IsVideoLayer()) {
               // Current plane is not the video layer and not the solid
               // color layer as well. Initialize the DisplayPlaneState
               // object and link it with OverlayPlane object.
-              ResetPlaneTarget(last_plane, commit_planes.back());
+              ResetPlaneTarget(last_plane);
             }
           }
           break;
         } else {
-          if (composition.empty()) {
-            composition.emplace_back(plane, layer, this, layer->GetZorder(),
-                                     display_transform_);
+          if (composition.size() == 1) {
             ISURFACETRACE("Added Layer: %d %d validate_final_layers: %d  \n",
                           layer->GetZorder(), composition.size(),
                           validate_final_layers);
             DisplayPlaneState &last_plane = composition.back();
-            ResetPlaneTarget(last_plane, commit_planes.back());
+            ResetPlaneTarget(last_plane);
             validate_final_layers = true;
             if (display_transform_ != kIdentity) {
               // If DisplayTransform is not supported, let's check if
@@ -269,7 +258,7 @@ bool DisplayPlaneManager::ValidateLayers(
                 // Check if we can rotate using Display plane.
                 if (FallbacktoGPU(last_plane.GetDisplayPlane(),
                                   last_plane.GetOffScreenTarget()->GetLayer(),
-                                  commit_planes)) {
+                                  composition)) {
                   last_plane.SetRotationType(
                       DisplayPlaneState::RotationType::kGPURotation, true);
                 } else {
@@ -280,13 +269,14 @@ bool DisplayPlaneManager::ValidateLayers(
 
             break;
           } else {
-            commit_planes.pop_back();
+            composition.pop_back();
+
             ISURFACETRACE("Added Layer: %d %d validate_final_layers: %d  \n",
                           layer->GetZorder(), composition.size(),
                           validate_final_layers);
             composition.back().AddLayer(layer);
-            while (SquashPlanesAsNeeded(layers, composition, commit_planes,
-                                        mark_later, &validate_final_layers)) {
+            while (SquashPlanesAsNeeded(layers, composition, mark_later,
+                                        &validate_final_layers)) {
               j--;
               plane = j->get();
             }
@@ -294,7 +284,7 @@ bool DisplayPlaneManager::ValidateLayers(
             DisplayPlaneState &last_plane = composition.back();
             if (!validate_final_layers)
               validate_final_layers = !(last_plane.GetOffScreenTarget());
-            ResetPlaneTarget(last_plane, commit_planes.back());
+            ResetPlaneTarget(last_plane);
           }
         }
       }
@@ -322,9 +312,8 @@ bool DisplayPlaneManager::ValidateLayers(
         if (needsquash) {
           // squash no video plane and return the
           ITRACE("ValidateLayers Squash non video planes need");
-          size_t squashed_planes =
-              SquashNonVideoPlanes(layers, composition, commit_planes,
-                                   mark_later, &validate_final_layers);
+          size_t squashed_planes = SquashNonVideoPlanes(
+              layers, composition, mark_later, &validate_final_layers);
           j -= squashed_planes;
         }
       }
@@ -349,8 +338,8 @@ bool DisplayPlaneManager::ValidateLayers(
       }
 
       if (composition.back().NeedsOffScreenComposition()) {
-        while (SquashPlanesAsNeeded(layers, composition, commit_planes,
-                                    mark_later, &validate_final_layers)) {
+        while (SquashPlanesAsNeeded(layers, composition, mark_later,
+                                    &validate_final_layers)) {
           continue;
         }
         DisplayPlaneState &squashed_plane = composition.back();
@@ -364,23 +353,20 @@ bool DisplayPlaneManager::ValidateLayers(
         }
 
         if (force_buffer || squashed_plane.NeedsSurfaceAllocation()) {
-          ResetPlaneTarget(squashed_plane, commit_planes.back());
+          ResetPlaneTarget(squashed_plane);
           validate_final_layers = true;
         }
 
         if (previous_layer) {
           squashed_plane.UsePlaneScalar(false);
         }
-
-        commit_planes.back().layer = squashed_plane.GetOverlayLayer();
       }
     }
   }
 
   if (!cursor_layers.empty()) {
-    ValidateCursorLayer(layers, commit_planes, cursor_layers, mark_later,
-                        composition, &validate_final_layers, &test_commit_done,
-                        false);
+    ValidateCursorLayer(layers, cursor_layers, mark_later, composition,
+                        &validate_final_layers, &test_commit_done, false);
 
     if (validate_final_layers && add_index > 0 &&
         (composition.size() == (overlay_planes_.size() - 1))) {
@@ -400,13 +386,12 @@ bool DisplayPlaneManager::ValidateLayers(
   }
 
   if (validate_final_layers) {
-    ValidateFinalLayers(commit_planes, composition, layers, mark_later, false);
+    ValidateFinalLayers(composition, layers, mark_later, false);
     test_commit_done = true;
   }
 
   bool render_layers = false;
-  FinalizeValidation(composition, commit_planes, &render_layers,
-                     re_validation_needed);
+  FinalizeValidation(composition, &render_layers, re_validation_needed);
   *commit_checked = test_commit_done;
   return render_layers;
 }
@@ -449,7 +434,6 @@ void DisplayPlaneManager::PreparePlaneForCursor(
 
 void DisplayPlaneManager::ValidateCursorLayer(
     std::vector<OverlayLayer> &all_layers,
-    std::vector<OverlayPlane> &commit_planes,
     std::vector<OverlayLayer *> &cursor_layers,
     std::vector<NativeSurface *> &mark_later,
     DisplayPlaneStateList &composition, bool *validate_final_layers,
@@ -482,19 +466,20 @@ void DisplayPlaneManager::ValidateCursorLayer(
     }
 
     OverlayLayer *cursor_layer = cursor_layers.at(cursor_index);
-    commit_planes.emplace_back(OverlayPlane(plane, cursor_layer));
-    bool fall_back = FallbacktoGPU(plane, cursor_layer, commit_planes);
+    composition.emplace_back(plane, cursor_layer, this,
+                             cursor_layer->GetZorder(), display_transform_);
+    bool fall_back = FallbacktoGPU(plane, cursor_layer, composition);
     *test_commit_done = true;
 
     // Lets ensure we fall back to GPU composition in case
     // cursor layer cannot be scanned out directly.
     if (fall_back && !is_video && last_plane) {
-      commit_planes.pop_back();
+      composition.pop_back();
       cursor_layer->SetLayerComposition(OverlayLayer::kGpu);
       ISURFACETRACE("Added CursorLayer: %d \n", cursor_layer->GetZorder());
       last_plane->AddLayer(cursor_layer);
-      while (SquashPlanesAsNeeded(all_layers, composition, commit_planes,
-                                  mark_later, validate_final_layers)) {
+      while (SquashPlanesAsNeeded(all_layers, composition, mark_later,
+                                  validate_final_layers)) {
         continue;
       }
 
@@ -508,19 +493,8 @@ void DisplayPlaneManager::ValidateCursorLayer(
       PreparePlaneForCursor(last_plane, mark_later, validate_final_layers,
                             last_plane->IsVideoPlane(), recycle_resources);
 
-      if (reset_overlay) {
-        // Layer for the plane should have changed, reset commit planes.
-        std::vector<OverlayPlane>().swap(commit_planes);
-        for (DisplayPlaneState &temp : composition) {
-          commit_planes.emplace_back(
-              OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
-        }
-      }
-
       last_plane->UsePlaneScalar(false);
     } else {
-      composition.emplace_back(plane, cursor_layer, this,
-                               cursor_layer->GetZorder(), display_transform_);
       ISURFACETRACE("Added CursorLayer for direct scanout: %d \n",
                     cursor_layer->GetZorder());
       plane->SetInUse(true);
@@ -555,8 +529,8 @@ void DisplayPlaneManager::ValidateCursorLayer(
     last_plane->AddLayer(cursor_layer);
     cursor_layer->SetLayerComposition(OverlayLayer::kGpu);
     last_layer = cursor_layer;
-    while (SquashPlanesAsNeeded(all_layers, composition, commit_planes,
-                                mark_later, validate_final_layers)) {
+    while (SquashPlanesAsNeeded(all_layers, composition, mark_later,
+                                validate_final_layers)) {
       continue;
     }
 
@@ -571,8 +545,7 @@ void DisplayPlaneManager::ValidateCursorLayer(
 }
 
 void DisplayPlaneManager::ValidateForDisplayTransform(
-    DisplayPlaneState &last_plane,
-    const std::vector<OverlayPlane> &commit_planes) {
+    DisplayPlaneState &last_plane, const DisplayPlaneStateList &composition) {
   if (display_transform_ != kIdentity) {
     // No need for any check if we are relying on rotation during
     // 3D Composition pass.
@@ -586,7 +559,7 @@ void DisplayPlaneManager::ValidateForDisplayTransform(
       // Ensure Rotation doesn't impact the results.
       if (FallbacktoGPU(last_plane.GetDisplayPlane(),
                         last_plane.GetOffScreenTarget()->GetLayer(),
-                        commit_planes)) {
+                        composition)) {
         last_plane.SetRotationType(
             DisplayPlaneState::RotationType::kGPURotation, false);
       }
@@ -601,8 +574,7 @@ void DisplayPlaneManager::ValidateForDisplayTransform(
 }
 
 void DisplayPlaneManager::ValidateForDownScaling(
-    DisplayPlaneState &last_plane,
-    const std::vector<OverlayPlane> &commit_planes) {
+    DisplayPlaneState &last_plane, const DisplayPlaneStateList &composition) {
 #ifdef ENABLE_DOWNSCALING
   uint32_t original_downscaling_factor = last_plane.GetDownScalingFactor();
   if (last_plane.RevalidationType() &
@@ -610,7 +582,7 @@ void DisplayPlaneManager::ValidateForDownScaling(
     last_plane.SetDisplayDownScalingFactor(1, false);
     if (!last_plane.IsUsingPlaneScalar() && last_plane.CanUseGPUDownScaling()) {
       last_plane.SetDisplayDownScalingFactor(4, false);
-      if (!plane_handler_->TestCommit(commit_planes)) {
+      if (!plane_handler_->TestCommit(composition)) {
         last_plane.SetDisplayDownScalingFactor(1, false);
       }
     }
@@ -624,13 +596,13 @@ void DisplayPlaneManager::ValidateForDownScaling(
     last_plane.RefreshSurfaces(NativeSurface::kFullClear, true);
   }
 #else
-  HWC_UNUSED(commit_planes);
+  HWC_UNUSED(composition);
   HWC_UNUSED(last_plane);
 #endif
 }
 
 void DisplayPlaneManager::ValidateForDisplayScaling(
-    DisplayPlaneState &last_plane, std::vector<OverlayPlane> &commit_planes) {
+    DisplayPlaneState &last_plane, const DisplayPlaneStateList &composition) {
   last_plane.ValidateReValidation();
   if (!(last_plane.RevalidationType() &
         DisplayPlaneState::ReValidationType::kUpScalar)) {
@@ -658,17 +630,15 @@ void DisplayPlaneManager::ValidateForDisplayScaling(
 
   // Display frame and Source rect are different, let's check if
   // we can take advantage of scalars attached to this plane.
-  if (last_plane.IsVideoPlane())
+  if (last_plane.IsVideoPlane()) {
     last_plane.UsePlaneScalar(false, false);
-  else
-    last_plane.UsePlaneScalar(true, false);
-
-  OverlayPlane &last_overlay_plane = commit_planes.back();
-  last_overlay_plane.layer = last_plane.GetOverlayLayer();
+    return;
+  }
+  last_plane.UsePlaneScalar(true, false);
 
   bool fall_back =
       FallbacktoGPU(last_plane.GetDisplayPlane(),
-                    last_plane.GetOffScreenTarget()->GetLayer(), commit_planes);
+                    last_plane.GetOffScreenTarget()->GetLayer(), composition);
   if (fall_back) {
     last_plane.UsePlaneScalar(false, false);
   }
@@ -678,13 +648,10 @@ void DisplayPlaneManager::ValidateForDisplayScaling(
   }
 }
 
-void DisplayPlaneManager::ResetPlaneTarget(DisplayPlaneState &plane,
-                                           OverlayPlane &overlay_plane) {
+void DisplayPlaneManager::ResetPlaneTarget(DisplayPlaneState &plane) {
   if (plane.NeedsSurfaceAllocation()) {
     SetOffScreenPlaneTarget(plane);
   }
-
-  overlay_plane.layer = plane.GetOverlayLayer();
 }
 
 void DisplayPlaneManager::ReleaseUnreservedPlanes(
@@ -796,7 +763,6 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 }
 
 void DisplayPlaneManager::ValidateFinalLayers(
-    std::vector<OverlayPlane> &commit_planes,
     DisplayPlaneStateList &composition, std::vector<OverlayLayer> &layers,
     std::vector<NativeSurface *> &mark_later, bool recycle_resources) {
   for (DisplayPlaneState &plane : composition) {
@@ -806,15 +772,14 @@ void DisplayPlaneManager::ValidateFinalLayers(
   }
 
   // If this combination fails just fall back to 3D for all layers.
-  if (!plane_handler_->TestCommit(commit_planes)) {
-    ForceGpuForAllLayers(commit_planes, composition, layers, mark_later,
-                         recycle_resources);
+  if (!plane_handler_->TestCommit(composition)) {
+    ForceGpuForAllLayers(composition, layers, mark_later, recycle_resources);
   }
 }
 
 bool DisplayPlaneManager::FallbacktoGPU(
     DisplayPlane *target_plane, OverlayLayer *layer,
-    const std::vector<OverlayPlane> &commit_planes) const {
+    const DisplayPlaneStateList &composition) const {
   // SolidColor can't be scanout directly
   if (layer->IsSolidColor())
     return true;
@@ -838,7 +803,7 @@ bool DisplayPlaneManager::FallbacktoGPU(
 
   // TODO(kalyank): Take relevant factors into consideration to determine if
   // Plane Composition makes sense. i.e. layer size etc
-  if (!plane_handler_->TestCommit(commit_planes)) {
+  if (!plane_handler_->TestCommit(composition)) {
     return true;
   }
 
@@ -851,7 +816,6 @@ bool DisplayPlaneManager::CheckPlaneFormat(uint32_t format) {
 }
 
 void DisplayPlaneManager::ForceVppForAllLayers(
-    std::vector<OverlayPlane> &commit_planes,
     DisplayPlaneStateList &composition, std::vector<OverlayLayer> &layers,
     size_t add_index, std::vector<NativeSurface *> &mark_later,
     bool recycle_resources) {
@@ -863,7 +827,6 @@ void DisplayPlaneManager::ForceVppForAllLayers(
       MarkSurfacesForRecycling(&plane, mark_later, recycle_resources);
     }
     DisplayPlaneStateList().swap(composition);
-    std::vector<OverlayPlane>().swap(commit_planes);
     auto overlay_begin = overlay_planes_.begin();
     // Let's mark all planes as free to be used.
     for (auto j = overlay_begin; j < overlay_planes_.end(); ++j) {
@@ -890,22 +853,18 @@ void DisplayPlaneManager::ForceVppForAllLayers(
   last_plane.SetVideoPlane(true);
   EnsureOffScreenTarget(last_plane);
   current_plane->SetInUse(true);
-
-  commit_planes.emplace_back(
-      OverlayPlane(last_plane.GetDisplayPlane(), last_plane.GetOverlayLayer()));
   // Check for Any display transform to be applied.
-  ValidateForDisplayTransform(last_plane, commit_planes);
+  ValidateForDisplayTransform(last_plane, composition);
   // Check for any change to scalar usage.
-  ValidateForDisplayScaling(last_plane, commit_planes);
+  ValidateForDisplayScaling(last_plane, composition);
   // Check for Downscaling.
-  ValidateForDownScaling(last_plane, commit_planes);
+  ValidateForDownScaling(last_plane, composition);
   // Reset andy Scanout validation state.
   uint32_t validation_done = DisplayPlaneState::ReValidationType::kScanout;
   last_plane.RevalidationDone(validation_done);
 }
 
 void DisplayPlaneManager::ForceGpuForAllLayers(
-    std::vector<OverlayPlane> &commit_planes,
     DisplayPlaneStateList &composition, std::vector<OverlayLayer> &layers,
     std::vector<NativeSurface *> &mark_later, bool recycle_resources) {
   // Let's mark all planes as free to be used.
@@ -922,7 +881,6 @@ void DisplayPlaneManager::ForceGpuForAllLayers(
   auto layer_begin = layers.begin();
   auto layer_end = layers.end();
   DisplayPlaneStateList().swap(composition);
-  std::vector<OverlayPlane>().swap(commit_planes);
   OverlayLayer *primary_layer = &(*(layers.begin()));
   DisplayPlane *current_plane = overlay_planes_.at(0).get();
 
@@ -942,14 +900,12 @@ void DisplayPlaneManager::ForceGpuForAllLayers(
 
   EnsureOffScreenTarget(last_plane);
   current_plane->SetInUse(true);
-  commit_planes.emplace_back(
-      OverlayPlane(last_plane.GetDisplayPlane(), last_plane.GetOverlayLayer()));
   // Check for Any display transform to be applied.
-  ValidateForDisplayTransform(last_plane, commit_planes);
+  ValidateForDisplayTransform(last_plane, composition);
   // Check for any change to scalar usage.
-  ValidateForDisplayScaling(last_plane, commit_planes);
+  ValidateForDisplayScaling(last_plane, composition);
   // Check for Downscaling.
-  ValidateForDownScaling(last_plane, commit_planes);
+  ValidateForDownScaling(last_plane, composition);
   // Reset andy Scanout validation state.
   uint32_t validation_done = DisplayPlaneState::ReValidationType::kScanout;
   last_plane.RevalidationDone(validation_done);
@@ -1002,21 +958,16 @@ bool DisplayPlaneManager::ReValidatePlanes(
   *request_full_validation = false;
   bool render = false;
   bool reset_composition_region = false;
-  std::vector<OverlayPlane> commit_planes;
   for (DisplayPlaneState &temp : composition) {
-    commit_planes.emplace_back(
-        OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
-
     if (temp.Scanout()) {
       continue;
     }
-
     render = true;
   }
 
   if (re_validate_commit) {
     // If this combination fails just fall back to full validation.
-    if (!plane_handler_->TestCommit(commit_planes)) {
+    if (!plane_handler_->TestCommit(composition)) {
       ISURFACETRACE(
           "ReValidatePlanes Test commit failed. Forcing full validation. \n");
       *request_full_validation = true;
@@ -1065,15 +1016,12 @@ bool DisplayPlaneManager::ReValidatePlanes(
 
       layer->SetLayerComposition(OverlayLayer::kDisplay);
 
-      commit_planes.at(index).layer = last_plane.GetOverlayLayer();
-
       // If this combination fails just fall back to original state.
-      if (FallbacktoGPU(last_plane.GetDisplayPlane(), layer, commit_planes)) {
+      if (FallbacktoGPU(last_plane.GetDisplayPlane(), layer, composition)) {
         // Reset to old state.
         last_plane.ForceGPURendering();
         layer->SetLayerComposition(OverlayLayer::kGpu);
         last_plane.SetOverlayLayer(current_layer);
-        commit_planes.at(index).layer = last_plane.GetOverlayLayer();
         if (uses_scalar)
           last_plane.UsePlaneScalar(true, false);
       } else {
@@ -1087,7 +1035,7 @@ bool DisplayPlaneManager::ReValidatePlanes(
     render = true;
     index++;
     if (revalidation_type & DisplayPlaneState::ReValidationType::kUpScalar) {
-      ValidateForDisplayScaling(last_plane, commit_planes);
+      ValidateForDisplayScaling(last_plane, composition);
       validation_done |= DisplayPlaneState::ReValidationType::kUpScalar;
     }
 
@@ -1111,7 +1059,7 @@ bool DisplayPlaneManager::ReValidatePlanes(
       EnsureOffScreenTarget(last_plane);
       if (FallbacktoGPU(last_plane.GetDisplayPlane(),
                         last_plane.GetOffScreenTarget()->GetLayer(),
-                        commit_planes)) {
+                        composition)) {
         new_type = DisplayPlaneState::RotationType::kGPURotation;
       }
 
@@ -1132,7 +1080,7 @@ bool DisplayPlaneManager::ReValidatePlanes(
           last_plane.SetDisplayDownScalingFactor(1, true);
       } else {
         // Check for Downscaling.
-        ValidateForDownScaling(last_plane, commit_planes);
+        ValidateForDownScaling(last_plane, composition);
       }
     }
 
@@ -1142,10 +1090,9 @@ bool DisplayPlaneManager::ReValidatePlanes(
   return render;
 }
 
-void DisplayPlaneManager::FinalizeValidation(
-    DisplayPlaneStateList &composition,
-    std::vector<OverlayPlane> &commit_planes, bool *render_layers,
-    bool *re_validation_needed) {
+void DisplayPlaneManager::FinalizeValidation(DisplayPlaneStateList &composition,
+                                             bool *render_layers,
+                                             bool *re_validation_needed) {
   bool re_validation = false;
   bool needs_gpu = false;
   for (DisplayPlaneState &plane : composition) {
@@ -1153,10 +1100,10 @@ void DisplayPlaneManager::FinalizeValidation(
       plane.RefreshSurfaces(NativeSurface::kFullClear);
       plane.ValidateReValidation();
       // Check for Any display transform to be applied.
-      ValidateForDisplayTransform(plane, commit_planes);
+      ValidateForDisplayTransform(plane, composition);
 
       // Check for Downscaling.
-      ValidateForDownScaling(plane, commit_planes);
+      ValidateForDownScaling(plane, composition);
 
       if (!needs_gpu) {
         needs_gpu = !plane.IsSurfaceRecycled();
@@ -1178,7 +1125,6 @@ void DisplayPlaneManager::FinalizeValidation(
 
 size_t DisplayPlaneManager::SquashNonVideoPlanes(
     const std::vector<OverlayLayer> &layers, DisplayPlaneStateList &composition,
-    std::vector<OverlayPlane> &commit_planes,
     std::vector<NativeSurface *> &mark_later, bool *validate_final_layers) {
   size_t composition_index = composition.size() - 1;
   size_t squashed_count = 0;
@@ -1215,21 +1161,11 @@ size_t DisplayPlaneManager::SquashNonVideoPlanes(
     composition_index--;
   }
 
-  if (!commit_planes.empty() && squashed_count) {
-    // Layer for the plane should have changed, reset commit planes.
-    std::vector<OverlayPlane>().swap(commit_planes);
-    for (DisplayPlaneState &temp : composition) {
-      commit_planes.emplace_back(
-          OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
-    }
-  }
-
   return squashed_count;
 }
 
 bool DisplayPlaneManager::SquashPlanesAsNeeded(
     const std::vector<OverlayLayer> &layers, DisplayPlaneStateList &composition,
-    std::vector<OverlayPlane> &commit_planes,
     std::vector<NativeSurface *> &mark_later, bool *validate_final_layers) {
   bool status = false;
   if (composition.size() > 1) {
@@ -1284,15 +1220,6 @@ bool DisplayPlaneManager::SquashPlanesAsNeeded(
         if (squashed_plane.NeedsSurfaceAllocation()) {
           SetOffScreenPlaneTarget(squashed_plane);
           *validate_final_layers = true;
-        }
-
-        if (!commit_planes.empty()) {
-          // Layer for the plane should have changed, reset commit planes.
-          std::vector<OverlayPlane>().swap(commit_planes);
-          for (DisplayPlaneState &temp : composition) {
-            commit_planes.emplace_back(
-                OverlayPlane(temp.GetDisplayPlane(), temp.GetOverlayLayer()));
-          }
         }
       }
     }

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -96,6 +96,10 @@ class DisplayPlaneManager {
   // with pipe of this displayplanemanager.
   void SetDisplayTransform(uint32_t transform);
 
+  uint32_t GetDisplayTransform() const {
+    return display_transform_;
+  }
+
   // If we have two planes as follows:
   // Plane N: Having top and bottom layer and needs 3d rendering.
   // Plane N-1 covering the middle layer of screen.

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -103,13 +103,11 @@ class DisplayPlaneManager {
   // one, otherwise we will scanout garbage with plane N.
   bool SquashPlanesAsNeeded(const std::vector<OverlayLayer> &layers,
                             DisplayPlaneStateList &composition,
-                            std::vector<OverlayPlane> &commit_planes,
                             std::vector<NativeSurface *> &mark_later,
                             bool *validate_final_layers);
 
   size_t SquashNonVideoPlanes(const std::vector<OverlayLayer> &layers,
                               DisplayPlaneStateList &composition,
-                              std::vector<OverlayPlane> &commit_planes,
                               std::vector<NativeSurface *> &mark_later,
                               bool *validate_final_layers);
 
@@ -127,15 +125,14 @@ class DisplayPlaneManager {
  private:
   DisplayPlaneState *GetLastUsedOverlay(DisplayPlaneStateList &composition);
   bool FallbacktoGPU(DisplayPlane *target_plane, OverlayLayer *layer,
-                     const std::vector<OverlayPlane> &commit_planes) const;
+                     const DisplayPlaneStateList &composition) const;
 
-  void ValidateFinalLayers(std::vector<OverlayPlane> &commit_planes,
-                           DisplayPlaneStateList &list,
+  void ValidateFinalLayers(DisplayPlaneStateList &list,
                            std::vector<OverlayLayer> &layers,
                            std::vector<NativeSurface *> &mark_later,
                            bool recycle_resources);
 
-  void ResetPlaneTarget(DisplayPlaneState &plane, OverlayPlane &overlay_plane);
+  void ResetPlaneTarget(DisplayPlaneState &plane);
 
   void EnsureOffScreenTarget(DisplayPlaneState &plane);
 
@@ -145,25 +142,22 @@ class DisplayPlaneManager {
                              bool recycle_resources);
 
   void ValidateForDisplayScaling(DisplayPlaneState &last_plane,
-                                 std::vector<OverlayPlane> &commit_planes);
+                                 const DisplayPlaneStateList &composition);
 
   // Checks if we can benefit using display plane rotation.
-  void ValidateForDisplayTransform(
-      DisplayPlaneState &last_plane,
-      const std::vector<OverlayPlane> &commit_planes);
+  void ValidateForDisplayTransform(DisplayPlaneState &last_plane,
+                                   const DisplayPlaneStateList &composition);
 
   // Checks if we can benefit by downscaling layer of this plane.
   void ValidateForDownScaling(DisplayPlaneState &last_plane,
-                              const std::vector<OverlayPlane> &commit_planes);
+                              const DisplayPlaneStateList &composition);
 
-  void ForceGpuForAllLayers(std::vector<OverlayPlane> &commit_planes,
-                            DisplayPlaneStateList &composition,
+  void ForceGpuForAllLayers(DisplayPlaneStateList &composition,
                             std::vector<OverlayLayer> &layers,
                             std::vector<NativeSurface *> &mark_later,
                             bool recycle_resources);
 
-  void ForceVppForAllLayers(std::vector<OverlayPlane> &commit_planes,
-                            DisplayPlaneStateList &composition,
+  void ForceVppForAllLayers(DisplayPlaneStateList &composition,
                             std::vector<OverlayLayer> &layers, size_t add_index,
                             std::vector<NativeSurface *> &mark_later,
                             bool recycle_resources);
@@ -172,18 +166,15 @@ class DisplayPlaneManager {
   // being added and all other layers are same as previous
   // frame.
   void ValidateCursorLayer(std::vector<OverlayLayer> &all_layers,
-                           std::vector<OverlayPlane> &commit_planes,
                            std::vector<OverlayLayer *> &cursor_layers,
                            std::vector<NativeSurface *> &mark_later,
                            DisplayPlaneStateList &composition,
                            bool *validate_final_layers, bool *test_commit_done,
                            bool recycle_resources);
 
-  bool CheckForDownScaling(DisplayPlaneStateList &composition,
-                           std::vector<OverlayPlane> &commit_planes);
+  bool CheckForDownScaling(DisplayPlaneStateList &composition);
 
   void FinalizeValidation(DisplayPlaneStateList &composition,
-                          std::vector<OverlayPlane> &commit_planes,
                           bool *render_layers, bool *re_validation_needed);
 
   void ResizeOverlays();

--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -37,10 +37,9 @@ DisplayPlaneState::DisplayPlanePrivateState::~DisplayPlanePrivateState() {
 }
 
 DisplayPlaneState::DisplayPlaneState(DisplayPlane *plane, OverlayLayer *layer,
-                                     DisplayPlaneManager *plane_manager,
-                                     uint32_t index, uint32_t plane_transform) {
+                                     DisplayPlaneManager *plane_manager) {
   private_data_ = std::make_shared<DisplayPlanePrivateState>();
-  private_data_->source_layers_.emplace_back(index);
+  private_data_->source_layers_.emplace_back(layer->GetZorder());
   private_data_->display_frame_ = layer->GetDisplayFrame();
   private_data_->rect_updated_ = true;
   private_data_->source_crop_ = layer->GetSourceCrop();
@@ -52,8 +51,9 @@ DisplayPlaneState::DisplayPlaneState(DisplayPlane *plane, OverlayLayer *layer,
   plane->SetInUse(true);
   private_data_->plane_ = plane;
   private_data_->layer_ = layer;
-  private_data_->plane_transform_ = plane_transform;
-  if (!private_data_->plane_->IsSupportedTransform(plane_transform)) {
+  private_data_->plane_transform_ = plane_manager->GetDisplayTransform();
+  if (!private_data_->plane_->IsSupportedTransform(
+          private_data_->plane_transform_)) {
     private_data_->rotation_type_ =
         DisplayPlaneState::RotationType::kGPURotation;
     private_data_->unsupported_display_rotation_ = true;

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -54,8 +54,7 @@ class DisplayPlaneState {
   DisplayPlaneState(DisplayPlaneState &&rhs) = default;
   DisplayPlaneState &operator=(DisplayPlaneState &&other) = default;
   DisplayPlaneState(DisplayPlane *plane, OverlayLayer *layer,
-                    DisplayPlaneManager *plane_manager, uint32_t index,
-                    uint32_t plane_transform);
+                    DisplayPlaneManager *plane_manager);
 
   // Copies plane state from state.
   void CopyState(DisplayPlaneState &state);

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -256,10 +256,8 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
           continue;
         }
 
-        std::vector<OverlayPlane> temp;
         while (display_plane_manager_->SquashPlanesAsNeeded(
-            layers, *composition, temp, surfaces_not_inuse_,
-            &plane_validation)) {
+            layers, *composition, surfaces_not_inuse_, &plane_validation)) {
           continue;
         }
         DisplayPlaneState& squashed_plane = composition->back();
@@ -383,10 +381,8 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
         }
 
         if (refresh_surfaces || reset_plane || update_rect) {
-          std::vector<OverlayPlane> temp;
           bool squashed = display_plane_manager_->SquashPlanesAsNeeded(
-              layers, *composition, temp, surfaces_not_inuse_,
-              &plane_validation);
+              layers, *composition, surfaces_not_inuse_, &plane_validation);
           if (squashed) {
             // We squashed planes and it's not the last one.
             // We might have messed up with plane order, let's
@@ -397,7 +393,7 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
               return;
             } else {
               while (display_plane_manager_->SquashPlanesAsNeeded(
-                  layers, *composition, temp, surfaces_not_inuse_,
+                  layers, *composition, surfaces_not_inuse_,
                   &plane_validation)) {
                 continue;
               }

--- a/wsi/displayplanehandler.h
+++ b/wsi/displayplanehandler.h
@@ -17,9 +17,9 @@
 #ifndef WSI_DISPLAYPLANEHANDLER_H_
 #define WSI_DISPLAYPLANEHANDLER_H_
 
+#include "displayplanestate.h"
 namespace hwcomposer {
 
-class DisplayPlane;
 struct OverlayLayer;
 
 struct OverlayPlane {
@@ -39,8 +39,7 @@ class DisplayPlaneHandler {
   virtual bool PopulatePlanes(
       std::vector<std::unique_ptr<DisplayPlane>>& overlay_planes) = 0;
 
-  virtual bool TestCommit(
-      const std::vector<OverlayPlane>& commit_planes) const = 0;
+  virtual bool TestCommit(const DisplayPlaneStateList& composition) const = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -1123,12 +1123,12 @@ void DrmDisplay::NotifyClientsOfDisplayChangeStatus() {
   manager_->NotifyClientsOfDisplayChangeStatus();
 }
 
-bool DrmDisplay::TestCommit(
-    const std::vector<OverlayPlane> &commit_planes) const {
+bool DrmDisplay::TestCommit(const DisplayPlaneStateList &composition) const {
   ScopedDrmAtomicReqPtr pset(drmModeAtomicAlloc());
-  for (auto i = commit_planes.begin(); i != commit_planes.end(); i++) {
-    DrmPlane *plane = static_cast<DrmPlane *>(i->plane);
-    if (!(plane->UpdateProperties(pset.get(), crtc_id_, i->layer, true))) {
+  for (auto &plane_state : composition) {
+    DrmPlane *plane = static_cast<DrmPlane *>(plane_state.GetDisplayPlane());
+    if (!(plane->UpdateProperties(pset.get(), crtc_id_,
+                                  plane_state.GetOverlayLayer(), true))) {
       return false;
     }
   }

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -97,8 +97,7 @@ class DrmDisplay : public PhysicalDisplay {
   void SetDisplayAttribute(const drmModeModeInfo &mode_info);
   void SetFakeAttribute(const drmModeModeInfo &mode_info);
 
-  bool TestCommit(
-      const std::vector<OverlayPlane> &commit_planes) const override;
+  bool TestCommit(const DisplayPlaneStateList &commit_planes) const override;
 
   bool PopulatePlanes(
       std::vector<std::unique_ptr<DisplayPlane>> &overlay_planes) override;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -483,7 +483,7 @@ bool PhysicalDisplay::PopulatePlanes(
 }
 
 bool PhysicalDisplay::TestCommit(
-    const std::vector<OverlayPlane> & /*commit_planes*/) const {
+    const DisplayPlaneStateList & /*commit_planes*/) const {
   ETRACE("TestCommit unimplemented in PhysicalDisplay.");
   return false;
 }

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -106,8 +106,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
 
   bool IsConnected() const override;
 
-  bool TestCommit(
-      const std::vector<OverlayPlane> &commit_planes) const override;
+  bool TestCommit(const DisplayPlaneStateList &commit_planes) const override;
 
   bool PopulatePlanes(
       std::vector<std::unique_ptr<DisplayPlane>> &overlay_planes) override;


### PR DESCRIPTION
DisplayPlaneStateList already hold that.
Reduce double vectors can avoid logic complexity

Change-Id: Id8704b6aa8d925ce76708d51dd155fba17decb17
Tests: Android UI normal
Tracked-On: None
Signed-off-by: Lin Johnson <johnson.lin@intel.com>