### PR TITLE
Avoid to re-validate Video Plane for Scaler

### DIFF
--- a/common/display/displayplanestate.cpp
+++ b/common/display/displayplanestate.cpp
@@ -612,7 +612,7 @@ void DisplayPlaneState::ValidateReValidation() {
   if (private_data_->source_layers_.size() == 1 &&
       !(private_data_->type_ == DisplayPlanePrivateState::PlaneType::kVideo)) {
     re_validate_layer_ |= ReValidationType::kScanout;
-  } else {
+  } else if (!IsVideoPlane()) {
     bool use_scalar = CanUseDisplayUpScaling();
     if (private_data_->use_plane_scalar_ != use_scalar) {
       re_validate_layer_ |= ReValidationType::kUpScalar;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -644,8 +644,14 @@ bool DrmDisplay::CommitFrame(
         comp_plane.GetRotationType();
     if ((plane_transform != kIdentity) &&
         (rotation_type == DisplayPlaneState::RotationType::kDisplayRotation)) {
-      HwcRect<int> rotated_rect =
-          RotateScaleRect(display_rect, width_, height_, plane_transform);
+      HwcRect<int> rotated_rect;
+      if (layer->IsVideoLayer()) {
+        rotated_rect =
+            RotateRect(display_rect, width_, height_, plane_transform);
+      } else {
+        rotated_rect =
+            RotateScaleRect(display_rect, width_, height_, plane_transform);
+      }
       layer->SetDisplayFrame(rotated_rect);
     }
 


### PR DESCRIPTION
Video Plane is now scaled by VPP, instead of Display Plane any
more. No need to re-validate Video Plane for scaler.

Change-Id: I870ab3d7ecf966180f83552e13d7f05885cb34e5
Tests: Work well on extend mode with rotate in Playing video
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>