### PR TITLE
Fixed the external display hang during video playback.

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -241,7 +241,11 @@ bool DisplayPlaneManager::ValidateLayers(
           } else {
             // Plane separation is needed
             if (!layer->IsSolidColor() && !layer->IsVideoLayer()) {
-              // Current plane is not the video layer and not the solid
+              // validate_final_layers needs to be updated to ensure
+              // plane squashing works as expected.
+              if (!validate_final_layers)
+                validate_final_layers = !(last_plane.GetOffScreenTarget());
+              // Current layer is not the video layer and not the solid
               // color layer as well. Initialize the DisplayPlaneState
               // object and link it with OverlayPlane object.
               ResetPlaneTarget(last_plane, commit_planes.back());


### PR DESCRIPTION
Update validate_final_layers state to ensure HWC update plans'
status properly and make the plane squashing behavior works as
expected.

Change-Id: I5f5aa496e57753da6b6e72f82900461ca672d367
Test: External display is not hang during video playback
Tracked-On: None
Signed-off-by: Wan Shuang <shuang.wan@intel.com>