### PR TITLE
Set the alpha of solid_color as 0xff by default

### DIFF
--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -348,7 +348,7 @@ struct HwcLayer {
       kVisible | kSurfaceDamageChanged | kVisibleRegionChanged | kZorderChanged;
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
-  uint32_t solid_color_ = 0;
+  uint32_t solid_color_ = 0xff;
 
   HWCLayerCompositionType composition_type_ = Composition_Device;
 };


### PR DESCRIPTION
For avoiding to impact the alpha of layer in case that solid_color
is not set.

Change-Id: I2030165839a9c7f371fed6f81279ac2d94db084e
Tests: Work well on GP-P
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>