### PR TITLE
Revert 2 black stripe related patches

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -238,19 +238,8 @@ bool DisplayPlaneManager::ValidateLayers(
               validate_final_layers = !(last_plane.GetOffScreenTarget());
 
             ResetPlaneTarget(last_plane, commit_planes.back());
-          } else {
-            // Plane separation is needed
-            if (!layer->IsSolidColor() && !layer->IsVideoLayer()) {
-              // validate_final_layers needs to be updated to ensure
-              // plane squashing works as expected.
-              if (!validate_final_layers)
-                validate_final_layers = !(last_plane.GetOffScreenTarget());
-              // Current layer is not the video layer and not the solid
-              // color layer as well. Initialize the DisplayPlaneState
-              // object and link it with OverlayPlane object.
-              ResetPlaneTarget(last_plane, commit_planes.back());
-            }
           }
+
           break;
         } else {
           if (composition.empty()) {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -688,11 +688,6 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     }
   }
 
-  if (previous_size != size) {
-    // Validate layers if visible layers changed from last frame.
-    validate_layers = true;
-  }
-
   if (idle_frame) {
     if ((add_index != -1) || (remove_index != -1) || re_validate_commit) {
       idle_frame = false;


### PR DESCRIPTION
Revert "Fixed the external display hang during video playback."
Revert "Fixed the black stripe issue during video playback control bar popup"

Change-Id: I2638468a04518ba9f45209eb5a8486a8de86b99d
Tests: Video playback with 2 displays and check plane & layer binding.
TrackOn: None
Signed-off-by: Wan Shuang <shuang.wan@intel.com>