### PR TITLE
Fix surface-damage error in SF-rotate 180

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -187,7 +187,7 @@ void OverlayLayer::ValidateTransform(uint32_t transform,
 void OverlayLayer::TransformDamage(HwcLayer* layer, uint32_t max_height,
                                    uint32_t max_width) {
   const HwcRect<int>& surface_damage = layer->GetLayerDamage();
-  if (surface_damage.empty()) {
+  if (surface_damage.empty() || !layer->HasSurfaceDamageRegionChanged()) {
     surface_damage_ = surface_damage;
     return;
   }
@@ -223,7 +223,12 @@ void OverlayLayer::TransformDamage(HwcLayer* layer, uint32_t max_height,
     surface_damage_.right = translated_damage.bottom * ratio_w_h + 0.5;
     surface_damage_.bottom = oy - translated_damage.left * ratio_h_w + 0.5;
   } else if (plane_transform_ == kTransform180) {
-    surface_damage_ = translated_damage;
+    ox = max_width;
+    oy = max_height;
+    surface_damage_.left = ox - translated_damage.right;
+    surface_damage_.top = oy - translated_damage.bottom;
+    surface_damage_.right = ox - translated_damage.left;
+    surface_damage_.bottom = oy - translated_damage.top;
   } else if (plane_transform_ & hwcomposer::HWCTransform::kTransform90) {
     if (plane_transform_ & kReflectX) {
       surface_damage_.left = translated_damage.top * ratio_w_h + 0.5;


### PR DESCRIPTION
When 'SetSurfaceDamage' is invoked without damage, surface_damage
should not be rotated too. and For 180 case, the size should be
rotated too for SF-rotation.

Change-Id: I231a08de6fb5017bca60f8be02146fb2a0a06e33
Tests: Work well on extend mode with rotate_90, 180 and 270
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>