### PR TITLE
Add a property for merged HWC and SF rotation status

### DIFF
--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -88,12 +88,18 @@ struct OverlayLayer {
     return transform_;
   }
 
+  // This represents hwc transform setting for this
+  // display on which this layer is being shown.
+  uint32_t GetPlaneTransform() const {
+    return plane_transform_;
+  }
+
   // This represents any transform applied
   // to this layer(i.e. GetTransform()) + overall
   // rotation applied to the display on which this
   // layer is being shown.
-  uint32_t GetPlaneTransform() const {
-    return plane_transform_;
+  uint32_t GetMergedTransform() const {
+    return merged_transform_;
   }
 
   // Applies transform to this layer before scanout.
@@ -289,6 +295,7 @@ struct OverlayLayer {
 
   uint32_t transform_ = 0;
   uint32_t plane_transform_ = 0;
+  uint32_t merged_transform_ = 0;
   uint32_t z_order_ = 0;
   uint32_t layer_index_ = 0;
   uint32_t source_crop_width_ = 0;

--- a/wsi/drm/drmplane.cpp
+++ b/wsi/drm/drmplane.cpp
@@ -342,7 +342,7 @@ bool DrmPlane::UpdateProperties(drmModeAtomicReqPtr property_set,
 
   if (rotation_prop_.id) {
     uint32_t rotation = 0;
-    uint32_t transform = layer->GetPlaneTransform();
+    uint32_t transform = layer->GetMergedTransform();
     if (transform & kTransform90) {
       rotation |= DRM_MODE_ROTATE_90;
       if (transform & kReflectX)
@@ -456,7 +456,7 @@ bool DrmPlane::ValidateLayer(const OverlayLayer* layer) {
   }
 
   bool zero_rotation = false;
-  uint32_t transform = layer->GetPlaneTransform();
+  uint32_t transform = layer->GetMergedTransform();
   if (transform == kIdentity) {
     zero_rotation = true;
   }


### PR DESCRIPTION
In SF rotation, display_frame and surface are already rotated from
SF. we need to split the rotation status for HWC and SF into
transform_ and plane_transform_ for deciding if display_frame and
surface need to be rotated. and add an property for merged rotation
for rotate surface_damage.

Change-Id: I0ce8522c2a9807d4194d0a8b8334b0f984def2b6
Tests: Work well in SF rotation on GP P and Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>