### PR TITLE
Only enable RBC when single display is connected

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -1147,7 +1147,7 @@ bool DrmDisplay::PopulatePlanes(
 
     bool use_modifier = true;
 #ifdef MODIFICATOR_WA
-    use_modifier = (manager_->GetConnectedPhysicalDisplayCount() < 3);
+    use_modifier = (manager_->GetConnectedPhysicalDisplayCount() < 2);
     if (i >= 2)
       use_modifier = false;
 #endif


### PR DESCRIPTION
RBC will be disabled when 2 or more displays are connected

Change-Id: I8944fb7070c99fad30732077f06b4c9e5e2bacd3
Tests: RBC only enabled with 1 connected display
Tracked-On: https://github.com/intel/IA-Hardware-Composer/issues/585
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>