### PR TITLE
[WA]Force refresh layer content on extend display

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -571,7 +571,7 @@ void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
 
   if (!layer->HasVisibleRegionChanged() && !content_changed &&
       surface_damage_.empty() && !layer->HasLayerContentChanged() &&
-      !(state_ & kNeedsReValidation)) {
+      !(state_ & kNeedsReValidation) && !force_content_changed_) {
     state_ &= ~kLayerContentChanged;
   }
 }

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -123,11 +123,17 @@ struct OverlayLayer {
   }
 
   const HwcRect<int>& GetSurfaceDamage() const {
-    return surface_damage_;
+    if (force_content_changed_)
+      return display_frame_;
+    else
+      return surface_damage_;
   }
 
   HwcRect<int>& GetSurfaceDamage() {
-    return surface_damage_;
+    if (force_content_changed_)
+      return display_frame_;
+    else
+      return surface_damage_;
   }
 
   uint32_t GetSourceCropWidth() const {
@@ -252,6 +258,10 @@ struct OverlayLayer {
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
                   ResourceManager* resource_manager, uint32_t z_order);
 
+  void SetForceContentChanged() {
+    force_content_changed_ = true;
+  }
+
   void Dump();
 
  private:
@@ -306,6 +316,7 @@ struct OverlayLayer {
   uint32_t dataspace_ = 0;
 
   uint32_t solid_color_ = 0;
+  bool force_content_changed_ = false;
 
   HwcRect<float> source_crop_;
   HwcRect<int> display_frame_;

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -545,6 +545,8 @@ void DisplayQueue::InitializeOverlayLayers(
 
     layers.emplace_back();
     OverlayLayer* overlay_layer = &(layers.back());
+    if (refrsh_display_id_ > 0)
+      overlay_layer->SetForceContentChanged();
     OverlayLayer* previous_layer = NULL;
     if (previous_size > z_order) {
       previous_layer = &(in_flight_layers_.at(z_order));


### PR DESCRIPTION
In "Presentation with Media Router" test case, the surface-damage
for the changing layer on extend display is 0. For work around it
HWC will mark "content is changed" for all layers on extend display

Change-Id: I048b56e967a6f06ba73eff5ae77c95a55cbd028c
Tests:         Tested on Android Q
Tracked-On:    None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>