### PR TITLE
Assign the render_area when surface_damage is empty

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -277,6 +277,8 @@ void HwcLayer::SufaceDamageTransfrom() {
         (current_rendering_damage_.right - current_rendering_damage_.left),
         (current_rendering_damage_.bottom - current_rendering_damage_.top));
 #endif
+  } else if (surface_damage_.empty()) {
+    current_rendering_damage_ = surface_damage_;
   } else {
     current_rendering_damage_ = translated_damage;
   }
@@ -293,7 +295,6 @@ void HwcLayer::Validate() {
     layer_cache_ &= ~kSourceRectChanged;
     if (state_ & kSurfaceDamageChanged) {
       SufaceDamageTransfrom();
-      state_ &= ~kSurfaceDamageChanged;
     }
   }
 


### PR DESCRIPTION
In some case, the left and top of source_crop is not 0,
the empty surface_damage will not be transformed correctly.

Change-Id: I98971705924b63df2655a7e19df26d8c433fbfe4
Tests:     Work well on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>