### PR TITLE
Force commit when surface damage for layer is 0000

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -437,7 +437,8 @@ void DisplayQueue::GetCachedLayers(const std::vector<OverlayLayer>& layers,
         reset_composition_regions = true;
 
       last_plane.SetOverlayLayer(layer);
-      if (layer->HasLayerContentChanged()) {
+      if (layer->HasLayerContentChanged() ||
+          layer->GetSurfaceDamage().empty()) {
         ignore_commit = false;
       }
 


### PR DESCRIPTION
The behavior of SF is changed. the empty of damage array are not
sent for sleeping(s3). Add a workaround to avoid flicking

Change-Id: I4c38ebe570be5ffe2c7dc206345d75d95ea45823
Tests: Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-83039
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>