### PR TITLE
Revert "[WA]Force refresh layer content on extend display"

### DIFF
--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -571,7 +571,7 @@ void OverlayLayer::ValidatePreviousFrameState(OverlayLayer* rhs,
 
   if (!layer->HasVisibleRegionChanged() && !content_changed &&
       surface_damage_.empty() && !layer->HasLayerContentChanged() &&
-      !(state_ & kNeedsReValidation) && !force_content_changed_) {
+      !(state_ & kNeedsReValidation)) {
     state_ &= ~kLayerContentChanged;
   }
 }

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -123,17 +123,11 @@ struct OverlayLayer {
   }
 
   const HwcRect<int>& GetSurfaceDamage() const {
-    if (force_content_changed_)
-      return display_frame_;
-    else
-      return surface_damage_;
+    return surface_damage_;
   }
 
   HwcRect<int>& GetSurfaceDamage() {
-    if (force_content_changed_)
-      return display_frame_;
-    else
-      return surface_damage_;
+    return surface_damage_;
   }
 
   uint32_t GetSourceCropWidth() const {
@@ -258,10 +252,6 @@ struct OverlayLayer {
   void CloneLayer(const OverlayLayer* layer, const HwcRect<int>& display_frame,
                   ResourceManager* resource_manager, uint32_t z_order);
 
-  void SetForceContentChanged() {
-    force_content_changed_ = true;
-  }
-
   void Dump();
 
  private:
@@ -316,7 +306,6 @@ struct OverlayLayer {
   uint32_t dataspace_ = 0;
 
   uint32_t solid_color_ = 0;
-  bool force_content_changed_ = false;
 
   HwcRect<float> source_crop_;
   HwcRect<int> display_frame_;

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -545,8 +545,6 @@ void DisplayQueue::InitializeOverlayLayers(
 
     layers.emplace_back();
     OverlayLayer* overlay_layer = &(layers.back());
-    if (refrsh_display_id_ > 0)
-      overlay_layer->SetForceContentChanged();
     OverlayLayer* previous_layer = NULL;
     if (previous_size > z_order) {
       previous_layer = &(in_flight_layers_.at(z_order));


### PR DESCRIPTION
The surface damage issue is fixed by AOSP patch
https://android.intel.com/#/c/672623/1
The WA is not needed any more
This reverts commit 95ec73b8710df14915d8bab798c7d9ee04c79c4e.

Change-Id: I5d675d20de486d688f43f09a5a292821184bc9ce
Tests: Work well with AOSP patch on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>