### PR TITLE
Fix klocwork issues in GFX domain base on #80 daily scan

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -400,8 +400,6 @@ void GpuDevice::ParseLogicalDisplaySetting(
       logical_split_str.find_first_not_of("0123456789") != std::string::npos)
     return;
   uint32_t physical_index = atoi(physical_index_str.c_str());
-  if (physical_index < 0)
-    return;
   uint32_t logical_split_num = atoi(logical_split_str.c_str());
   if (logical_split_num <= 1)
     return;

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -169,6 +169,7 @@ void DrmDisplay::GetEDIDDisplayData(const ScopedDrmObjectPropertyPtr &props) {
 
   edid = (uint8_t *)blob->data;
   if (!edid) {
+    drmModeFreePropertyBlob(blob);
     return;
   }
   std::memset(display_data, 0, sizeof(display_data));
@@ -196,6 +197,7 @@ void DrmDisplay::GetEDIDDisplayData(const ScopedDrmObjectPropertyPtr &props) {
     }
   }
 
+  drmModeFreePropertyBlob(blob);
   ITRACE("Got EDID display name \"%s\"\n", display_name_.c_str());
 }
 

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -198,7 +198,7 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
   bool planes_updated_ = false;
   bool first_commit_ = false;
-  std::string display_name_;
+  std::string display_name_ = "";
   HWCContentProtection current_protection_support_ =
       HWCContentProtection::kUnSupported;
   HWCContentProtection desired_protection_support_ =


### PR DESCRIPTION
Revert an old fix because it dosen't pass kw scan.
Add more initialization statements and resource free functions.
