### PR TITLE
Filter EDIP for prefer and performance config

### DIFF
--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -409,6 +409,64 @@ bool DrmDisplay::GetDisplayAttribute(uint32_t config /*config*/,
   return status;
 }
 
+uint32_t DrmDisplay::FindPreferedDisplayMode(size_t modes_size) {
+  uint32_t prefer_display_mode = 0;
+  if (modes_size > 1) {
+    SPIN_LOCK(display_lock_);
+    for (size_t i = 0; i < modes_size; i++) {
+      // There is only one preferred mode per connector.
+      if (modes_[i].type & DRM_MODE_TYPE_PREFERRED) {
+        prefer_display_mode = i;
+        IHOTPLUGEVENTTRACE("Preferred display config is found. index: %d", i);
+        break;
+      }
+    }
+    SPIN_UNLOCK(display_lock_);
+  }
+  if (prefer_display_mode_ != prefer_display_mode)
+    prefer_display_mode_ = prefer_display_mode;
+  return prefer_display_mode;
+}
+
+uint32_t DrmDisplay::FindPerformaceDisplayMode(size_t modes_size) {
+  uint32_t perf_display_mode;
+  perf_display_mode = prefer_display_mode_;
+  if (modes_size >= prefer_display_mode_) {
+    int32_t prefer_width = 0, prefer_height = 0, prefer_interval = 0;
+    int32_t perf_width = 0, perf_height = 0, perf_interval = 0,
+            previous_perf_interval = 0;
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kWidth,
+                        &prefer_width);
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kHeight,
+                        &prefer_height);
+    GetDisplayAttribute(prefer_display_mode_, HWCDisplayAttribute::kRefreshRate,
+                        &prefer_interval);
+    previous_perf_interval = prefer_interval;
+    IHOTPLUGEVENTTRACE("Preferred width:%d, height:%d, interval:%d",
+                       prefer_width, prefer_height, prefer_interval);
+    for (size_t i = 0; i < modes_size; i++) {
+      if (i != prefer_display_mode_) {
+        GetDisplayAttribute(i, HWCDisplayAttribute::kWidth, &perf_width);
+        GetDisplayAttribute(i, HWCDisplayAttribute::kHeight, &perf_height);
+        GetDisplayAttribute(i, HWCDisplayAttribute::kRefreshRate,
+                            &perf_interval);
+        IHOTPLUGEVENTTRACE("EDIP item width:%d, height:%d, rate:%d", perf_width,
+                           perf_height, perf_interval);
+        if (prefer_width == perf_width && prefer_height == perf_height &&
+            prefer_interval > perf_interval &&
+            previous_perf_interval > perf_interval) {
+          perf_display_mode = i;
+          previous_perf_interval = perf_interval;
+        }
+      }
+    }
+  }
+  if (perf_display_mode_ != perf_display_mode)
+    perf_display_mode_ = perf_display_mode;
+  IHOTPLUGEVENTTRACE("PerformaceDisplayMode: %d", perf_display_mode_);
+  return perf_display_mode;
+}
+
 bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
   if (!num_configs)
     return false;
@@ -421,8 +479,16 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
     return PhysicalDisplay::GetDisplayConfigs(num_configs, configs);
   }
 
+  uint32_t prefer_display_mode = prefer_display_mode_;
+  uint32_t perf_display_mode = perf_display_mode_;
+
   if (!configs) {
-    *num_configs = modes_size;
+    prefer_display_mode = FindPreferedDisplayMode(modes_size);
+    perf_display_mode = FindPerformaceDisplayMode(modes_size);
+    if (prefer_display_mode == perf_display_mode)
+      *num_configs = 1;
+    else
+      *num_configs = 2;
     IHOTPLUGEVENTTRACE(
         "GetDisplayConfigs: Total Configs: %d pipe: %d display: %p",
         *num_configs, pipe_, this);
@@ -433,9 +499,9 @@ bool DrmDisplay::GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) {
       "GetDisplayConfigs: Populating Configs: %d pipe: %d display: %p",
       *num_configs, pipe_, this);
 
-  uint32_t size = *num_configs > modes_size ? modes_size : *num_configs;
-  for (uint32_t i = 0; i < size; i++)
-    configs[i] = i;
+  configs[0] = prefer_display_mode;
+  if (prefer_display_mode != perf_display_mode)
+    configs[1] = perf_display_mode;
 
   return true;
 }

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -155,68 +155,6 @@ void DrmDisplay::DrmConnectorGetDCIP3Support(
   return;
 }
 
-void DrmDisplay::GetEDIDDisplayData(const ScopedDrmObjectPropertyPtr &props) {
-  uint8_t *edid = NULL;
-  uint64_t edid_blob_id;
-  struct edid_display_data display_data[4];
-  drmModePropertyBlobPtr blob;
-
-  GetDrmObjectPropertyValue("EDID", props, &edid_blob_id);
-  blob = drmModeGetPropertyBlob(gpu_fd_, edid_blob_id);
-  if (!blob) {
-    return;
-  }
-
-  edid = (uint8_t *)blob->data;
-  if (!edid) {
-    drmModeFreePropertyBlob(blob);
-    return;
-  }
-  std::memset(display_data, 0, sizeof(display_data));
-  std::memcpy((void *)display_data, (void *)(edid + 54),
-              sizeof(edid_display_data) * 4);
-
-  for (int i = 0; i < 4; i++) {
-    if (!(display_data[i].indicate == 0x0000 &&
-          display_data[i].reserved1 == 0x00 &&
-          display_data[i].reserved2 == 0x00))
-      continue;
-
-    if (display_data[i].tag_number == 0xfc) {
-      display_name_.clear();
-      size_t display_desc_size =
-          sizeof(((struct edid_display_data *)0)->desc_data);
-      size_t display_desc_str_size =
-          strchrnul((char *)display_data[i].desc_data, '\n') -
-          (char *)display_data[i].desc_data;
-      size_t display_desc_copy_size = display_desc_str_size > display_desc_size
-                                          ? display_desc_size
-                                          : display_desc_str_size;
-      display_name_.assign((char *)display_data[i].desc_data,
-                           display_desc_copy_size);
-    }
-  }
-
-  drmModeFreePropertyBlob(blob);
-  ITRACE("Got EDID display name \"%s\"\n", display_name_.c_str());
-}
-
-/*
-* Check limited monitors exposing some modes which not
-* be supported by monitor hardware actually. Limited monitors
-* be defined in HWC_LIMITED_MONITOR_LIST.
-*/
-bool DrmDisplay::CheckLimitedMonitor() {
-  for (unsigned int i = 0; i < HWC_LIMITED_MONITOR_LIST.size(); ++i) {
-    if (display_name_.compare(HWC_LIMITED_MONITOR_LIST[i]) == 0) {
-      ITRACE("Got a limited monitor: %s\n",
-             HWC_LIMITED_MONITOR_LIST[i].c_str());
-      return true;
-    }
-  }
-  return false;
-}
-
 bool DrmDisplay::ConnectDisplay(const drmModeModeInfo &mode_info,
                                 const drmModeConnector *connector,
                                 uint32_t config) {
@@ -293,8 +231,6 @@ bool DrmDisplay::ConnectDisplay(const drmModeModeInfo &mode_info,
   } else {
     ITRACE("DCIP3 support not available");
   }
-
-  GetEDIDDisplayData(connector_props);
 
   PhysicalDisplay::Connect();
   SetHDCPState(desired_protection_support_, content_type_);
@@ -773,6 +709,7 @@ void DrmDisplay::SetDrmModeInfo(const std::vector<drmModeModeInfo> &mode_info) {
 #endif
       modes_.emplace_back(mode_info[i]);
   }
+
   SPIN_UNLOCK(display_lock_);
 }
 

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -171,6 +171,9 @@ class DrmDisplay : public PhysicalDisplay {
 
   void TraceFirstCommit();
 
+  uint32_t FindPreferedDisplayMode(size_t modes_size);
+  uint32_t FindPerformaceDisplayMode(size_t modes_size);
+
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;
   uint32_t mmHeight_ = 0;
@@ -198,6 +201,8 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t flags_ = DRM_MODE_ATOMIC_ALLOW_MODESET;
   bool planes_updated_ = false;
   bool first_commit_ = false;
+  uint32_t prefer_display_mode_ = 0;
+  uint32_t perf_display_mode_ = 0;
   std::string display_name_ = "";
   HWCContentProtection current_protection_support_ =
       HWCContentProtection::kUnSupported;

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -133,8 +133,6 @@ class DrmDisplay : public PhysicalDisplay {
     first_commit_ = true;
   }
 
-  bool CheckLimitedMonitor();
-
  private:
   void ShutDownPipe();
   void GetDrmObjectPropertyValue(const char *name,
@@ -167,7 +165,6 @@ class DrmDisplay : public PhysicalDisplay {
   std::vector<uint8_t *> FindExtendedBlocksForTag(uint8_t *edid,
                                                   uint8_t block_tag);
   void DrmConnectorGetDCIP3Support(const ScopedDrmObjectPropertyPtr &props);
-  void GetEDIDDisplayData(const ScopedDrmObjectPropertyPtr &props);
 
   void TraceFirstCommit();
 

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -306,14 +306,7 @@ bool DrmDisplayManager::UpdateDisplayState() {
                              encoder->crtc_id, display->CrtcId(),
                              display->GetDisplayPipe());
           // Set the modes supported for each display
-          if (display->CheckLimitedMonitor()) {
-            // only expose the preferred mode for limited monitor
-            std::vector<drmModeModeInfo> limited_mode(
-                1, connector->modes[preferred_mode]);
-            display->SetDrmModeInfo(limited_mode);
-          } else {
-            display->SetDrmModeInfo(mode);
-          }
+          display->SetDrmModeInfo(mode);
           break;
         }
       }
@@ -361,14 +354,7 @@ bool DrmDisplayManager::UpdateDisplayState() {
           IHOTPLUGEVENTTRACE("Connected with crtc: %d pipe:%d \n",
                              display->CrtcId(), display->GetDisplayPipe());
           // Set the modes supported for each display
-          if (display->CheckLimitedMonitor()) {
-            // only expose the preferred mode for limited monitor
-            std::vector<drmModeModeInfo> limited_mode(
-                1, connector->modes[preferred_mode]);
-            display->SetDrmModeInfo(limited_mode);
-          } else {
-            display->SetDrmModeInfo(mode);
-          }
+          display->SetDrmModeInfo(mode);
           break;
         }
       }

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -306,15 +306,5 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   uint32_t config_ = DEFAULT_CONFIG_ID;
 };
 
-struct __attribute__((packed)) edid_display_data {
-  uint16_t indicate;
-  uint8_t reserved1;
-  uint8_t tag_number;
-  uint8_t reserved2;
-  uint8_t desc_data[13];
-};
-
-const std::vector<std::string> HWC_LIMITED_MONITOR_LIST{"TD2230 Series"};
-
 }  // namespace hwcomposer
 #endif  // WSI_PHYSICALDISPLAY_H_


### PR DESCRIPTION
Asked by AOSP, only 2 display config should be return to SF
one is the preferred config. and the other is optional better
performance config.

Change-Id: I966bbdeb819e54b12a5ef37103e593207b95a940
Tests: Work well on Android Q GP
Tracked-On: https://jira.devtools.intel.com/browse/OAM-83748
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>