### PR TITLE
Add power mode set when connecting display even in connected state.

### DIFF
--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -152,6 +152,10 @@ void PhysicalDisplay::Connect() {
 
   SPIN_LOCK(modeset_lock_);
   if (connection_state_ & kConnected) {
+    IHOTPLUGEVENTTRACE(
+        "PhysicalDisplay::Connect connected already, return with power mode "
+        "update.");
+    UpdatePowerMode();
     SPIN_UNLOCK(modeset_lock_);
     return;
   }


### PR DESCRIPTION
This is WA as APL NUC always triggers hotplug when resume from S3,
which causes the postpone mode set be ingnored and display can't
be resumed from blackscreen.

Change-Id: I49e66552b373f1adde7aa6d04a19c508adeab991
Test: Display can be resumed from S3 successfully.
Tracked-On: OAM-81142
Sighed-off-by: Yugang, Fan <yugang.fan@intel.com>