### PR TITLE
Force VPP rendering when has_video and "ForceGpuForAllLayers"

### DIFF
--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -133,7 +133,7 @@ class DisplayPlaneManager {
                            DisplayPlaneStateList &list,
                            std::vector<OverlayLayer> &layers,
                            std::vector<NativeSurface *> &mark_later,
-                           bool recycle_resources);
+                           bool recycle_resources, size_t add_index);
 
   void ResetPlaneTarget(DisplayPlaneState &plane, OverlayPlane &overlay_plane);
 


### PR DESCRIPTION
Once video is contained, use VPP to compose all layers instead
of OpenGL render

Change-Id: I4e5bafe34c691d8c4b8ed8526ba0f3d20619b082
Tests: Work on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>