### PR TITLE
Set the dest buffer usage for Protected video

### DIFF
--- a/common/compositor/nativesurface.cpp
+++ b/common/compositor/nativesurface.cpp
@@ -53,7 +53,8 @@ bool NativeSurface::Init(ResourceManager *resource_manager, uint32_t format,
   *modifier_succeeded = false;
   bool modifier_used = false;
 
-  if (usage == hwcomposer::kLayerVideo) {
+  if (usage == hwcomposer::kLayerVideo ||
+      usage == hwcomposer::kLayerProtected) {
     modifier = 0;
   }
 

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -779,14 +779,15 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 
   if (!surface) {
     NativeSurface *new_surface = NULL;
-    if (video_separate) {
+    if (plane.IsVideoPlane() && (plane.GetSourceLayers().size() == 1)) {
       new_surface = CreateVideoSurface(width_, height_);
+      if (plane.GetOverlayLayer()->IsProtected())
+        usage = hwcomposer::kLayerProtected;
+      else
+        usage = hwcomposer::kLayerVideo;
     } else {
       new_surface = Create3DSurface(width_, height_);
     }
-
-    if (plane.IsVideoPlane() && (plane.GetSourceLayers().size() == 1))
-      usage = hwcomposer::kLayerVideo;
 
     bool modifer_succeeded = false;
     new_surface->Init(resource_manager_, preferred_format, usage, modifier,

--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -166,9 +166,10 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
   }
 #endif
 
-  if ((layer_type == hwcomposer::kLayerVideo) &&
+  if ((layer_type == hwcomposer::kLayerVideo ||
+       layer_type == hwcomposer::kLayerProtected) &&
       !IsSupportedMediaFormat(format)) {
-    ETRACE("Forcing normal usage for Video Layer. \n");
+    ITRACE("Forcing normal usage for Video Layer. \n");
     force_normal_usage = true;
   }
 
@@ -176,7 +177,6 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
     usage |= GRALLOC1_CONSUMER_USAGE_HWCOMPOSER |
              GRALLOC1_PRODUCER_USAGE_GPU_RENDER_TARGET |
              GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE;
-    layer_type = hwcomposer::kLayerNormal;
   } else if (layer_type == hwcomposer::kLayerVideo ||
              layer_type == hwcomposer::kLayerProtected) {
     switch (pixel_format) {

--- a/wsi/drm/drmbuffer.cpp
+++ b/wsi/drm/drmbuffer.cpp
@@ -109,6 +109,9 @@ void DrmBuffer::InitializeFromNativeHandle(HWCNativeHandle handle,
   }
 
   media_image_.handle_ = image_.handle_;
+  if (handle->meta_data_.usage_ == kLayerProtected) {
+    image_.handle_->meta_data_.usage_ = handle->meta_data_.usage_;
+  }
   Initialize(image_.handle_->meta_data_);
   original_handle_ = handle;
 }


### PR DESCRIPTION
The protected layer usage should be set in dest buffer
to make sure even if the buffer is created with format AB24
it is still a video layer.

Change-Id: Ibbe43e008a771ef33c06006259ece2dc7ace1162
Tests: Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-82976
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>