### PR TITLE
Set the dest layer as Video when the format is AB24

### DIFF
--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -149,16 +149,21 @@ bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
 
   set_format_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_, pixel_format);
 #ifdef ENABLE_RBC
-  uint64_t modifier = 0;
-  if (set_modifier_) {
-    if (preferred_modifier != -1) {
-      modifier = preferred_modifier;
+  if (preferred_modifier != 0) {
+    uint64_t modifier = 0;
+    if (set_modifier_) {
+      if (preferred_modifier != -1) {
+        modifier = preferred_modifier;
+      }
+      set_modifier_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_,
+                    modifier);
     }
-    set_modifier_(gralloc1_dvc, temp->gralloc1_buffer_descriptor_t_, modifier);
-  }
 
-  if (modifier_used && modifier != DRM_FORMAT_MOD_NONE) {
-    *modifier_used = true;
+    if (modifier_used && modifier != DRM_FORMAT_MOD_NONE) {
+      *modifier_used = true;
+    }
+  } else {
+    *modifier_used = false;
   }
 #else
   if (modifier_used) {


### PR DESCRIPTION
After create the layer surface with format AB24 for video or protected
layer. need to re-set the layer as Video.
also do not use RBC once the preferred modifier is 0.

Change-Id: Ic01b7069186d847d923af77ea257fb886f5429bb
Tests: Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-82976
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>