### PR TITLE
Fix a logic error that some overlay plane is used twice in one frame …

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -288,6 +288,8 @@ bool DisplayPlaneManager::ValidateLayers(
             ISURFACETRACE("Added Layer: %d %d validate_final_layers: %d  \n",
                           layer->GetZorder(), composition.size(),
                           validate_final_layers);
+            j--;
+            plane = j->get();
             composition.back().AddLayer(layer);
             while (SquashPlanesAsNeeded(layers, composition, commit_planes,
                                         mark_later, &validate_final_layers)) {
@@ -299,6 +301,7 @@ bool DisplayPlaneManager::ValidateLayers(
             if (!validate_final_layers)
               validate_final_layers = !(last_plane.GetOffScreenTarget());
             ResetPlaneTarget(last_plane, commit_planes.back());
+            break;
           }
         }
       }


### PR DESCRIPTION
…composition

After a commit_planes pop out, it shouldn't directly jump over the current plane.
Otherwise, it could waste an overlay plane. So add "j--", then in the next layer
mapping, it could still try to use that plane.

After the SquashPlanesAsNeeded done, it should "break" and check the next plane.
Otherwise, the current plane could be used twice.

Change-Id: Id7a883844b6384002c5ee31708225ff2f0172c44
Tracked-On: https://jira.devtools.intel.com/browse/OAM-83890
Signed-off-by: Yi Yao <yi.yao@intel.com>