### PR TITLE
[Do not merge]Revert "Assign the render_area when surface_damage is e…

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -277,8 +277,6 @@ void HwcLayer::SufaceDamageTransfrom() {
         (current_rendering_damage_.right - current_rendering_damage_.left),
         (current_rendering_damage_.bottom - current_rendering_damage_.top));
 #endif
-  } else if (surface_damage_.empty()) {
-    current_rendering_damage_ = surface_damage_;
   } else {
     current_rendering_damage_ = translated_damage;
   }
@@ -295,6 +293,7 @@ void HwcLayer::Validate() {
     layer_cache_ &= ~kSourceRectChanged;
     if (state_ & kSurfaceDamageChanged) {
       SufaceDamageTransfrom();
+      state_ &= ~kSurfaceDamageChanged;
     }
   }
 


### PR DESCRIPTION
…mpty"

This commit could cause partial refresh issue, revert it.
This reverts commit 38539ba32438908e82975564854f6ac3e1dde2c9.

Tests: Work well on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>