### PR TITLE
[code refine] correct error log message in the right component.

### DIFF
--- a/common/compositor/compositorthread.cpp
+++ b/common/compositor/compositorthread.cpp
@@ -68,7 +68,7 @@ void CompositorThread::FreeResources() {
 
 void CompositorThread::Wait() {
   if (fd_chandler_.Poll(-1) <= 0) {
-    ETRACE("Poll Failed in DisplayManager %s", PRINTERROR());
+    ETRACE("Poll Failed in CompositorThread %s", PRINTERROR());
     return;
   }
 

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -762,18 +762,19 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
     preferred_format = plane.GetDisplayPlane()->GetPreferredFormat();
   }
 
-  uint64_t modifier = plane.GetDisplayPlane()->GetPreferredFormatModifier();
+  uint64_t preferred_modifier =
+      plane.GetDisplayPlane()->GetPreferredFormatModifier();
   if (plane.IsVideoPlane())
-    modifier = 0;
-  for (auto &fb : surfaces_) {
-    if (fb->GetSurfaceAge() == -1) {
-      OverlayBuffer *layer_buffer = fb->GetLayer()->GetBuffer();
+    preferred_modifier = 0;
+  for (auto &srf : surfaces_) {
+    if (srf->GetSurfaceAge() == -1) {
+      OverlayBuffer *layer_buffer = srf->GetLayer()->GetBuffer();
       if (!layer_buffer)
         continue;
       uint32_t surface_format = layer_buffer->GetFormat();
       if ((preferred_format == surface_format) &&
-          (fb->GetModifier() == modifier)) {
-        surface = fb.get();
+          (preferred_modifier == srf->GetModifier())) {
+        surface = srf.get();
         break;
       }
     }
@@ -789,8 +790,8 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
     }
 
     bool modifer_succeeded = false;
-    new_surface->Init(resource_manager_, preferred_format, usage, modifier,
-                      &modifer_succeeded);
+    new_surface->Init(resource_manager_, preferred_format, usage,
+                      preferred_modifier, &modifer_succeeded);
     if (video_separate)
       new_surface->GetLayer()->SetVideoLayer(true);
 

--- a/common/utils/hwcthread.cpp
+++ b/common/utils/hwcthread.cpp
@@ -72,7 +72,7 @@ void HWCThread::HandleExit() {
 
 void HWCThread::HandleWait() {
   if (fd_handler_.Poll(-1) <= 0) {
-    ETRACE("Poll Failed in DisplayManager %s", PRINTERROR());
+    ETRACE("Poll Failed in HWCThread HandleWait %s", PRINTERROR());
     return;
   }
 

--- a/os/linux/pixeluploader.cpp
+++ b/os/linux/pixeluploader.cpp
@@ -110,7 +110,7 @@ void PixelUploader::HandleRoutine() {
 
 void PixelUploader::Wait() {
   if (fd_chandler_.Poll(-1) <= 0) {
-    ETRACE("Poll Failed in DisplayManager %s", PRINTERROR());
+    ETRACE("Poll Failed in PixelUploader %s", PRINTERROR());
     return;
   }
 


### PR DESCRIPTION
Tests: compile successfully.
Tracked-On: None
Signed-off-by: Yuanjun Huang <yuanjun.huang@intel.com>