### PR TITLE
Use SurfaceFlinger to do client composite if layers more than 3

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -422,6 +422,14 @@ bool HwcLayer::IsCursorLayer() const {
   return is_cursor_layer_;
 }
 
+void HwcLayer::MarkAsVideoLayer() {
+  is_video_layer_ = true;
+}
+
+bool HwcLayer::IsVideoLayer() const {
+  return is_video_layer_;
+}
+
 void HwcLayer::UpdateRenderingDamage(const HwcRect<int>& old_rect,
                                      const HwcRect<int>& newrect,
                                      bool same_rect) {

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -143,6 +143,10 @@ class DisplayQueue {
     }
   }
 
+  int GetTotalOverlays() const {
+    return display_plane_manager_->GetTotalOverlays();
+  }
+
   void ReleaseUnreservedPlanes(std::vector<uint32_t>& reserved_planes);
 
  private:

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -125,6 +125,10 @@ class IAHWC2 : public hwc2_device_t {
       return hwc_layer_.IsCursorLayer();
     }
 
+    bool IsVideoLayer() const {
+      return hwc_layer_.IsVideoLayer();
+    }
+
     // Layer hooks
     HWC2::Error SetCursorPosition(int32_t x, int32_t y);
     HWC2::Error SetLayerBlendMode(int32_t mode);
@@ -231,6 +235,7 @@ class IAHWC2 : public hwc2_device_t {
     bool disable_explicit_sync_;
     bool enable_nested_display_compose_;
     uint32_t scaling_mode_;
+    uint32_t planes_;
   };
 
   static IAHWC2 *toIAHWC2(hwc2_device_t *dev) {

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -279,6 +279,9 @@ struct HwcLayer {
   void MarkAsCursorLayer();
   bool IsCursorLayer() const;
 
+  void MarkAsVideoLayer();
+  bool IsVideoLayer() const;
+
   /**
    * API for getting damage area caused by this layer for current
    * frame update.
@@ -348,6 +351,7 @@ struct HwcLayer {
       kVisible | kSurfaceDamageChanged | kVisibleRegionChanged | kZorderChanged;
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
+  bool is_video_layer_ = false;
   uint32_t solid_color_ = 0xff;
 
   HWCLayerCompositionType composition_type_ = Composition_Device;

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -431,6 +431,10 @@ class NativeDisplay {
   virtual void MarkFirstCommit() {
   }
 
+  virtual int GetTotalOverlays() const {
+    return 0;
+  }
+
  protected:
   friend class PhysicalDisplay;
   friend class GpuDevice;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -652,4 +652,11 @@ bool PhysicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   strncpy(name, string.c_str(), *size);
   return true;
 }
+
+int PhysicalDisplay::GetTotalOverlays() const {
+  if (display_queue_)
+    return display_queue_->GetTotalOverlays();
+  else
+    return 0;
+}
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -257,6 +257,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
     return connection_state_ & kFakeConnected;
   }
 
+  int GetTotalOverlays() const override;
+
  private:
   bool UpdatePowerMode();
   void RefreshClones();


### PR DESCRIPTION
If layers more than 3, layer1 and layer2 set to Device composite
type, and other layers set to Client composite type.

Change-Id: I6c32a5d5b3cdd31feb113288fba4afc11842b9b5
Tracked-On:
Signed-off-by: Yang, Dong <dong.yang@intel.com>