### PR TITLE
Initialize SurfaceDamage with display_frame_ by default

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -118,9 +118,7 @@ void HwcLayer::SetSurfaceDamage(const HwcRegion& surface_damage) {
       return;
     }
   } else if (rects == 0) {
-    rect = display_frame_;
-    // damage is assigned with display_frame, no need to transform
-    state_ &= ~kSurfaceDamageChanged;
+    rect = source_crop_;
   }
 
   if ((surface_damage_.left == rect.left) &&
@@ -280,7 +278,7 @@ void HwcLayer::SufaceDamageTransfrom() {
   } else if (surface_damage_.empty()) {
     current_rendering_damage_ = surface_damage_;
   } else {
-    current_rendering_damage_ = translated_damage;
+    current_rendering_damage_ = display_frame_;
   }
 }
 
@@ -295,6 +293,8 @@ void HwcLayer::Validate() {
     layer_cache_ &= ~kSourceRectChanged;
     if (state_ & kSurfaceDamageChanged) {
       SufaceDamageTransfrom();
+    } else {
+      current_rendering_damage_ = display_frame_;
     }
   }
 

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -187,7 +187,7 @@ void OverlayLayer::ValidateTransform(uint32_t transform,
 void OverlayLayer::TransformDamage(HwcLayer* layer, uint32_t max_height,
                                    uint32_t max_width) {
   const HwcRect<int>& surface_damage = layer->GetLayerDamage();
-  if (surface_damage.empty() || !layer->HasSurfaceDamageRegionChanged()) {
+  if (surface_damage.empty()) {
     surface_damage_ = surface_damage;
     return;
   }

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -113,15 +113,6 @@ struct HwcLayer {
   }
 
   /**
-   * API for querying damage region of this layer
-   * has changed from last Present call to
-   * NativeDisplay.
-   */
-  bool HasSurfaceDamageRegionChanged() const {
-    return state_ & kSurfaceDamageChanged;
-  }
-
-  /**
    * API for querying if content of layer has changed
    * for last Present call to NativeDisplay.
    */
@@ -347,8 +338,7 @@ struct HwcLayer {
   std::vector<int32_t> right_source_constraint_;
   int z_order_ = -1;
   uint32_t total_displays_ = 1;
-  int state_ =
-      kVisible | kSurfaceDamageChanged | kVisibleRegionChanged | kZorderChanged;
+  int state_ = kVisible | kVisibleRegionChanged | kZorderChanged;
   int layer_cache_ = kLayerAttributesChanged | kDisplayFrameRectChanged;
   bool is_cursor_layer_ = false;
   bool is_video_layer_ = false;


### PR DESCRIPTION
From Q, AOSP will not set the surfaceDamage for each frame. and some
times, surface_damage will not be set by SF. So has to set SurfaceDamage
with display_frame_ by default. and always do 'Transform' for
surfaceDamage once it is set.
Another change, when surfaceDamage is empty from SF, surface_damage will
be assigned with source_crop for 'Transform'.

Change-Id: I608c9b985ba8575280170ac886f2c508d181574f
Tests:      Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-84227
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>