### PR TITLE
Skip Client layer without buffer

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -637,6 +637,14 @@ HWC2::Error IAHWC2::HwcDisplay::PresentDisplay(int32_t *retire_fence) {
       cursor_z_order = l.second.z_order();
       continue;
     }
+#ifndef FORCE_ALL_DEVICE_TYPE
+    if ((l.second.validated_type() == HWC2::Composition::Client) &&
+        (l.second.GetLayer()->GetNativeHandle() == NULL)) {
+      ICOMPOSITORTRACE(
+          "Skip clinet layer without buffer which composed by SurfaceFlinger");
+      continue;
+    }
+#endif
 
     if ((l.second.validated_type() != HWC2::Composition::SolidColor) &&
         (l.second.GetLayer()->GetNativeHandle() == NULL)) {


### PR DESCRIPTION
The Client layer composed by SF could be sent to HWC.
and trigger a error log below
HWC don't support layer without buffer if not in type SolidColor

Change-Id: I76bb79520453c68a0b17fbf69db0a151d993bbb4
Tests: Work on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>