### PR TITLE
Need to check if display_plane_manager is null

### DIFF
--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -144,7 +144,10 @@ class DisplayQueue {
   }
 
   int GetTotalOverlays() const {
-    return display_plane_manager_->GetTotalOverlays();
+    if (display_plane_manager_)
+      return display_plane_manager_->GetTotalOverlays();
+    else
+      return 0;
   }
 
   void ReleaseUnreservedPlanes(std::vector<uint32_t>& reserved_planes);


### PR DESCRIPTION
In non-headless case, the displaymanager is null in queue.

Change-Id: I8a026d898ecacba1814ddd6e4da6760de22b3e62
Tests: Work well on Android Q.
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>