### PR TITLE
support Iris driver

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -139,8 +139,19 @@ LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/common/compositor/vk \
 	$(LOCAL_PATH)/../mesa/include
 else
+
+# iris driver flags
+ifneq ($(filter iris, $(BOARD_GPU_DRIVERS)),)
+$(warning "Iris driver not fully supported, instability or lower performance may occur!")
+LOCAL_CPPFLAGS += \
+	-DUSE_GL \
+	-DDISABLE_EXPLICIT_SYNC
+else
+# i965 driver flags
 LOCAL_CPPFLAGS += \
 	-DUSE_GL
+endif
+
 endif
 
 ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -153,6 +153,12 @@ HWC2::Error IAHWC2::Init() {
   char value[PROPERTY_VALUE_MAX];
   property_get("board.disable.explicit.sync", value, "0");
   disable_explicit_sync_ = atoi(value);
+
+/* Build wants to explicitly disable sync. */
+#ifdef DISABLE_EXPLICIT_SYNC
+  disable_explicit_sync_ = true;
+#endif
+
   if (disable_explicit_sync_)
     ALOGI("EXPLICIT SYNC support is disabled");
   else


### PR DESCRIPTION
This patch introduces supported options for iris driver, RBC and
explicit sync needs to be disabled for now.

Patch also forces compositor to disable sync if this was explicitly
wanted during build since setting property
'board.disable.explicit.sync' does not work as expected.

Test: Compile and run sucessfully with Iris driver on Android.
Tracked-On: None
Signed-off-by: Tapani Pälli <tapani.palli@intel.com>