### PR TITLE
Re-invoke SetActiveConfig for Hotplug to initialize ClientLayer

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -118,6 +118,11 @@ class IAHotPlugEventCallback : public hwcomposer::HotPlugCallback {
     int32_t status = static_cast<int32_t>(HWC2::Connection::Connected);
     if (!connected) {
       status = static_cast<int32_t>(HWC2::Connection::Disconnected);
+    } else {
+      hwc2_config_t default_config;
+      uint32_t num_configs = 1;
+      display_->GetDisplayConfigs(&num_configs, &default_config);
+      display_->SetActiveConfig(default_config);
     }
 
     IHOTPLUGEVENTTRACE(
@@ -752,16 +757,21 @@ HWC2::Error IAHWC2::HwcDisplay::SetActiveConfig(hwc2_config_t config) {
     return HWC2::Error::BadConfig;
   }
 
+  int display_width = 0;
+  int display_height = 0;
+  display_->GetDisplayAttribute(config, HWCDisplayAttribute::kWidth,
+                                &display_width);
+  display_->GetDisplayAttribute(config, HWCDisplayAttribute::kHeight,
+                                &display_height);
+
   // Setup the client layer's dimensions
-  hwc_rect_t display_frame = {.left = 0,
-                              .top = 0,
-                              .right = static_cast<int>(display_->Width()),
-                              .bottom = static_cast<int>(display_->Height())};
+  hwc_rect_t display_frame = {
+      .left = 0, .top = 0, .right = display_width, .bottom = display_height};
   client_layer_.SetLayerDisplayFrame(display_frame);
   hwc_frect_t source_crop = {.left = 0.0f,
                              .top = 0.0f,
-                             .right = display_->Width() + 0.0f,
-                             .bottom = display_->Height() + 0.0f};
+                             .right = display_width + 0.0f,
+                             .bottom = display_height + 0.0f};
   client_layer_.SetLayerSourceCrop(source_crop);
 
   return HWC2::Error::None;


### PR DESCRIPTION
SetActiveConfig is not invoked by SF when hotplug even the display
is not primary. HWC must invoke it for initialize the clientLayer.

Change-Id: I2e4a2321d28f59c718db8c743c9513c469066f68
Tests: Work well for HotPlug on Android Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>