### PR TITLE
Update ValidateLayers for only 1 plane case

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -132,6 +132,8 @@ LOCAL_CPPFLAGS += \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
         -DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
         -DKVM_HWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.kvm.ini"' \
+        -DKVM_HWC_PROPERTY='"ro.graphics.hwcomposer.kvm"' \
+        -DUSE_ANDROID_PROPERTIES \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
         -Wno-unused-parameter \
         -O3

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -131,6 +131,7 @@ LOCAL_CPPFLAGS += \
         -Wcast-qual -Wcast-align \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
         -DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
+        -DKVM_HWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.kvm.ini"' \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
         -Wno-unused-parameter \
         -O3

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,6 +28,7 @@ AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong 
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 AM_CPPFLAGS += -DLOCK_DIR_PREFIX='"${prefix}/etc"'
 AM_CPPFLAGS += -DHWC_DISPLAY_INI_PATH='"${prefix}/etc/hwc_display.ini"'
+AM_CPPFLAGS += -DKVM_HWC_DISPLAY_INI_PATH='"${prefix}/etc/hwc_display.kvm.ini"'
 
 libhwcomposer_common_la_LIBADD = \
 	$(DRM_LIBS) \

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -28,7 +28,6 @@ AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong 
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 AM_CPPFLAGS += -DLOCK_DIR_PREFIX='"${prefix}/etc"'
 AM_CPPFLAGS += -DHWC_DISPLAY_INI_PATH='"${prefix}/etc/hwc_display.ini"'
-AM_CPPFLAGS += -DKVM_HWC_DISPLAY_INI_PATH='"${prefix}/etc/hwc_display.kvm.ini"'
 
 libhwcomposer_common_la_LIBADD = \
 	$(DRM_LIBS) \

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -228,6 +228,9 @@ void GpuDevice::ParsePlaneReserveSettings(std::string &value) {
       if (skip_duplicate_plane) {
         continue;
       }
+      IPLANERESERVEDTRACE(
+          "Parsing configure for reserving display[%d], plane[%d]",
+          display_index, reserved_plane_index_num);
       reserved_drm_planes_.emplace_back(reserved_plane_index_num);
     }
     reserved_drm_display_planes_map_[display_index] = reserved_drm_planes_;
@@ -819,6 +822,8 @@ void GpuDevice::InitializeFloatDisplay(
 void GpuDevice::HandleHWCSettings() {
   // Handle config file reading
   const char *hwc_dp_cfg_path = HWC_DISPLAY_INI_PATH;
+  // TODO Get Kvm property to decide if need to load KVM config
+  // KVM_HWC_DISPLAY_INI_PATH
   ITRACE("Hwc display config file is %s", hwc_dp_cfg_path);
 
   bool use_logical = false;

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -21,6 +21,7 @@
 #include "mosaicdisplay.h"
 
 #include "hwctrace.h"
+#include "hwcutils.h"
 
 namespace hwcomposer {
 
@@ -820,10 +821,18 @@ void GpuDevice::InitializeFloatDisplay(
 }
 
 void GpuDevice::HandleHWCSettings() {
-  // Handle config file reading
+// Handle config file reading
+#ifndef KVM_HWC_PROPERTY
   const char *hwc_dp_cfg_path = HWC_DISPLAY_INI_PATH;
-  // TODO Get Kvm property to decide if need to load KVM config
-  // KVM_HWC_DISPLAY_INI_PATH
+#else
+  // Get Kvm property to decide if need to load KVM config
+  std::string hwc_dp_cfg_path_str;
+  if (IsKvmPlatform())
+    hwc_dp_cfg_path_str = KVM_HWC_DISPLAY_INI_PATH;
+  else
+    hwc_dp_cfg_path_str = HWC_DISPLAY_INI_PATH;
+  const char *hwc_dp_cfg_path = hwc_dp_cfg_path_str.c_str();
+#endif
   ITRACE("Hwc display config file is %s", hwc_dp_cfg_path);
 
   bool use_logical = false;

--- a/common/utils/hwctrace.h
+++ b/common/utils/hwctrace.h
@@ -44,6 +44,7 @@ extern "C" {
 // #define SURFACE_BASIC_TRACING 1
 // #define COMPOSITOR_TRACING 1
 // #define RECT_DAMAGE_TRACING 1
+// #define PLANE_RESERVED_TRACING 1
 
 // Function call tracing
 #ifdef FUNCTION_CALL_TRACING
@@ -123,6 +124,12 @@ class TraceFunc {
 #define IRECTDAMAGETRACE ITRACE
 #else
 #define IRECTDAMAGETRACE(fmt, ...) ((void)0)
+#endif
+
+#ifdef PLANE_RESERVED_TRACING
+#define IPLANERESERVEDTRACE ITRACE
+#else
+#define IPLANERESERVEDTRACE(fmt, ...) ((void)0)
 #endif
 
 #ifdef RESOURCE_CACHE_TRACING

--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -144,6 +144,20 @@ uint32_t GetTotalPlanesForFormat(uint32_t format) {
   return 1;
 }
 
+#ifdef KVM_HWC_PROPERTY
+bool IsKvmPlatform() {
+  const char* key = KVM_HWC_PROPERTY;
+  char* value = new char[20];
+  const char* property_true = "true";
+  int len = property_get(key, value, "");
+  if (len > 0 && strcmp(value, property_true) == 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+#endif
+
 std::string StringifyRect(HwcRect<int> rect) {
   std::stringstream ss;
   ss << "{(" << rect.left << "," << rect.top << ") "

--- a/hwc_display.kvm.ini
+++ b/hwc_display.kvm.ini
@@ -1,0 +1,72 @@
+# The switches of logical and mosaic mode.
+
+LOGICAL="false"
+MOSAIC="false"
+CLONE="true"
+FLOAT="false"
+PLANE_RESERVED="true"
+ROTATION="false"
+
+# The Order of Physical Displays. This along with connection status
+# will be used to determine the order. If display is first in this
+# list but is not connected than it will added to the last.The order
+# is preserved till the next reboot.
+PHYSICAL_DISPLAY="0:1:2"
+
+# Rotation of display, with format "physical-display-number:rotation".
+# physical-display-number: start from 0, included all display ports(whatever connected or disconnected)
+# rotation: Rotation which needs to be applied.
+# 0 - 0 degree
+# 1 - 90 degree
+# 2 - 180 degree
+# 3 - 270 degree
+PHYSICAL_DISPLAY_ROTATION="1:1"
+
+# Logical display definitions, with format "physical-display-number:split-number"
+# physical-display-number: start from 0, included all display ports(whatever connected or disconnected)
+# split-number: the sub display number you want to split
+LOGICAL_DISPLAY="0:3"
+
+# Mosaic display definitions, with format "sub-display-index+sub-display-index+sub-display-index....."
+# sub-display-index: start from 0, should be the available displays number, follow the order of the connected logical displays
+MOSAIC_DISPLAY="0+1+2"
+
+# Float display definitions, with format "sub-display-index:left+top+right+bottom".
+# Float display definitions take precedence over display hardware capabilities,
+# in other words, default resolution is replaced by current definition.
+# sub-display-index: start from 0, should be the available displays number, follow the order of the connected logical displays
+# left, top, right and bottom specify the frame rectangle to be displayed as floating on a display with sub-display-index
+FLOAT_DISPLAY="0:320+180+1600+900"
+
+# Clone display definitions, with format "physical-display-number:cloned-physical-display-number". This
+# setting is ignored if LOGICAL or MOSAIC is set to true.
+# physical-display-number: start from 0, included all display ports(whatever connected or disconnected)
+# cloned-physical-display-number: the display which should clone physical-display-number.
+CLONE_DISPLAY="1+2"
+
+# HWC reserved DRM Plane. 4 DRM planes are available.
+# 0 - Primary Plane
+# 1 - Overlay Plane
+# 2 - Overlay Plane
+# 3 - Cursor Plane
+# 0:0+1+2+3 - ALl planes of display 0 are used for HWC
+# 1:0+1+3   - 0/1/3 planes of display 1 are used for HWC, plane 2 is reserved for other component
+DRM_PLANE_RESERVED="0:0;1:0"
+
+
+# ------------------------------------------------------------------------------------------------------------------------
+# A typical usages:
+#   there are 3 physical displays(ports? crtc? pipe?), the first one and third one are connected, the second one is disconnected
+#   use:
+#       LOGICAL_DISPLAY="0:3"
+#       LOGICAL_DISPLAY="1:2"
+#   to split the physical displays, the final logical displays number will be "0, 1, 2, 3, 4, 5", "3, 4" belongs to
+#   second physical display and is disconnected, so available displays number are "0, 1, 2, 5"
+#   use:
+#       MOSAIC_DISPLAY="2+5"
+#       MOSAIC_DISPLAY="0+3+4"
+#   the final mosaic display will be (keep the order by the smallest logical display num):
+#       MOSAIC_DISPLAY 0: includes 1 logical display(logical display 0) only
+#       MOSAIC_DISPLAY 1: includes 2 and 5 logical displays (5 is the third physical display without split displays)
+#   the logical display 1 is not used for mosaic display, will be second display of the final available display.
+# ------------------------------------------------------------------------------------------------------------------------

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -17,6 +17,9 @@
 #ifndef COMMON_UTILS_HWCUTILS_H_
 #define COMMON_UTILS_HWCUTILS_H_
 
+#ifdef USE_ANDROID_PROPERTIES
+#include <cutils/properties.h>
+#endif
 #include <hwcdefs.h>
 #include <sstream>
 
@@ -80,6 +83,15 @@ bool IsSupportedMediaFormat(uint32_t format);
  * @return The number of planes for a given format
  */
 uint32_t GetTotalPlanesForFormat(uint32_t format);
+
+#ifdef KVM_HWC_PROPERTY
+/**
+ * Check if running on KVM
+ *
+ * @return True when running on KVM/QEMU
+ */
+bool IsKvmPlatform();
+#endif
 
 /**
  * Check if two rectangles overlap

--- a/yunos.mk
+++ b/yunos.mk
@@ -18,7 +18,8 @@ LOCAL_CPPFLAGS += \
 	-DUSE_GL \
 	-DYUN_HAL \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
-	-DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"'
+	-DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
+        -DKVM_HWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.kvm.ini"'
 
 LOCAL_C_INCLUDES := \
 	system/core/include/utils \


### PR DESCRIPTION
Only 1 plane is available for HWC on Kvm.
Update the logic to
1/ Non-video case and Client is used, all layers are Client. just need
to scan out the Client layer
2/ Non-video case and Client is not used, force to compose all layers
by GPU
3/ Video case, Force to compose all layers in VPP
For video case, still meet surface issue (Fail to allocate surface).
Not sure if it is limitation in layer size of VPP. will fix later.

Change-Id: Iabc1fdb0fa8faaca3f49376177eab631d0c571ca
Tests: PlaneReservation work for reserve 1 plane on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-84953
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>