### PR TITLE
Fix surface leak in 1 plane case

### DIFF
--- a/common/utils/hwctrace.h
+++ b/common/utils/hwctrace.h
@@ -45,6 +45,7 @@ extern "C" {
 // #define COMPOSITOR_TRACING 1
 // #define RECT_DAMAGE_TRACING 1
 // #define PLANE_RESERVED_TRACING 1
+// #define SURFACE_RECYCLE_TRACING 1
 
 // Function call tracing
 #ifdef FUNCTION_CALL_TRACING
@@ -130,6 +131,12 @@ class TraceFunc {
 #define IPLANERESERVEDTRACE ITRACE
 #else
 #define IPLANERESERVEDTRACE(fmt, ...) ((void)0)
+#endif
+
+#ifdef SURFACE_RECYCLE_TRACING
+#define ISURFACERECYCLETRACE ITRACE
+#else
+#define ISURFACERECYCLETRACE(fmt, ...) ((void)0)
 #endif
 
 #ifdef RESOURCE_CACHE_TRACING

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -895,7 +895,6 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   for (std::pair<const hwc2_layer_t, IAHWC2::Hwc2Layer> &l : layers_) {
     if (l.second.IsVideoLayer()) {
       include_video_layer = true;
-      ALOGI("layers: %d is video layer\n", l.first);
       break;
     }
   }


### PR DESCRIPTION
Avoid to allocate unnecessary Surface in ForceVPP and ForceGPU.
and Check all layer to avoid missing video_layer.

Change-Id: I777ee656cd93ce04453cea0f0dc630df6172d89a
Tests: Work well with 1 plane and Multiple plane case
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>