### PR TITLE
Need to check if current layer is video when do squash

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -191,7 +191,7 @@ bool DisplayPlaneManager::ValidateLayers(
           bool needsquash =
               composition.back().IsVideoPlane() && (layer_begin != layer_end);
           if (!needsquash) {
-            auto temp_iter = layer_begin;
+            auto temp_iter = layer_begin - 1;
             while (temp_iter != layer_end) {
               if ((*temp_iter).IsVideoLayer()) {
                 needsquash = true;


### PR DESCRIPTION
lay_begin is added itself before checking video, it will
make the current layer be missed in checking

Change-Id: I98b2828787eddf0d54da9bb20902cb66b33b9caf
Tests: Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85450
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>