### PR TITLE
Hwc2.3 get display identification data

### DIFF
--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -238,6 +238,12 @@ bool LogicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool LogicalDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                  uint32_t *outDataSize,
+                                                  uint8_t *outData) {
+  return true;
+}
+
 void LogicalDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
                                             uint32_t *capabilities) {
   physical_display_->GetDisplayCapabilities(numCapabilities, capabilities);

--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -238,4 +238,9 @@ bool LogicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+void LogicalDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
+                                            uint32_t *capabilities) {
+  physical_display_->GetDisplayCapabilities(numCapabilities, capabilities);
+}
+
 }  // namespace hwcomposer

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -105,6 +105,9 @@ class LogicalDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -105,6 +105,9 @@ class LogicalDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities) override;
+
   uint32_t GetXTranslation() override {
     return (((physical_display_->Width()) / total_divisions_) * index_);
   }

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -608,6 +608,12 @@ bool MosaicDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool MosaicDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                 uint32_t *outDataSize,
+                                                 uint8_t *outData) {
+  return true;
+}
+
 bool MosaicDisplay::IsBypassClientCTM() const
 {
   uint32_t size = physical_displays_.size();

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -608,6 +608,26 @@ bool MosaicDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool MosaicDisplay::IsBypassClientCTM() const
+{
+  uint32_t size = physical_displays_.size();
+  for (uint32_t i = 0; i < size; i++)  {
+    if (!physical_displays_.at(i)->IsBypassClientCTM()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void MosaicDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
+                                           uint32_t *capabilities) {
+  if (IsBypassClientCTM()) {
+        ++*numCapabilities;
+        *capabilities |= static_cast<uint32_t>(HWCDisplayCapability::
+                         kDisplayCapabilitySkipClientColorTransform);
+  }
+}
+
 void MosaicDisplay::SetHDCPState(HWCContentProtection state,
                                  HWCContentType content_type) {
   uint32_t size = physical_displays_.size();

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -100,7 +100,10 @@ class MosaicDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
-  bool IsBypassClientCTM() const override;
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
+  bool IsBypassClientCTM() const;
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -100,6 +100,10 @@ class MosaicDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
+  bool IsBypassClientCTM() const override;
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities) override;
+
   uint32_t GetXTranslation() override {
     return 0;
   }

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -492,6 +492,12 @@ bool VirtualDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool VirtualDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                  uint32_t *outDataSize,
+                                                  uint8_t *outData) {
+  return true;
+}
+
 void VirtualDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
                                             uint32_t *capabilities) {
 }

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -492,6 +492,10 @@ bool VirtualDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+void VirtualDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
+                                            uint32_t *capabilities) {
+}
+
 int VirtualDisplay::GetDisplayPipe() {
   return -1;
 }

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -77,6 +77,9 @@ class VirtualDisplay : public NativeDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -76,6 +76,10 @@ class VirtualDisplay : public NativeDisplay {
 
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
+
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities) override;
+
   int GetDisplayPipe() override;
 
   bool SetPowerMode(uint32_t power_mode) override;

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -970,8 +970,27 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
 
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayIdentificationData(
     uint8_t *outPort, uint32_t *outDataSize, uint8_t *outData) {
-  unsupported(__func__);
-  return HWC2::Error::None;
+
+  supported(__func__);
+  ITRACE("Invoked IAHWC2::HwcDisplay::GetDisplayIdentificationData()");
+  if (outPort == NULL || outDataSize == NULL) {
+    ETRACE("Return BadParameter");
+    return HWC2::Error::BadParameter;
+  }
+
+  if (display_) {
+    if(display_->GetDisplayIdentificationData(outPort, outDataSize, outData)) {
+
+      (outData == NULL) ?
+        ITRACE("outPort=%x, outDataSize=%x, outData=NULL", outPort, outDataSize) :
+        ITRACE("outPort=%x, outDataSize=%x, outData=%x", outPort, outDataSize, outData);
+
+      return HWC2::Error::None;
+    }
+  }
+
+  ETRACE("Return BadDisplay");
+  return HWC2::Error::BadDisplay;
 }
 
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayCapabilities(uint32_t *outNumCapabilities,

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -968,6 +968,72 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   return HWC2::Error::None;
 }
 
+HWC2::Error IAHWC2::HwcDisplay::GetDisplayIdentificationData(
+    uint8_t *outPort, uint32_t *outDataSize, uint8_t *outData) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::GetDisplayCapabilities(uint32_t *outNumCapabilities,
+                                                       uint32_t *outCapabilities) {
+  supported(__func__);
+
+  if (!outNumCapabilities) {
+    ALOGE("BadParameter");
+    return HWC2::Error::BadParameter;
+  }
+
+  /* Return number of display capabilities only */
+  if (outCapabilities == NULL) {
+    *outNumCapabilities = getNumCapabilities();
+    return HWC2::Error::None;
+  }
+
+  *outCapabilities = 0;
+  *outNumCapabilities = 0;
+
+  /* Record miscellaneous display capabilities */
+  display_->GetDisplayCapabilities(outNumCapabilities, outCapabilities);
+  setNumCapabilities(*outNumCapabilities);
+
+  /* Record doze suspend display capability */
+  int32_t doze = 0;
+  GetDozeSupport(&doze);
+  if (doze == true) {
+    ++*outNumCapabilities;
+    setNumCapabilities(*outNumCapabilities);
+    *outCapabilities |= HWC2_DISPLAY_CAPABILITY_DOZE;
+  }
+
+  if (numCap_ == maxNumCap_) {
+    ALOGI("Maximum number of display capabilities reached");
+  }
+
+  ALOGI("outCapabilities=%d, outNumCapabilities=%d", *outCapabilities, *outNumCapabilities);
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::GetDisplayedContentSamplingAttributes(
+    int32_t *format, int32_t *dataspace, uint8_t *supported_components) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::SetDisplayedContentSamplingEnabled(
+    int32_t enabled, uint8_t component_mask, uint64_t max_frames) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::GetDisplayedContentSample(uint64_t max_frames,
+                                                          uint64_t timestamp,
+                                                          uint64_t *frame_count,
+                                                          int32_t *samples_size,
+                                                          uint64_t **samples) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
 HWC2::Error IAHWC2::Hwc2Layer::SetCursorPosition(int32_t /*x*/, int32_t /*y*/) {
   supported(__func__);
   return HWC2::Error::None;
@@ -1136,6 +1202,18 @@ HWC2::Error IAHWC2::Hwc2Layer::SetLayerZOrder(uint32_t order) {
   return HWC2::Error::None;
 }
 
+HWC2::Error IAHWC2::Hwc2Layer::SetLayerColorTransform(const float *matrix) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::Hwc2Layer::SetLayerPerFrameMetadataBlobs(
+    uint32_t numElements, const int32_t *keys, const uint32_t *sizes,
+    const uint8_t *metadata) {
+  unsupported(__func__);
+  return HWC2::Error::None;
+}
+
 // static
 int IAHWC2::HookDevClose(hw_device_t * /*dev*/) {
   unsupported(__func__);
@@ -1281,6 +1359,32 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_VALIDATE_DISPLAY>(
           DisplayHook<decltype(&HwcDisplay::ValidateDisplay),
                       &HwcDisplay::ValidateDisplay, uint32_t *, uint32_t *>);
+    case HWC2::FunctionDescriptor::GetDisplayIdentificationData:
+      return ToHook<HWC2_PFN_GET_DISPLAY_IDENTIFICATION_DATA>(
+          DisplayHook<decltype(&HwcDisplay::GetDisplayIdentificationData),
+                      &HwcDisplay::GetDisplayIdentificationData, uint8_t *,
+                      uint32_t *, uint8_t *>);
+    case HWC2::FunctionDescriptor::GetDisplayCapabilities:
+      return ToHook<HWC2_PFN_GET_DISPLAY_CAPABILITIES>(
+          DisplayHook<decltype(&HwcDisplay::GetDisplayCapabilities),
+                      &HwcDisplay::GetDisplayCapabilities, uint32_t *,
+                      uint32_t *>);
+    case HWC2::FunctionDescriptor::GetDisplayedContentSamplingAttributes:
+      return ToHook<HWC2_PFN_GET_DISPLAYED_CONTENT_SAMPLING_ATTRIBUTES>(
+          DisplayHook<decltype(
+                          &HwcDisplay::GetDisplayedContentSamplingAttributes),
+                      &HwcDisplay::GetDisplayedContentSamplingAttributes,
+                      int32_t *, int32_t *, uint8_t *>);
+    case HWC2::FunctionDescriptor::SetDisplayedContentSamplingEnabled:
+      return ToHook<HWC2_PFN_SET_DISPLAYED_CONTENT_SAMPLING_ENABLED>(
+          DisplayHook<decltype(&HwcDisplay::SetDisplayedContentSamplingEnabled),
+                      &HwcDisplay::SetDisplayedContentSamplingEnabled, int32_t,
+                      uint8_t, uint64_t>);
+    case HWC2::FunctionDescriptor::GetDisplayedContentSample:
+      return ToHook<HWC2_PFN_GET_DISPLAYED_CONTENT_SAMPLE>(
+          DisplayHook<decltype(&HwcDisplay::GetDisplayedContentSample),
+                      &HwcDisplay::GetDisplayedContentSample, uint64_t,
+                      uint64_t, uint64_t *, int32_t *, uint64_t **>);
 
     // Layer functions
     case HWC2::FunctionDescriptor::SetCursorPosition:
@@ -1339,6 +1443,15 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_LAYER_Z_ORDER>(
           LayerHook<decltype(&Hwc2Layer::SetLayerZOrder),
                     &Hwc2Layer::SetLayerZOrder, uint32_t>);
+    case HWC2::FunctionDescriptor::SetLayerColorTransform:
+      return ToHook<HWC2_PFN_SET_LAYER_COLOR_TRANSFORM>(
+          LayerHook<decltype(&Hwc2Layer::SetLayerColorTransform),
+                    &Hwc2Layer::SetLayerColorTransform, const float *>);
+    case HWC2::FunctionDescriptor::SetLayerPerFrameMetadataBlobs:
+      return ToHook<HWC2_PFN_SET_LAYER_PER_FRAME_METADATA_BLOBS>(
+          LayerHook<decltype(&Hwc2Layer::SetLayerPerFrameMetadataBlobs),
+                    &Hwc2Layer::SetLayerPerFrameMetadataBlobs, uint32_t,
+                    const int32_t *, const uint32_t *, const uint8_t *>);
     case HWC2::FunctionDescriptor::Invalid:
     default:
       return NULL;

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -144,6 +144,11 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::Error SetLayerTransform(int32_t transform);
     HWC2::Error SetLayerVisibleRegion(hwc_region_t visible);
     HWC2::Error SetLayerZOrder(uint32_t z);
+    HWC2::Error SetLayerColorTransform(const float *matrix);
+    HWC2::Error SetLayerPerFrameMetadataBlobs(uint32_t numElements,
+                                              const int32_t *keys,
+                                              const uint32_t *sizes,
+                                              const uint8_t *metadata);
 
    private:
     // sf_type_ stores the initial type given to us by surfaceflinger,
@@ -162,6 +167,18 @@ class IAHWC2 : public hwc2_device_t {
     HwcDisplay();
     HwcDisplay(const HwcDisplay &) = delete;
     HwcDisplay &operator=(const HwcDisplay &) = delete;
+
+    uint32_t numCap_ = 0;
+    uint32_t maxNumCap_ = HWC2_DISPLAY_CAPABILITY_DOZE -
+                          HWC2_DISPLAY_CAPABILITY_INVALID; /* last - first */
+
+    uint32_t getNumCapabilities() {
+      return numCap_;
+    }
+
+    void setNumCapabilities(uint32_t num) {
+      numCap_ = num;
+    }
 
     HWC2::Error Init(hwcomposer::NativeDisplay *display, int display_index,
                      bool disable_explicit_sync, uint32_t scaling_mode);
@@ -217,6 +234,22 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::Error SetPowerMode(int32_t mode);
     HWC2::Error SetVsyncEnabled(int32_t enabled);
     HWC2::Error ValidateDisplay(uint32_t *num_types, uint32_t *num_requests);
+    HWC2::Error GetDisplayIdentificationData(uint8_t *outPort,
+                                             uint32_t *outDataSize,
+                                             uint8_t *outData);
+    HWC2::Error GetDisplayCapabilities(uint32_t *outNumCapabilities,
+                                       uint32_t *outCapabilities);
+    HWC2::Error GetDisplayedContentSamplingAttributes(
+        int32_t *format, int32_t *dataspace, uint8_t *supported_components);
+    HWC2::Error SetDisplayedContentSamplingEnabled(int32_t enabled,
+                                                   uint8_t component_mask,
+                                                   uint64_t max_frames);
+    HWC2::Error GetDisplayedContentSample(uint64_t max_frames,
+                                          uint64_t timestamp,
+                                          uint64_t *frame_count,
+                                          int32_t *samples_size,
+                                          uint64_t **samples);
+
     Hwc2Layer &get_layer(hwc2_layer_t layer) {
       return layers_.at(layer);
     }

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -141,6 +141,13 @@ enum class HWCScalingRunTimeSetting : int32_t {
   kScalingModeHighQuality = 2  // use high quality scaling mode.
 };
 
+enum class HWCDisplayCapability : uint32_t
+{
+  kDisplayCapabilityInvalid = 0,
+  kDisplayCapabilitySkipClientColorTransform = 1,
+  kDisplayCapabilityDoze = 2
+};
+
 struct EnumClassHash {
   template <typename T>
   std::size_t operator()(T t) const {

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -89,6 +89,9 @@ class NativeDisplay {
   virtual bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) = 0;
   virtual bool GetDisplayName(uint32_t *size, char *name) = 0;
 
+  virtual bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                            uint8_t *outData) = 0;
+
   virtual void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                                       uint32_t *outCapabilities) = 0;
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -88,6 +88,10 @@ class NativeDisplay {
 
   virtual bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) = 0;
   virtual bool GetDisplayName(uint32_t *size, char *name) = 0;
+
+  virtual void GetDisplayCapabilities(uint32_t *outNumCapabilities,
+                                      uint32_t *outCapabilities) = 0;
+
   /**
    * API for getting connected display's pipe id.
    * @return "-1" for unconnected display, valid values are 0 ~ 2.
@@ -309,6 +313,11 @@ class NativeDisplay {
    * API to check if display is connected.
    */
   virtual bool IsConnected() const {
+    return false;
+  }
+
+  /* Returns capability to bypass client-enabled CTM for this display */
+  virtual bool IsBypassClientCTM() const {
     return false;
   }
 

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -463,6 +463,19 @@ bool DrmDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+void DrmDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
+                                        uint32_t *capabilities) {
+  if (ctm_id_prop_) {
+    PhysicalDisplay::GetDisplayCapabilities(numCapabilities, capabilities);
+
+    if (PhysicalDisplay::IsBypassClientCTM() == true)  {
+      ++*numCapabilities;
+      *capabilities |= static_cast<uint32_t>(HWCDisplayCapability::
+                       kDisplayCapabilitySkipClientColorTransform);
+    }
+  }
+}
+
 void DrmDisplay::UpdateDisplayConfig() {
   // update the activeConfig
   SPIN_LOCK(display_lock_);

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -170,6 +170,9 @@ class DrmDisplay : public PhysicalDisplay {
   uint32_t FindPreferedDisplayMode(size_t modes_size);
   uint32_t FindPerformaceDisplayMode(size_t modes_size);
 
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities);
+
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;
   uint32_t mmHeight_ = 0;

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -61,6 +61,12 @@ class DrmDisplay : public PhysicalDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities) override;
+
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   bool SetBroadcastRGB(const char *range_property) override;
 
   void SetHDCPState(HWCContentProtection state,
@@ -169,9 +175,6 @@ class DrmDisplay : public PhysicalDisplay {
 
   uint32_t FindPreferedDisplayMode(size_t modes_size);
   uint32_t FindPerformaceDisplayMode(size_t modes_size);
-
-  void GetDisplayCapabilities(uint32_t *numCapabilities,
-                              uint32_t *capabilities);
 
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -659,4 +659,13 @@ int PhysicalDisplay::GetTotalOverlays() const {
   else
     return 0;
 }
+
+bool PhysicalDisplay::IsBypassClientCTM() const {
+  return bypassClientCTM_;
+}
+
+void PhysicalDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
+                                             uint32_t *capabilities) {
+}
+
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -125,7 +125,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
-  bool IsBypassClientCTM() const override;
+  bool IsBypassClientCTM() const;
   void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                               uint32_t *outCapabilities) override;
 

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -125,6 +125,10 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  bool IsBypassClientCTM() const override;
+  void GetDisplayCapabilities(uint32_t *outNumCapabilities,
+                              uint32_t *outCapabilities) override;
+
   bool EnableDRMCommit(bool enable) override;
 
   /**
@@ -305,6 +309,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   std::vector<NativeDisplay *> cloned_displays_;
   std::vector<NativeDisplay *> clones_;
   uint32_t config_ = DEFAULT_CONFIG_ID;
+  bool bypassClientCTM_ = false;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
This commit has been validated on APL NUC and Gordon Peak with 3 connected displays.  This PR transfers the commit to Github since Android Q will be released shortly (presumably tomorrow).

Add HWC2.3 GetDisplayIdentificationData

This API retrieves the EDID metadata for all display devices connected
to a video source. The metadata identifies the port, and describes the
display type, such as HDMI or DisplayPort and their capabilities.  The
data blob returned by the API contains the supported EDID format,
typically EDID 1.3, as specified in VESA E-EDID Standard Release A
Revision 1.  Note that EDID 1.4 metadata format is not supported since
the format is incompatible with the HDMI specification.

Tests:         Validated on Gordon Peak with three connected displays
Tracked-On:    https://jira.devtools.intel.com/browse/OAM-71878
Signed-off-by: Michele Lim <michele.lim@intel.com>