### PR TITLE
Add HWC2.3 GetDisplayIdentificationData

### DIFF
--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -238,6 +238,12 @@ bool LogicalDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool LogicalDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                  uint32_t *outDataSize,
+                                                  uint8_t *outData) {
+  return true;
+}
+
 void LogicalDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
                                             uint32_t *capabilities) {
   physical_display_->GetDisplayCapabilities(numCapabilities, capabilities);

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -105,6 +105,9 @@ class LogicalDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -608,6 +608,12 @@ bool MosaicDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool MosaicDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                 uint32_t *outDataSize,
+                                                 uint8_t *outData) {
+  return true;
+}
+
 bool MosaicDisplay::IsBypassClientCTM() const {
   uint32_t size = physical_displays_.size();
   for (uint32_t i = 0; i < size; i++) {

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -100,7 +100,10 @@ class MosaicDisplay : public NativeDisplay {
 
   bool EnableDRMCommit(bool enable) override;
 
-  bool IsBypassClientCTM() const override;
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
+  bool IsBypassClientCTM() const;
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -492,6 +492,12 @@ bool VirtualDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool VirtualDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                                  uint32_t *outDataSize,
+                                                  uint8_t *outData) {
+  return true;
+}
+
 void VirtualDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
                                             uint32_t *capabilities) {
 }

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -77,6 +77,9 @@ class VirtualDisplay : public NativeDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   void GetDisplayCapabilities(uint32_t *numCapabilities,
                               uint32_t *capabilities) override;
 

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -969,8 +969,26 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
 
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayIdentificationData(
     uint8_t *outPort, uint32_t *outDataSize, uint8_t *outData) {
-  unsupported(__func__);
-  return HWC2::Error::None;
+  supported(__func__);
+  ITRACE("Invoked IAHWC2::HwcDisplay::GetDisplayIdentificationData()");
+  if (outPort == NULL || outDataSize == NULL) {
+    ETRACE("Return BadParameter");
+    return HWC2::Error::BadParameter;
+  }
+
+  if (display_) {
+    if (display_->GetDisplayIdentificationData(outPort, outDataSize, outData)) {
+      (outData == NULL) ? ITRACE("outPort=%x, outDataSize=%x, outData=NULL",
+                                 outPort, outDataSize)
+                        : ITRACE("outPort=%x, outDataSize=%x, outData=%x",
+                                 outPort, outDataSize, outData);
+
+      return HWC2::Error::None;
+    }
+  }
+
+  ETRACE("Return BadDisplay");
+  return HWC2::Error::BadDisplay;
 }
 
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayCapabilities(

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -89,6 +89,10 @@ class NativeDisplay {
   virtual bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) = 0;
   virtual bool GetDisplayName(uint32_t *size, char *name) = 0;
 
+  virtual bool GetDisplayIdentificationData(uint8_t *outPort,
+                                            uint32_t *outDataSize,
+                                            uint8_t *outData) = 0;
+
   virtual void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                                       uint32_t *outCapabilities) = 0;
 

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -463,6 +463,86 @@ bool DrmDisplay::GetDisplayName(uint32_t *size, char *name) {
   return true;
 }
 
+bool DrmDisplay::GetDisplayIdentificationData(uint8_t *outPort,
+                                              uint32_t *outDataSize,
+                                              uint8_t *outData) {
+  uint8_t *edid = NULL;
+  uint8_t numBlocks = 0;
+  uint32_t size = 0;
+  uint64_t edid_blob_id;
+  drmModePropertyBlobPtr blob;
+
+  ITRACE("Invoked DrmDisplay::GetDisplayIdentificationData()");
+
+  (outData == NULL)
+      ? ITRACE("gpu_fd_:%d, connector_:%d, outData=NULL", gpu_fd_, connector_)
+      : ITRACE("gpu_fd_:%d, connector_:%d, outData:%p", gpu_fd_, connector_,
+               outData);
+
+  ScopedDrmObjectPropertyPtr connector_props(drmModeObjectGetProperties(
+      gpu_fd_, connector_, DRM_MODE_OBJECT_CONNECTOR));
+
+  if (!gpu_fd_ || !connector_ || !connector_props) {
+    if (connector_props) {
+      connector_props.release();
+    }
+    ETRACE("Invalid connector possibly due to no connected display.");
+    return false;
+  }
+
+  GetDrmObjectPropertyValue("EDID", connector_props, &edid_blob_id);
+  blob = drmModeGetPropertyBlob(gpu_fd_, edid_blob_id);
+  if (!blob) {
+    ETRACE("Invalid EDID blob");
+    connector_props.release();
+    return false;
+  }
+
+  edid = (uint8_t *)blob->data;
+  if (!edid) {
+    drmModeFreePropertyBlob(blob);
+    connector_props.release();
+    ETRACE("Invalid EDID data");
+    return false;
+  }
+
+  /* if outData == NULL, estimate the size in bytes of the data which would
+     have been returned before this function was called */
+  if (outData == NULL) {
+    numBlocks = edid[126];
+    *outDataSize = 128 + 128 * 4;
+    ITRACE("Estimate of EDID data size: %d", *outDataSize);
+
+    drmModeFreePropertyBlob(blob);
+    connector_props.release();
+    return true;
+  }
+
+  /* Retrieve total EDID size, data and number of extension blocks */
+  size = blob->length;
+  if (!size) {
+    drmModeFreePropertyBlob(blob);
+    connector_props.release();
+    ETRACE("Invalid EDID size");
+    return false;
+  }
+
+  /* if outData != NULL, the size of outData, which must not exceed the value
+     stored in outDataSize prior to the call */
+  if (outData != NULL) {
+    *outDataSize = size;
+    std::memcpy(outData, (uint8_t *)edid, size);
+  }
+
+  drmModeFreePropertyBlob(blob);
+  connector_props.release();
+
+  *outPort = CrtcId();
+  ITRACE("CRTC id: %d", *outPort);
+
+  return true;
+}
+
 void DrmDisplay::GetDisplayCapabilities(uint32_t *numCapabilities,
                                         uint32_t *capabilities) {
   if (ctm_id_prop_) {

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -61,6 +61,12 @@ class DrmDisplay : public PhysicalDisplay {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
+  void GetDisplayCapabilities(uint32_t *numCapabilities,
+                              uint32_t *capabilities) override;
+
+  bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
+                                    uint8_t *outData) override;
+
   bool SetBroadcastRGB(const char *range_property) override;
 
   void SetHDCPState(HWCContentProtection state,
@@ -169,9 +175,6 @@ class DrmDisplay : public PhysicalDisplay {
 
   uint32_t FindPreferedDisplayMode(size_t modes_size);
   uint32_t FindPerformaceDisplayMode(size_t modes_size);
-
-  void GetDisplayCapabilities(uint32_t *numCapabilities,
-                              uint32_t *capabilities);
 
   uint32_t crtc_id_ = 0;
   uint32_t mmWidth_ = 0;

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -125,7 +125,7 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
-  bool IsBypassClientCTM() const override;
+  bool IsBypassClientCTM() const;
   void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                               uint32_t *outCapabilities) override;
 


### PR DESCRIPTION
This API retrieves the EDID metadata for all display devices connected
to a video source. The metadata identifies the port, and describes the
display type, such as HDMI or DisplayPort and their capabilities.  The
data blob returned by the API contains the supported EDID format,
typically EDID 1.3, as specified in VESA E-EDID Standard Release A
Revision 1.  Note that EDID 1.4 metadata format is not supported since
the format is incompatible with the HDMI specification.

Change-Id:     Ia7f9ab0d4c20d5422e8446cdadd280d653e5e34c
Tests:         Validated on Gordon Peak with three connected displays
Tracked-On:    https://jira.devtools.intel.com/browse/OAM-71878
Signed-off-by: Michele Lim <michele.lim@intel.com>