### PR TITLE
Validatelayers when current layer may not need be composed

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -269,7 +269,13 @@ void DisplayQueue::InitializeOverlayLayers(
       has_video_layer = true;
     }
     if (previous_layer) {
-      if ((overlay_layer->IsVideoLayer() != previous_layer->IsVideoLayer())) {
+#ifndef FORCE_ALL_DEVICE_TYPE
+      if ((overlay_layer->IsVideoLayer() != previous_layer->IsVideoLayer()) ||
+          (overlay_layer->IsSolidColor() != previous_layer->IsSolidColor()) ||
+          (overlay_layer->GetAlpha() != previous_layer->GetAlpha())) {
+#else
+      if (overlay_layer->IsVideoLayer() != previous_layer->IsVideoLayer()) {
+#endif
         re_validate_begin = 0;
       }
       // Does not need to re_validate


### PR DESCRIPTION
HWC need to do compose for SolidColor and Alpha!=FF/0 layer,
when current layer is different in SolidColor and Alpha!=FF/0
with cached layer. HWC need to re-run ValidateLayers

Change-Id: If8c764e21614051e65b2a4fb7f623115673b7902
Tests: No unnecessay compose are invoked in Camera preview
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85475
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>