### PR TITLE
Fix the vts composer2.2/2.3 failed subcases

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -801,6 +801,44 @@ HWC2::Error IAHWC2::HwcDisplay::SetColorMode(int32_t mode) {
   return HWC2::Error::None;
 }
 
+HWC2::Error IAHWC2::HwcDisplay::SetColorModeWithRenderIntent(int32_t mode,
+                                                             int32_t intent) {
+  supported(__func__);
+  if (mode < 0)
+    return HWC2::Error::BadParameter;
+  if (intent < 0)
+    return HWC2::Error::BadParameter;
+
+  // TODO: Use the parameter mode to set the color mode for the display to be
+  // used.
+
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::GetRenderIntents(int32_t mode,
+                                                 uint32_t *outNumIntents,
+                                                 int32_t *outIntents) {
+  supported(__func__);
+  if (mode < 0) {
+    return HWC2::Error::BadParameter;
+  }
+
+  if (!outNumIntents) {
+    return HWC2::Error::BadParameter;
+  }
+
+  if (outIntents == NULL) {
+    *outNumIntents = GetNumRenderIntents();
+    return HWC2::Error::None;
+  }
+
+  if (mode == HAL_COLOR_MODE_NATIVE) {
+    *outIntents = HAL_RENDER_INTENT_COLORIMETRIC;
+  }
+
+  return HWC2::Error::None;
+}
+
 HWC2::Error IAHWC2::HwcDisplay::SetColorTransform(const float *matrix,
                                                   int32_t hint) {
   supported(__func__);
@@ -1049,6 +1087,7 @@ HWC2::Error IAHWC2::HwcDisplay::GetDisplayedContentSample(uint64_t max_frames,
                                                           int32_t *samples_size,
                                                           uint64_t **samples) {
   unsupported(__func__);
+  *frame_count = 0;
   return HWC2::Error::None;
 }
 
@@ -1357,6 +1396,16 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_COLOR_MODE>(
           DisplayHook<decltype(&HwcDisplay::SetColorMode),
                       &HwcDisplay::SetColorMode, int32_t>);
+    case HWC2::FunctionDescriptor::GetRenderIntents:
+      return ToHook<HWC2_PFN_GET_RENDER_INTENTS>(
+          DisplayHook<decltype(&HwcDisplay::GetRenderIntents),
+                      &HwcDisplay::GetRenderIntents, int32_t, uint32_t *,
+                      int32_t *>);
+    case HWC2::FunctionDescriptor::SetColorModeWithRenderIntent:
+      return ToHook<HWC2_PFN_SET_COLOR_MODE_WITH_RENDER_INTENT>(
+          DisplayHook<decltype(&HwcDisplay::SetColorModeWithRenderIntent),
+                      &HwcDisplay::SetColorModeWithRenderIntent, int32_t,
+                      int32_t>);
     case HWC2::FunctionDescriptor::SetColorTransform:
       return ToHook<HWC2_PFN_SET_COLOR_TRANSFORM>(
           DisplayHook<decltype(&HwcDisplay::SetColorTransform),

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -168,7 +168,7 @@ class IAHWC2 : public hwc2_device_t {
     HwcDisplay(const HwcDisplay &) = delete;
     HwcDisplay &operator=(const HwcDisplay &) = delete;
 
-    uint32_t numCap_ = 0;
+    uint32_t numCap_ = 1;  // at least support the doze
     uint32_t maxNumCap_ = HWC2_DISPLAY_CAPABILITY_DOZE -
                           HWC2_DISPLAY_CAPABILITY_INVALID; /* last - first */
 
@@ -178,6 +178,11 @@ class IAHWC2 : public hwc2_device_t {
 
     void setNumCapabilities(uint32_t num) {
       numCap_ = num;
+    }
+
+    uint32_t num_intents_ = 1;  // at least support the COLORIMETRIC
+    uint32_t GetNumRenderIntents() {
+      return num_intents_;
     }
 
     HWC2::Error Init(hwcomposer::NativeDisplay *display, int display_index,
@@ -229,6 +234,10 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::Error SetClientTarget(buffer_handle_t target, int32_t acquire_fence,
                                 int32_t dataspace, hwc_region_t damage);
     HWC2::Error SetColorMode(int32_t mode);
+    HWC2::Error SetColorModeWithRenderIntent(int32_t mode, int32_t intent);
+    HWC2::Error GetRenderIntents(int32_t mode, uint32_t *outNumIntents,
+                                 int32_t *outIntents);
+
     HWC2::Error SetColorTransform(const float *matrix, int32_t hint);
     HWC2::Error SetOutputBuffer(buffer_handle_t buffer, int32_t release_fence);
     HWC2::Error SetPowerMode(int32_t mode);


### PR DESCRIPTION
Change-Id: Iee76ded6ac5252e60cd09efc6f5c4be12e423329
Tests: VTS Composer2.1/2.1/2.3 all pass, no regression.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-84415
Signed-off-by: HeYue <yue.he@intel.com>