### PR TITLE
the index for changed layer should be 0 in 1 overlay case

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -89,7 +89,9 @@ bool DisplayPlaneManager::ValidateLayers(
   CTRACE();
 
   size_t video_layers = 0;
-  for (size_t lindex = 0; lindex < layers.size(); lindex++) {
+  if (total_overlays_ == 1)
+    add_index = 0;
+  for (size_t lindex = add_index; lindex < layers.size(); lindex++) {
     if (layers[lindex].IsVideoLayer())
       video_layers++;
   }

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -895,7 +895,6 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   for (std::pair<const hwc2_layer_t, IAHWC2::Hwc2Layer> &l : layers_) {
     if (l.second.IsVideoLayer()) {
       include_video_layer = true;
-      ALOGI("layers: %d is video layer\n", l.first);
       break;
     }
   }


### PR DESCRIPTION
When overlay is more than 1, need to start from the index

Change-Id: Ia662688a85f64458cfea72c4104b2bf8cfea9917
Tests: Play video normally
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>