### PR TITLE
Ignore queue update without DRM master.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -170,6 +170,10 @@ bool GpuDevice::ResetDrmMaster(bool drop_master) {
   return ret;
 }
 
+bool GpuDevice::IsDrmMaster() {
+  return display_manager_->IsDrmMaster();
+}
+
 const std::vector<NativeDisplay *> &GpuDevice::GetAllDisplays() {
   return total_displays_;
 }

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "displayplanemanager.h"
+#include "gpudevice.h"
 #include "hwctrace.h"
 #include "hwcutils.h"
 #include "nativesurface.h"
@@ -469,6 +470,11 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
                                PixelUploaderCallback* call_back,
                                bool handle_constraints) {
   CTRACE();
+  if (!GpuDevice::getInstance().IsDrmMaster()) {
+    ITRACE("DRM master is not set, ignore queue update.");
+    return true;
+  }
+
   ScopedIdleStateTracker tracker(idle_tracker_, compositor_,
                                  resource_manager_.get(), this);
   if (tracker.IgnoreUpdate()) {

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -110,6 +110,8 @@ class GpuDevice : public HWCThread {
 
   bool ResetDrmMaster(bool drop_master);
 
+  bool IsDrmMaster();
+
   std::vector<uint32_t> GetDisplayReservedPlanes(uint32_t display_id);
 
  private:


### PR DESCRIPTION
Ignore displayqueue.QueueUpdate without DRM master.
Since surface can not be committed to DRM without Drm master.
Ignore any update, to avoid wasting GPU resource for
rendering

Change-Id: I7034297b0d30dd7b9c07f0a6d7abd94b4865c225
Tests: No EGL exit in 10 round reboot.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85425
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>