### PR TITLE
Update the alpha blending logic for composing.

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -230,12 +230,23 @@ bool DisplayPlaneManager::ValidateLayers(
           // Separate plane added
           composition.emplace_back(plane, layer, this);
           DisplayPlaneState &last_plane = composition.back();
+          ISURFACETRACE(
+              "Added Layer[%d] into separate plane[%d](NotInUse): %d %d "
+              "validate_final_layers: %d  \n",
+              layer->GetZorder(), last_plane.GetDisplayPlane()->id(),
+              layer->GetZorder(), composition.size(), validate_final_layers);
 
           // If we are able to composite buffer with the given plane, lets use
           // it.
           bool fall_back = FallbacktoGPU(plane, layer, composition);
           test_commit_done = true;
           if (fall_back) {
+            ISURFACETRACE(
+                "Force GPU rander the plane[%d], for the layer[%d] isVideo: "
+                "%d, isSolidColor: %d, alpha: %d",
+                last_plane.GetDisplayPlane()->id(), layer->GetZorder(),
+                layer->IsVideoLayer(), layer->IsSolidColor(),
+                layer->GetAlpha());
             last_plane.ForceGPURendering();
           }
         } else {

--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -37,6 +37,18 @@ int HWCPoll(int fd, int timeout) {
   return ret;
 }
 
+bool IsLayerAlphaBlendingCommitted(OverlayLayer* layer) {
+  uint64_t alpha = 0xFF;
+
+  if (layer->GetBlending() == HWCBlending::kBlendingPremult)
+    alpha = layer->GetAlpha();
+
+  if (layer->GetZorder() > 0 && alpha != 0xFF) {
+    return false;
+  }
+  return true;
+}
+
 void ResetRectToRegion(const HwcRegion& hwc_region, HwcRect<int>& rect) {
   size_t total_rects = hwc_region.size();
   if (total_rects == 0) {

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -20,8 +20,10 @@
 #ifdef USE_ANDROID_PROPERTIES
 #include <cutils/properties.h>
 #endif
+
 #include <hwcdefs.h>
 #include <sstream>
+#include "overlaylayer.h"
 
 namespace hwcomposer {
 
@@ -36,6 +38,8 @@ namespace hwcomposer {
  * @return -1 on error
  */
 int HWCPoll(int fd, int timeout);
+
+bool IsLayerAlphaBlendingCommitted(OverlayLayer* layer);
 
 /**
  * Reset the bounds of a rectangle to enclose all rectangles in a region


### PR DESCRIPTION
When layer alpha become 0xff(blending is Premult), re-validate for
composing or scanout. when the alpha(Premult) become 0, still need
to compose, otherwise, a alpha 255 surface will be shown(for alpha=0)
in scanout.

Change-Id: I97bd1321c5122fc05d7b68cbd23c4fc1692ea7d4
Tests: Work well on Android Q
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85651
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>