### PR TITLE
Fixed the dmabuf leak issue caused by prime FDs are not released.

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -27,6 +27,7 @@
 #include "hwctrace.h"
 #include "overlaylayer.h"
 
+#include "gpudevice.h"
 #include "hwcutils.h"
 
 namespace hwcomposer {
@@ -308,6 +309,15 @@ bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
           }
           mHyperDmaExportedBuffers.erase(search);
         }
+
+        FrameBufferManager *fb_manager =
+            GpuDevice::getInstance().GetFrameBufferManager();
+
+        if (fb_manager) {
+          fb_manager->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                               handle.handle_->meta_data_.gem_handles_);
+        }
+
         handler->ReleaseBuffer(handle.handle_);
         handler->DestroyHandle(handle.handle_);
       }

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -27,6 +27,7 @@
 #include "hwctrace.h"
 #include "overlaylayer.h"
 
+#include "gpudevice.h"
 #include "hwcutils.h"
 
 namespace hwcomposer {
@@ -294,6 +295,15 @@ void VirtualPanoramaDisplay::HyperDmaExport(bool notify_stopping) {
         }
         mHyperDmaExportedBuffers.erase(search);
       }
+
+      FrameBufferManager *fb_manager =
+          GpuDevice::getInstance().GetFrameBufferManager();
+
+      if (fb_manager) {
+        fb_manager->RemoveFB(handle.handle_->meta_data_.num_planes_,
+                             handle.handle_->meta_data_.gem_handles_);
+      }
+
       handler->ReleaseBuffer(handle.handle_);
       handler->DestroyHandle(handle.handle_);
     }


### PR DESCRIPTION
Release prime FDs if the buffer needs to be released.

Change-Id: Id9381a2fbd7681aca71a5e6ab387713f5b644e31
Tracked-On: https://jira.devtools.intel.com/browse/OAM-82969
Tests: HWC virtual memory doesn't inrease abnormally.
Signed-off-by: Wan Shuang <shuang.wan@intel.com>