### PR TITLE
Fixed the HWC crash due to messed virtual display handle.

### DIFF
--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "hwcservice.h"
+#include "spinlock.h"
 
 /*we have two extend displays,the seconde one's take over virtual
 display ID slot.to simplify ID management,start the virtual display
@@ -386,6 +387,7 @@ class IAHWC2 : public hwc2_device_t {
   HwcDisplay primary_display_;
   std::map<uint32_t, std::unique_ptr<HwcDisplay>> virtual_displays_;
   uint32_t virtual_display_index_ = 0;
+  SpinLock spin_lock_;
 
   bool disable_explicit_sync_ = false;
   android::HwcService hwcService_;

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -415,21 +415,20 @@ void DrmDisplayManager::NotifyClientsOfDisplayChangeStatus() {
 }
 
 NativeDisplay *DrmDisplayManager::CreateVirtualDisplay(uint32_t display_index) {
-  spin_lock_.lock();
   NativeDisplay *latest_display;
   std::unique_ptr<VirtualDisplay> display(
       new VirtualDisplay(fd_, buffer_handler_.get(), display_index, 0));
   virtual_displays_.emplace(display_index, std::move(display));
   latest_display = virtual_displays_.at(display_index).get();
-  spin_lock_.unlock();
   return latest_display;
 }
 
 void DrmDisplayManager::DestroyVirtualDisplay(uint32_t display_index) {
-  spin_lock_.lock();
-  virtual_displays_.at(display_index).reset(nullptr);
-  virtual_displays_.erase(display_index);
-  spin_lock_.unlock();
+  auto it = virtual_displays_.find(display_index);
+  if (it != virtual_displays_.end()) {
+    virtual_displays_.at(display_index).reset(nullptr);
+    virtual_displays_.erase(display_index);
+  }
 }
 
 std::vector<NativeDisplay *> DrmDisplayManager::GetAllDisplays() {


### PR DESCRIPTION
The virtual display handle tracked in map might be messed due to
newly created display instance might overwrite exiting one.

Tracked-On: None
Tests: HWC doesn't crash when create/destroy VDS frequently.
Signed-off-by: Wan Shuang <shuang.wan@intel.com>