### PR TITLE
Fix screen flicker in mosaic mode when audio switch

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -284,7 +284,6 @@ void HwcLayer::SufaceDamageTransfrom() {
 
 void HwcLayer::Validate() {
   if (total_displays_ == 1) {
-    state_ &= ~kVisibleRegionChanged;
     state_ |= kLayerValidated;
     state_ &= ~kLayerContentChanged;
     state_ &= ~kZorderChanged;


### PR DESCRIPTION
Remove the hwc layer state reset when layer only will
present to one display.
When overlaylayer ValidatePreviousFrameState this causes
kLayerContentChanged always be 0. But in mosaic mode, after
present to second display, the layer will still present to
first display, this time the layer region is changed in fact.

Change-Id: Id5a5e2849934e37568c37c21cbd823419af77d58
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85023
Signed-off-by: Yuanzhe Liu <yuanzhe.liu@intel.com>