### PR TITLE
[Revert me]Assign the commit fence to the first video

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -273,6 +273,10 @@ void DisplayQueue::InitializeOverlayLayers(
       if (overlay_layer->IsVideoLayer() != previous_layer->IsVideoLayer()) {
         re_validate_begin = 0;
       }
+      if ((!previous_layer->IsVideoLayer()) && overlay_layer->IsVideoLayer())
+        video_first_frame_ = true;
+      if (previous_layer->IsVideoLayer() && overlay_layer->IsVideoLayer())
+        video_first_frame_ = false;
       if (re_validate_begin == size) {
         bool need_revalidate =
             overlay_layer->IsSolidColor() != previous_layer->IsSolidColor();
@@ -807,6 +811,14 @@ void DisplayQueue::SetReleaseFenceToLayers(
           int32_t temp = overlay_layer.GetAcquireFence();
           if (temp > 0) {
             layer->SetReleaseFence(dup(temp));
+          } else {
+            if (layer->IsVideoLayer() && video_first_frame_) {
+              ITRACE(
+                  "set commit fence[%d] for first video buffer as release "
+                  "fence",
+                  fence);
+              layer->SetReleaseFence(dup(fence));
+            }
           }
         }
       }

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -403,6 +403,7 @@ class DisplayQueue {
   bool clone_mode_ = false;
   // Set to true if this queue needs to render the offscreen surfaces.
   bool clone_rendered_ = false;
+  bool video_first_frame_ = false;
   // Surfaces to be marked as not in use. These
   // are surfaces which are added to surfaces_not_inuse_
   // below.


### PR DESCRIPTION
As a WA, assign the commit fence to the first video layer.
for CTS testing. and this issue should be fixed in AOSP

Change-Id: I753e4513781d68463fed474478919eb12ae83d1a
Tests: PASS in CTS AdaptivePlayback testing
Tracked-On: https://jira.devtools.intel.com/browse/OAM-85616
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>