### PR TITLE
Fix a null pointer in 2 Overlay case

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -120,7 +120,7 @@ bool DisplayPlaneManager::ValidateLayers(
   }
 
   // Let's mark all planes as free to be used.
-  for (auto j = overlay_begin; j != overlay_planes_.end(); ++j) {
+  for (auto j = overlay_begin; j < overlay_planes_.end(); ++j) {
     j->get()->SetInUse(false);
   }
 


### PR DESCRIPTION
When quiting video playback, the overlay.begin + composition
could be larger than overlay.end.

Change-Id: Ie7fcdee210e75f010a710025c061953307e796c5
Tests: Work well on Acrn with 3 displays.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-86947
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>