### PR TITLE
Use merged transform for rotation

### DIFF
--- a/common/compositor/renderstate.cpp
+++ b/common/compositor/renderstate.cpp
@@ -52,7 +52,7 @@ void RenderState::ConstructState(std::vector<OverlayLayer> &layers,
     bool flip_xy[2] = {false, false};
     uint32_t transform = layer.GetTransform();
     if (use_plane_transform) {
-      transform = layer.GetPlaneTransform();
+      transform = layer.GetMergedTransform();
     }
 
     switch (transform) {


### PR DESCRIPTION
The merged transform for layer and plane rotation should be used for
calculating rotated displayframe

Change-Id: Id30e07d06acf158293a1fdadd59a17792f81fa48
Tests: Work well on Android P and Q
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>