### PR TITLE
replace spin lock with mutex

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -123,7 +123,8 @@ LOCAL_CPPFLAGS += \
 	-Wno-unused-private-field \
 	-Wno-unused-function \
 	-Wno-unused-parameter \
-	-Wno-unused-variable
+	-Wno-unused-variable \
+	-DUSE_MUTEX
 
 LOCAL_CPPFLAGS += -DVA_SUPPORT_COLOR_RANGE
 

--- a/wsi/drm/drmdisplaymanager.h
+++ b/wsi/drm/drmdisplaymanager.h
@@ -121,7 +121,11 @@ class DrmDisplayManager : public HWCThread, public DisplayManager {
   int hotplug_fd_ = -1;
   bool notify_client_ = false;
   bool release_lock_ = false;
+#ifdef USE_MUTEX
+  std::mutex mLock;
+#else
   SpinLock spin_lock_;
+#endif
   int connected_display_count_ = 0;
   bool drm_master_ = false;
 };


### PR DESCRIPTION
The spin lock is a dead-loop waiting lock, incase
a realtime thread waiting for it, the cpu resource
won't be released and trigger a dead-lock, so use
mutext to replace it.

Change-Id: I572effc8fa79df1a1df8bc44c9e70bf86e23acd3
Tracked-On: None
Signed-off-by: zhang jun <jun.zhang@intel.com>
Signed-off-by: Yang, Dong <dong.yang@intel.com>