### PR TITLE
Set commit fence for all video layer

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -273,10 +273,6 @@ void DisplayQueue::InitializeOverlayLayers(
       if (overlay_layer->IsVideoLayer() != previous_layer->IsVideoLayer()) {
         re_validate_begin = 0;
       }
-      if ((!previous_layer->IsVideoLayer()) && overlay_layer->IsVideoLayer())
-        video_first_frame_ = true;
-      if (previous_layer->IsVideoLayer() && overlay_layer->IsVideoLayer())
-        video_first_frame_ = false;
       if (re_validate_begin == size) {
         bool need_revalidate =
             overlay_layer->IsSolidColor() != previous_layer->IsSolidColor();
@@ -812,11 +808,8 @@ void DisplayQueue::SetReleaseFenceToLayers(
           if (temp > 0) {
             layer->SetReleaseFence(dup(temp));
           } else {
-            if (layer->IsVideoLayer() && video_first_frame_) {
-              ITRACE(
-                  "set commit fence[%d] for first video buffer as release "
-                  "fence",
-                  fence);
+            // [WA] set commit fence for video buffer as release fence
+            if (layer->IsVideoLayer()) {
               layer->SetReleaseFence(dup(fence));
             }
           }

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -403,7 +403,6 @@ class DisplayQueue {
   bool clone_mode_ = false;
   // Set to true if this queue needs to render the offscreen surfaces.
   bool clone_rendered_ = false;
-  bool video_first_frame_ = false;
   // Surfaces to be marked as not in use. These
   // are surfaces which are added to surfaces_not_inuse_
   // below.


### PR DESCRIPTION
CTS test case not only check the fence of first frame
CTS also check the fence after the video config is changed
has to assign the commit fence for all video layer for
getting pass in CTS.

Change-Id: I7f3a041cad3e77888b871d03ea9fac79919b87f6
Tests: Get PASS in CTS AdaptivePlaybackTest.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-88423
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>