### PR TITLE
Should validate from 0 when current layer is new video

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -295,6 +295,8 @@ void DisplayQueue::InitializeOverlayLayers(
         if (need_revalidate)
           re_validate_begin = layer_index;
       }
+    } else if (overlay_layer->IsVideoLayer()) {
+      re_validate_begin = 0;
     } else if (re_validate_begin == size) {
       re_validate_begin = layer_index;
     }


### PR DESCRIPTION
Should validate all layers again when video layer presents and no
correcponding previous layer in previous list.

Change-Id: Ib77b24dd751c0362b27d9159e483d96e924b47c1
Tests: Protected Video can be played well
Tracked-On: https://jira.devtools.intel.com/browse/OAM-88442
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>