### PR TITLE
Skip the client-composed cursor layer

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -56,6 +56,8 @@ void DisplayPlaneManager::ResizeOverlays() {
       } else {
         total_overlays_--;
       }
+    } else {
+      cursor_plane_ = NULL;
     }
   }
   IPLANERESERVEDTRACE(
@@ -110,7 +112,6 @@ bool DisplayPlaneManager::ValidateLayers(
                     layers.size());
       ForceVppForAllLayers(composition, layers, add_index, mark_later, false);
     }
-
     return true;
   }
 


### PR DESCRIPTION
When all layer are set as Client (1 plane case)
the (client)cursor layer still be sent from SF incorrectly.
Skip this duplicated cursor.

Change-Id: Ifa562863f0c7423c014ed6c276dfd416a4989da9
Tests: UI normal, Cursor layer is present well
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>