### PR TITLE
Set all layer as Client on CIV

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -128,6 +128,8 @@ LOCAL_CPPFLAGS += \
 
 LOCAL_CPPFLAGS += -DVA_SUPPORT_COLOR_RANGE
 
+LOCAL_CPPFLAGS += -DKVM_HWC_PROPERTY='"ro.graphics.hwcomposer.kvm"'
+
 ifeq ($(strip $(BOARD_USES_VULKAN)), true)
 LOCAL_SHARED_LIBRARIES += \
 	libvulkan

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1017,6 +1017,10 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
     for (std::pair<const uint32_t, hwc2_layer_t> &l : z_map) {
       if (!avail_planes--)
         break;
+#ifdef KVM_HWC_PROPERTY
+      if (IsKvmPlatform())
+        break;
+#endif
       if (layers_[l.second].sf_type() == HWC2::Composition::SolidColor) {
         layers_[l.second].set_validated_type(HWC2::Composition::SolidColor);
       } else {


### PR DESCRIPTION
The buffer of Antutu6.1.1-3D can not be scaned-out directly.
WA: set all layer as Client on KVMgt

Change-Id: Ib7e4c20a1e05cf9dcc8e690373c20eac0c7ab042
Tests: UI normal
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>