### PR TITLE
Force to create GL surface for ForceXXXForAllLayers

### DIFF
--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -470,7 +470,8 @@ void DisplayPlaneManager::SetDisplayTransform(uint32_t transform) {
   display_transform_ = transform;
 }
 
-void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
+void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane,
+                                                bool force_normal_surface) {
   NativeSurface *surface = NULL;
   // We only use media formats when video compostion for 1 layer
   int dest_x = plane.GetDisplayFrame().left;
@@ -480,7 +481,7 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
       plane.IsVideoPlane() && (plane.GetSourceLayers().size() == 1);
   uint32_t preferred_format = 0;
   uint32_t usage = hwcomposer::kLayerNormal;
-  if (video_separate && !(dest_w % 2 || dest_x % 2)) {
+  if (video_separate && !(dest_w % 2 || dest_x % 2) && !force_normal_surface) {
     preferred_format = plane.GetDisplayPlane()->GetPreferredVideoFormat();
   } else {
     preferred_format = plane.GetDisplayPlane()->GetPreferredFormat();
@@ -519,7 +520,7 @@ void DisplayPlaneManager::EnsureOffScreenTarget(DisplayPlaneState &plane) {
 
   if (!surface) {
     NativeSurface *new_surface = NULL;
-    if (video_separate) {
+    if (video_separate && !force_normal_surface) {
 #ifdef SURFACE_RECYCLE_TRACING
       ISURFACERECYCLETRACE("CreateVideoSurface for plane[%d]",
                            plane.GetDisplayPlane()->id());
@@ -618,7 +619,7 @@ void DisplayPlaneManager::ForceVppForAllLayers(
   auto layer_end = layers.end();
   OverlayLayer *primary_layer = &(*(layer_begin));
   DisplayPlane *current_plane = overlay_planes_.at(composition.size()).get();
-  composition.emplace_back(current_plane, primary_layer, this);
+  composition.emplace_back(current_plane, primary_layer, this, true);
   DisplayPlaneState &last_plane = composition.back();
   layer_begin++;
   ISURFACETRACE("Added layer in ForceVPPForAllLayers: %d \n",
@@ -626,7 +627,7 @@ void DisplayPlaneManager::ForceVppForAllLayers(
 
   for (auto i = layer_begin; i != layer_end; ++i) {
     ISURFACETRACE("Added layer in ForceVPPForAllLayers: %d \n", i->GetZorder());
-    last_plane.AddLayer(&(*(i)));
+    last_plane.AddLayer(&(*(i)), true);
     i->SetLayerComposition(OverlayLayer::kGpu);
   }
   last_plane.SetVideoPlane(true);
@@ -664,7 +665,7 @@ void DisplayPlaneManager::ForceGpuForAllLayers(
   OverlayLayer *primary_layer = &(*(layers.begin()));
   DisplayPlane *current_plane = overlay_planes_.at(0).get();
 
-  composition.emplace_back(current_plane, primary_layer, this);
+  composition.emplace_back(current_plane, primary_layer, this, true);
   DisplayPlaneState &last_plane = composition.back();
   layer_begin++;
   ISURFACETRACE("Added layer in ForceGpuForAllLayers: %d \n",
@@ -672,11 +673,11 @@ void DisplayPlaneManager::ForceGpuForAllLayers(
 
   for (auto i = layer_begin; i != layer_end; ++i) {
     ISURFACETRACE("Added layer in ForceGpuForAllLayers: %d \n", i->GetZorder());
-    last_plane.AddLayer(&(*(i)));
+    last_plane.AddLayer(&(*(i)), true);
     i->SetLayerComposition(OverlayLayer::kGpu);
   }
 
-  if (last_plane.NeedsSurfaceAllocation())
+  while (last_plane.NeedsSurfaceAllocation())
     EnsureOffScreenTarget(last_plane);
   current_plane->SetInUse(true);
   // Check for Any display transform to be applied.

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -121,7 +121,8 @@ class DisplayPlaneManager {
 
   void ResetPlanes(drmModeAtomicReqPtr pset);
 
-  void EnsureOffScreenTarget(DisplayPlaneState &plane);
+  void EnsureOffScreenTarget(DisplayPlaneState &plane,
+                             bool force_normal_surface = false);
 
  private:
   DisplayPlaneState *GetLastUsedOverlay(DisplayPlaneStateList &composition);

--- a/common/display/displayplanestate.h
+++ b/common/display/displayplanestate.h
@@ -54,12 +54,13 @@ class DisplayPlaneState {
   DisplayPlaneState(DisplayPlaneState &&rhs) = default;
   DisplayPlaneState &operator=(DisplayPlaneState &&other) = default;
   DisplayPlaneState(DisplayPlane *plane, OverlayLayer *layer,
-                    DisplayPlaneManager *plane_manager);
+                    DisplayPlaneManager *plane_manager,
+                    bool force_normal_surface = false);
 
   // Copies plane state from state.
   void CopyState(DisplayPlaneState &state);
 
-  void AddLayer(const OverlayLayer *layer);
+  void AddLayer(const OverlayLayer *layer, bool force_normal_surface = false);
 
   // This API should be called only when source_layers being
   // shown by this plane might be removed in this frame.
@@ -71,7 +72,7 @@ class DisplayPlaneState {
   void RefreshLayerRects(const std::vector<OverlayLayer> &layers);
 
   // Forces GPU Rendering of content for this plane.
-  void ForceGPURendering();
+  void ForceGPURendering(bool force_normal_surface = false);
 
   void DisableGPURendering();
 
@@ -239,7 +240,7 @@ class DisplayPlaneState {
   void Dump() const;
 
  private:
-  void EnsureOffScreenPlaneTarget();
+  void EnsureOffScreenPlaneTarget(bool force_normal_surface = false);
   void UpdateRotateFrame();
   void CalculateSourceCrop(HwcRect<float> &source_crop) const;
 


### PR DESCRIPTION
If the first layer is video, a nativesurface will be created during
ForceGpuForAllLayers. In ForceGpuForAllLayers, all surface should be
GL surface. For VPP composing, the surface should also be 3D format

Change-Id: I0cd48ee863329e64afab4c6497fd2f3d52485f50
Tests: Work well on CIV video case
Tracked-On: https://jira.devtools.intel.com/browse/OAM-88556
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>