### PR TITLE
rename library name to avoid name conflicts from external

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 // =====================
-// libdrmhwc_utils.a
+// libdrmhwc_utils_intel.a
 // =====================
 cc_library_static {
-    name: "libdrmhwc_utils",
+    name: "libdrmhwc_utils_intel",
 
     srcs: ["worker.cpp"],
 
@@ -30,10 +30,10 @@ cc_library_static {
 }
 
 // =====================
-// hwcomposer.drm.so
+// hwcomposer.drm.intel.so
 // =====================
 cc_defaults {
-    name: "hwcomposer.drm_defaults",
+    name: "hwcomposer.drm_defaults.intel",
 
     shared_libs: [
         "libcutils",
@@ -45,7 +45,7 @@ cc_defaults {
         "libutils",
     ],
 
-    static_libs: ["libdrmhwc_utils"],
+    static_libs: ["libdrmhwc_utils_intel"],
 
     cflags: [
         "-Wall",
@@ -61,8 +61,8 @@ cc_defaults {
     vendor: true,
 }
 cc_library_static {
-    name: "drm_hwcomposer",
-    defaults: ["hwcomposer.drm_defaults"],
+    name: "drm_hwcomposer_intel",
+    defaults: ["hwcomposer.drm_defaults.intel"],
     srcs: [
         "autolock.cpp",
         "resourcemanager.cpp",
@@ -84,27 +84,31 @@ cc_library_static {
 }
 
 cc_library_shared {
-    name: "hwcomposer.drm",
-    defaults: ["hwcomposer.drm_defaults"],
-    whole_static_libs: ["drm_hwcomposer"],
+    name: "hwcomposer.drm.intel",
+    defaults: ["hwcomposer.drm_defaults.intel"],
+    whole_static_libs: ["drm_hwcomposer_intel"],
     srcs: ["platformdrmgeneric.cpp"],
     cppflags: ["-DUSE_DRM_GENERIC_IMPORTER"],
 }
 
 cc_library_shared {
-    name: "hwcomposer.drm_minigbm",
-    defaults: ["hwcomposer.drm_defaults"],
-    whole_static_libs: ["drm_hwcomposer"],
+    name: "hwcomposer.broxton",
+    defaults: ["hwcomposer.drm_defaults.intel"],
+    whole_static_libs: ["drm_hwcomposer_intel"],
+    cppflags: ["-DDRV_I915"],
     srcs: [
         "platformdrmgeneric.cpp",
         "platformminigbm.cpp",
     ],
-    include_dirs: ["external/minigbm/cros_gralloc"],
+    include_dirs: [
+        "hardware/intel/external/minigbm-intel/cros_gralloc",
+        "hardware/intel/external/minigbm-intel",
+    ],
 }
 
 // Used by hwcomposer.drm_hikey and hwcomposer.drm_hikey960
 filegroup {
-    name: "drm_hwcomposer_platformhisi",
+    name: "drm_hwcomposer_platformhisi_intel",
     srcs: [
         "platformdrmgeneric.cpp",
         "platformhisi.cpp",

--- a/hwcutils.cpp
+++ b/hwcutils.cpp
@@ -50,9 +50,8 @@ int DrmHwcBuffer::ImportBuffer(buffer_handle_t handle, Importer *importer) {
   if (ret)
     return ret;
 
-  if (importer_ != NULL) {
+  if (importer_ != NULL)
     importer_->ReleaseBuffer(&bo_);
-  }
 
   importer_ = importer;
 

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -1,13 +1,13 @@
 
 
 cc_test {
-    name: "hwc-drm-tests",
+    name: "hwc-drm-tests-intel",
 
     srcs: ["worker_test.cpp"],
 
     vendor: true,
     header_libs: ["libhardware_headers"],
-    static_libs: ["libdrmhwc_utils"],
-    shared_libs: ["hwcomposer.drm"],
+    static_libs: ["libdrmhwc_utils_intel"],
+    shared_libs: ["hwcomposer.drm.intel"],
     include_dirs: ["external/drm_hwcomposer"],
 }


### PR DESCRIPTION
1. rename to xxx.intel in Android.bp
2. support DRM_FORMAT_NV12 in hwc

Signed-off-by: yifang ma <yifangx.ma@intel.com>