### PR TITLE
Always use Client even if planes are more than layers

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -980,9 +980,9 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
      * If more layers then planes, save one plane
      * for client composited layers
      */
-    if (avail_planes < layers_.size())
+    if (avail_planes <= layers_.size())
       avail_planes--;
-    if (layers_.size() > avail_planes) {
+    if (layers_.size() >= avail_planes) {
       size_t lay_index = 0;
       for (std::pair<const uint32_t, hwc2_layer_t> &l : z_map) {
         if (lay_index == (layers_.size() - avail_planes)) {


### PR DESCRIPTION
A bug in SF's layer buffer when the buffer is composed in Cilent.
and present as Device in next frame. probably, the app didn't draw
or sync the buffer fence with SF.
A workaround here, always use Client layer even if the layers
are less than the planes.

Tests: Work well on customer device.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-89673
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>

Change-Id: Ia84eccdab8d62bc502680b4bd4243bcbe158d38e