### PR TITLE
Should not ignore commiting when the size of layer is changed.

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -535,7 +535,8 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
   }
 
   // Validate Overlays and Layers usage.
-  bool can_ignore_commit = idle_frame && !validate_layers;
+  bool can_ignore_commit = idle_frame && !validate_layers &&
+                           source_layers_->size() == in_flight_layers_.size();
 
   if (can_ignore_commit) {
     *ignore_clone_update = true;


### PR DESCRIPTION
When the current layer list is less than the previous one.
The committing should not be ignored.

Tests: UI work well.
Tracked-On: https://jira.devtools.intel.com/browse/OAM-89768
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
Change-Id: I499cea361e659a98028e515596c411d9fb2d2feb