### PR TITLE
Use Kernel Param to judge if running with GVT-g

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -54,6 +54,7 @@ endif
 LOCAL_SHARED_LIBRARIES := \
 	libcutils \
 	libdrm \
+	libdrm_intel \
 	libEGL \
 	libGLESv2 \
 	libhardware \
@@ -127,8 +128,6 @@ LOCAL_CPPFLAGS += \
 	-DUSE_MUTEX
 
 LOCAL_CPPFLAGS += -DVA_SUPPORT_COLOR_RANGE
-
-LOCAL_CPPFLAGS += -DKVM_HWC_PROPERTY='"ro.graphics.hwcomposer.kvm"'
 
 ifeq ($(strip $(BOARD_USES_VULKAN)), true)
 LOCAL_SHARED_LIBRARIES += \

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -132,7 +132,6 @@ LOCAL_CPPFLAGS += \
 	-DLOCK_DIR_PREFIX='"/vendor/etc"' \
         -DHWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.ini"' \
         -DKVM_HWC_DISPLAY_INI_PATH='"/vendor/etc/hwc_display.kvm.ini"' \
-        -DKVM_HWC_PROPERTY='"ro.graphics.hwcomposer.kvm"' \
         -DUSE_ANDROID_PROPERTIES \
         -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
         -Wno-unused-parameter \

--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -156,22 +156,6 @@ uint32_t GetTotalPlanesForFormat(uint32_t format) {
   return 1;
 }
 
-#ifdef KVM_HWC_PROPERTY
-bool IsKvmPlatform() {
-  const char* key = KVM_HWC_PROPERTY;
-  char* value = new char[20];
-  const char* property_true = "true";
-  int len = property_get(key, value, "");
-  if (len > 0 && strcmp(value, property_true) == 0) {
-    delete[] value;
-    return true;
-  } else {
-    delete[] value;
-    return false;
-  }
-}
-#endif
-
 bool IsEdidFilting() {
   const char* key = ALL_EDID_FLAG_PROPERTY;
   char* value = new char[20];

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -979,15 +979,13 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   force_all_device_type = true;
 #endif
 
-#ifdef KVM_HWC_PROPERTY
   /*
    * On KVM, only 1 plane is avaialble for committing, so skip VA-VPP
    * composing. On KVM, all layers are composed by SF Client.
    */
-  if (include_video_layer && IsKvmPlatform()) {
+  if (include_video_layer && GpuDevice::getInstance().IsGvtActive()) {
     include_video_layer = false;
   }
-#endif
   if (include_video_layer || force_all_device_type) {
     for (std::pair<const hwc2_layer_t, IAHWC2::Hwc2Layer> &l : layers_) {
       IAHWC2::Hwc2Layer &layer = l.second;
@@ -1033,10 +1031,9 @@ HWC2::Error IAHWC2::HwcDisplay::ValidateDisplay(uint32_t *num_types,
     for (std::pair<const uint32_t, hwc2_layer_t> &l : z_map) {
       if (!avail_planes--)
         break;
-#ifdef KVM_HWC_PROPERTY
-      if (IsKvmPlatform() && GpuDevice::getInstance().IsReservedDrmPlane())
+      if (GpuDevice::getInstance().IsGvtActive() &&
+          GpuDevice::getInstance().IsReservedDrmPlane())
         break;
-#endif
       if (layers_[l.second].sf_type() == HWC2::Composition::SolidColor) {
         layers_[l.second].set_validated_type(HWC2::Composition::SolidColor);
       } else {

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -53,6 +53,8 @@ class GpuDevice : public HWCThread {
 
   uint32_t GetFD() const;
 
+  bool IsGvtActive() const;
+
   NativeDisplay* GetDisplay(uint32_t display);
 
   NativeDisplay* CreateVirtualDisplay(uint32_t display_index);
@@ -116,6 +118,8 @@ class GpuDevice : public HWCThread {
 
  private:
   GpuDevice();
+
+  void CheckGvtActive();
 
   void ResetAllDisplayCommit(bool enable);
 
@@ -197,6 +201,7 @@ class GpuDevice : public HWCThread {
   SpinLock initialization_state_lock_;
   SpinLock drm_master_lock_;
   int lock_fd_ = -1;
+  bool gvt_active_ = false;
   friend class DrmDisplayManager;
 };
 

--- a/public/hwcutils.h
+++ b/public/hwcutils.h
@@ -90,15 +90,6 @@ bool IsSupportedMediaFormat(uint32_t format);
  */
 uint32_t GetTotalPlanesForFormat(uint32_t format);
 
-#ifdef KVM_HWC_PROPERTY
-/**
- * Check if running on KVM
- *
- * @return True when running on KVM/QEMU
- */
-bool IsKvmPlatform();
-#endif
-
 /**
  * Check if need to send all EDID, or only preferred and perf
  */

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -720,8 +720,7 @@ bool DrmDisplay::Commit(
     *commit_fence = 0;
   }
 #else
-#ifdef KVM_HWC_PROPERTY
-  if (IsKvmPlatform()) {
+  if (GpuDevice::getInstance().IsGvtActive()) {
     int32_t fence = *commit_fence;
     if (fence > 0) {
       HWCPoll(fence, -1);
@@ -729,7 +728,6 @@ bool DrmDisplay::Commit(
       *commit_fence = 0;
     }
   }
-#endif
 #endif
   if (first_commit_) {
     TraceFirstCommit();
@@ -796,17 +794,13 @@ bool DrmDisplay::CommitFrame(
   }
 
 #ifndef ENABLE_DOUBLE_BUFFERING
-#ifdef KVM_HWC_PROPERTY
-  if (!IsKvmPlatform()) {
-#endif
+  if (!GpuDevice::getInstance().IsGvtActive()) {
     if (previous_fence > 0) {
       HWCPoll(previous_fence, -1);
       close(previous_fence);
       *previous_fence_released = true;
     }
-#ifdef KVM_HWC_PROPERTY
   }
-#endif
 #endif
 
   int ret = drmModeAtomicCommit(gpu_fd_, pset, flags, NULL);


### PR DESCRIPTION
Use the new kernel param to judge if celadon is running with
GVT-g, or GVT-d/native.
The KVM property is not needed any more. and the related method
is removed too

Change-Id: I935b0d97b8dd94ddc7485b9ef9221069a71eefb4
Tests: Work well on both GVT-d and GVT-g
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>