### PR TITLE
Entend the reserved plane range for EHL.

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -204,7 +204,7 @@ void GpuDevice::ParsePlaneReserveSettings(std::string &value) {
   // Get each display setting
   while (std::getline(i_value, display_line_str, ';')) {
     if (display_line_str.empty() ||
-        display_line_str.find_first_not_of("0123:+") != std::string::npos)
+        display_line_str.find_first_not_of("0123456789:+") != std::string::npos)
       continue;
     std::string display_index_str =
         display_line_str.substr(0, display_line_str.find(":"));
@@ -216,7 +216,7 @@ void GpuDevice::ParsePlaneReserveSettings(std::string &value) {
     // Get reversed drm plane index
     while (std::getline(planes_index_value, reserved_plane_index_str, '+')) {
       if (reserved_plane_index_str.empty() ||
-          reserved_plane_index_str.find_first_not_of("0123") !=
+          reserved_plane_index_str.find_first_not_of("0123456789") !=
               std::string::npos)
         continue;
       uint32_t reserved_plane_index_num =

--- a/wsi/drm/drmdisplaymanager.cpp
+++ b/wsi/drm/drmdisplaymanager.cpp
@@ -685,7 +685,8 @@ void DrmDisplayManager::RemoveUnreservedPlanes() {
     if (!displays_.at(i)->IsConnected() || displays_.at(i)->IsPlanesUpdated())
       continue;
     std::vector<uint32_t> reserved_planes = device_.GetDisplayReservedPlanes(i);
-    if (!reserved_planes.empty() && reserved_planes.size() < 4)
+    if (!reserved_planes.empty() &&
+        reserved_planes.size() <= displays_.at(i)->GetTotalOverlays())
       displays_.at(i)->ReleaseUnreservedPlanes(reserved_planes);
     displays_.at(i)->SetPlanesUpdated(true);
   }


### PR DESCRIPTION
More than 4 planes are available on EHL.
the range need to be extended.

Change-Id: Ieb27296be6a73dca2dc33e5362e7434201006e6d
Tests: Work well on EHL.
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>