### PR TITLE
Add 2.4 api

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -957,6 +957,11 @@ int DisplayQueue::RegisterVsyncCallback(std::shared_ptr<VsyncCallback> callback,
   return vblank_handler_->RegisterCallback(callback, display_id);
 }
 
+int DisplayQueue::RegisterVsyncPeriodCallback(
+    std::shared_ptr<VsyncPeriodCallback> callback, uint32_t display_id) {
+  return vblank_handler_->RegisterCallback(callback, display_id);
+}
+
 void DisplayQueue::RegisterRefreshCallback(
     std::shared_ptr<RefreshCallback> callback, uint32_t display_id) {
   idle_tracker_.idle_lock_.lock();

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -85,7 +85,8 @@ class DisplayQueue {
   void RestoreVideoDefaultDeinterlace();
   int RegisterVsyncCallback(std::shared_ptr<VsyncCallback> callback,
                             uint32_t display_id);
-
+  int RegisterVsyncPeriodCallback(std::shared_ptr<VsyncPeriodCallback> callback,
+                                  uint32_t display_id);
   void RegisterRefreshCallback(std::shared_ptr<RefreshCallback> callback,
                                uint32_t display_id);
 

--- a/common/display/vblankeventhandler.cpp
+++ b/common/display/vblankeventhandler.cpp
@@ -26,12 +26,16 @@ namespace hwcomposer {
 
 static const int64_t kOneSecondNs = 1 * 1000 * 1000 * 1000;
 
+#define VPERIOD75HZ 13333333
+#define VPERIOD90HZ 11111111
+
 VblankEventHandler::VblankEventHandler(DisplayQueue* queue)
     : HWCThread(-8, "VblankEventHandler"),
       display_(0),
       enabled_(false),
       fd_(-1),
       last_timestamp_(-1),
+      previous_timestamp_(-1),
       queue_(queue) {
   memset(&type_, 0, sizeof(type_));
 }
@@ -63,7 +67,23 @@ int VblankEventHandler::RegisterCallback(
     std::shared_ptr<VsyncCallback> callback, uint32_t display) {
   spin_lock_.lock();
   callback_ = callback;
-  display_ = display;
+  if (!display_)
+    display_ = display;
+  else if (display_ != display)
+    return -1;
+  last_timestamp_ = -1;
+  spin_lock_.unlock();
+  return 0;
+}
+
+int VblankEventHandler::RegisterCallback(
+    std::shared_ptr<VsyncPeriodCallback> callback, uint32_t display) {
+  spin_lock_.lock();
+  callback_2_4_ = callback;
+  if (!display_)
+    display_ = display;
+  else if (display_ != display)
+    return -1;
   last_timestamp_ = -1;
   spin_lock_.unlock();
   return 0;
@@ -87,14 +107,21 @@ void VblankEventHandler::HandlePageFlipEvent(unsigned int sec,
   int64_t timestamp = ((int64_t)sec * kOneSecondNs) + ((int64_t)usec * 1000);
   IPAGEFLIPEVENTTRACE("HandleVblankCallBack Frame Time %f",
                       static_cast<float>(timestamp - last_timestamp_) / (1000));
+  int64_t vperiod = timestamp - previous_timestamp_;
   last_timestamp_ = timestamp;
 
   IPAGEFLIPEVENTTRACE("Callback called from HandlePageFlipEvent. %lu",
                       timestamp);
   spin_lock_.lock();
   if (enabled_ && callback_) {
-    callback_->Callback(display_, timestamp);
+    if ((abs(vperiod - vperiod_) > (VPERIOD75HZ - VPERIOD90HZ)) &&
+        previous_timestamp_ != -1)
+      callback_2_4_->Callback(display_, timestamp, vperiod);
+    else
+      callback_->Callback(display_, timestamp);
   }
+  vperiod_ = vperiod;
+  previous_timestamp_ = timestamp;
   spin_lock_.unlock();
 }
 

--- a/common/display/vblankeventhandler.h
+++ b/common/display/vblankeventhandler.h
@@ -45,6 +45,9 @@ class VblankEventHandler : public HWCThread {
   int RegisterCallback(std::shared_ptr<VsyncCallback> callback,
                        uint32_t display_id);
 
+  int RegisterCallback(std::shared_ptr<VsyncPeriodCallback> callback,
+                       uint32_t display_id);
+
   int VSyncControl(bool enabled);
 
  protected:
@@ -56,12 +59,15 @@ class VblankEventHandler : public HWCThread {
   // actually call the hook) and we don't want the memory freed until we're
   // done
   std::shared_ptr<VsyncCallback> callback_ = NULL;
+  std::shared_ptr<VsyncPeriodCallback> callback_2_4_ = NULL;
   SpinLock spin_lock_;
   uint32_t display_;
+  int64_t vperiod_;
   bool enabled_ = false;
 
   int fd_;
   int64_t last_timestamp_;
+  int64_t previous_timestamp_;
   drmVBlankSeqType type_;
   DisplayQueue* queue_;
 };

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -57,6 +57,25 @@ class IAVsyncCallback : public hwcomposer::VsyncCallback {
   hwc2_function_pointer_t hook_;
 };
 
+class IAVsyncPeriodCallback : public hwcomposer::VsyncPeriodCallback {
+ public:
+  IAVsyncPeriodCallback(hwc2_callback_data_t data, hwc2_function_pointer_t hook)
+      : data_(data), hook_(hook) {
+  }
+
+  void Callback(uint32_t display, int64_t timestamp,
+                uint32_t vsyncPeriodNanos) {
+    if (hook_ != NULL) {
+      auto hook = reinterpret_cast<HWC2_PFN_VSYNC_2_4>(hook_);
+      hook(data_, display, timestamp, vsyncPeriodNanos);
+    }
+  }
+
+ private:
+  hwc2_callback_data_t data_;
+  hwc2_function_pointer_t hook_;
+};
+
 class IARefreshCallback : public hwcomposer::RefreshCallback {
  public:
   IARefreshCallback(hwc2_callback_data_t data, hwc2_function_pointer_t hook)
@@ -335,6 +354,15 @@ HWC2::Error IAHWC2::RegisterCallback(int32_t descriptor,
 
       break;
     }
+    case HWC2::Callback::Vsync_2_4: {
+      primary_display_.RegisterVsyncPeriodCallback(data, function);
+      for (size_t i = 0; i < size; ++i) {
+        IAHWC2::HwcDisplay *display = extended_displays_.at(i).get();
+        display->RegisterVsyncPeriodCallback(data, function);
+      }
+
+      break;
+    }
     case HWC2::Callback::Refresh: {
       primary_display_.RegisterRefreshCallback(data, function);
       for (size_t i = 0; i < size; ++i) {
@@ -418,6 +446,19 @@ HWC2::Error IAHWC2::HwcDisplay::RegisterVsyncCallback(
   auto callback = std::make_shared<IAVsyncCallback>(data, func);
   int ret = display_->RegisterVsyncCallback(std::move(callback),
                                             static_cast<int>(handle_));
+  if (ret) {
+    ALOGE("Failed to register callback d=%" PRIu64 " ret=%d", handle_, ret);
+    return HWC2::Error::BadDisplay;
+  }
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::RegisterVsyncPeriodCallback(
+    hwc2_callback_data_t data, hwc2_function_pointer_t func) {
+  supported(__func__);
+  auto callback = std::make_shared<IAVsyncPeriodCallback>(data, func);
+  int ret = display_->RegisterVsyncPeriodCallback(std::move(callback),
+                                                  static_cast<int>(handle_));
   if (ret) {
     ALOGE("Failed to register callback d=%" PRIu64 " ret=%d", handle_, ret);
     return HWC2::Error::BadDisplay;
@@ -815,6 +856,23 @@ HWC2::Error IAHWC2::HwcDisplay::SetActiveConfig(hwc2_config_t config) {
   return HWC2::Error::None;
 }
 
+HWC2::Error IAHWC2::HwcDisplay::SetActiveConfigWithConstraints(
+    hwc2_config_t config,
+    hwc_vsync_period_change_constraints_t *vsyncPeriodChangeConstraints,
+    hwc_vsync_period_change_timeline_t *outTimeline) {
+  supported(__func__);
+  return SetActiveConfig(config);
+}
+
+HWC2::Error IAHWC2::HwcDisplay::GetDisplayVsyncPeriod(
+    hwc2_vsync_period_t *outVsyncPeriod) {
+  supported(__func__);
+  if (display_->GetDisplayVsyncPeriod(outVsyncPeriod))
+    return HWC2::Error::None;
+  else
+    return HWC2::Error::BadConfig;
+}
+
 HWC2::Error IAHWC2::HwcDisplay::SetClientTarget(buffer_handle_t target,
                                                 int32_t acquire_fence,
                                                 int32_t dataspace,
@@ -948,6 +1006,11 @@ HWC2::Error IAHWC2::HwcDisplay::SetVsyncEnabled(int32_t enabled) {
       ALOGE("SetVsyncEnabled called with invalid parameter");
       return HWC2::Error::BadParameter;
   }
+  return HWC2::Error::None;
+}
+
+HWC2::Error IAHWC2::HwcDisplay::SetDisplayBrightness(float brightness) {
+  supported(__func__);
   return HWC2::Error::None;
 }
 
@@ -1439,10 +1502,22 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_ACTIVE_CONFIG>(
           DisplayHook<decltype(&HwcDisplay::SetActiveConfig),
                       &HwcDisplay::SetActiveConfig, hwc2_config_t>);
+    case HWC2::FunctionDescriptor::SetActiveConfigWithConstraints:
+      return ToHook<HWC2_PFN_SET_ACTIVE_CONFIG_WITH_CONSTRAINTS>(
+          DisplayHook<decltype(&HwcDisplay::SetActiveConfigWithConstraints),
+                      &HwcDisplay::SetActiveConfigWithConstraints,
+                      hwc2_config_t, hwc_vsync_period_change_constraints_t *,
+                      hwc_vsync_period_change_timeline_t *>);
+    case HWC2::FunctionDescriptor::GetDisplayVsyncPeriod:
+      return ToHook<HWC2_PFN_GET_DISPLAY_VSYNC_PERIOD>(
+          DisplayHook<decltype(&HwcDisplay::GetDisplayVsyncPeriod),
+                      &HwcDisplay::GetDisplayVsyncPeriod,
+                      hwc2_vsync_period_t *>);
     case HWC2::FunctionDescriptor::SetClientTarget:
-      return ToHook<HWC2_PFN_SET_CLIENT_TARGET>(DisplayHook<
-          decltype(&HwcDisplay::SetClientTarget), &HwcDisplay::SetClientTarget,
-          buffer_handle_t, int32_t, int32_t, hwc_region_t>);
+      return ToHook<HWC2_PFN_SET_CLIENT_TARGET>(
+          DisplayHook<decltype(&HwcDisplay::SetClientTarget),
+                      &HwcDisplay::SetClientTarget, buffer_handle_t, int32_t,
+                      int32_t, hwc_region_t>);
     case HWC2::FunctionDescriptor::SetColorMode:
       return ToHook<HWC2_PFN_SET_COLOR_MODE>(
           DisplayHook<decltype(&HwcDisplay::SetColorMode),
@@ -1473,6 +1548,10 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
       return ToHook<HWC2_PFN_SET_VSYNC_ENABLED>(
           DisplayHook<decltype(&HwcDisplay::SetVsyncEnabled),
                       &HwcDisplay::SetVsyncEnabled, int32_t>);
+    case HWC2::FunctionDescriptor::SetDisplayBrightness:
+      return ToHook<HWC2_PFN_SET_DISPLAY_BRIGHTNESS>(
+          DisplayHook<decltype(&HwcDisplay::SetDisplayBrightness),
+                      &HwcDisplay::SetDisplayBrightness, float>);
     case HWC2::FunctionDescriptor::ValidateDisplay:
       return ToHook<HWC2_PFN_VALIDATE_DISPLAY>(
           DisplayHook<decltype(&HwcDisplay::ValidateDisplay),

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -196,6 +196,9 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::Error RegisterVsyncCallback(hwc2_callback_data_t data,
                                       hwc2_function_pointer_t func);
 
+    HWC2::Error RegisterVsyncPeriodCallback(hwc2_callback_data_t data,
+                                            hwc2_function_pointer_t func);
+
     HWC2::Error RegisterRefreshCallback(hwc2_callback_data_t data,
                                         hwc2_function_pointer_t func);
 
@@ -232,6 +235,11 @@ class IAHWC2 : public hwc2_device_t {
                                  int32_t *fences);
     HWC2::Error PresentDisplay(int32_t *retire_fence);
     HWC2::Error SetActiveConfig(hwc2_config_t config);
+    HWC2::Error SetActiveConfigWithConstraints(
+        hwc2_config_t config,
+        hwc_vsync_period_change_constraints_t *vsyncPeriodChangeConstraints,
+        hwc_vsync_period_change_timeline_t *outTimeline);
+    HWC2::Error GetDisplayVsyncPeriod(hwc2_vsync_period_t *outVsyncPeriod);
     HWC2::Error SetClientTarget(buffer_handle_t target, int32_t acquire_fence,
                                 int32_t dataspace, hwc_region_t damage);
     HWC2::Error SetColorMode(int32_t mode);
@@ -243,6 +251,7 @@ class IAHWC2 : public hwc2_device_t {
     HWC2::Error SetOutputBuffer(buffer_handle_t buffer, int32_t release_fence);
     HWC2::Error SetPowerMode(int32_t mode);
     HWC2::Error SetVsyncEnabled(int32_t enabled);
+    HWC2::Error SetDisplayBrightness(float brightness);
     HWC2::Error ValidateDisplay(uint32_t *num_types, uint32_t *num_requests);
     HWC2::Error GetDisplayIdentificationData(uint8_t *outPort,
                                              uint32_t *outDataSize,

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -41,6 +41,14 @@ class VsyncCallback {
   virtual void Callback(uint32_t display, int64_t timestamp) = 0;
 };
 
+class VsyncPeriodCallback {
+ public:
+  virtual ~VsyncPeriodCallback() {
+  }
+  virtual void Callback(uint32_t display, int64_t timestamp,
+                        uint32_t vsyncPeriodNanos) = 0;
+};
+
 class RefreshCallback {
  public:
   virtual ~RefreshCallback() {
@@ -95,6 +103,9 @@ class NativeDisplay {
 
   virtual void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                                       uint32_t *outCapabilities) = 0;
+  virtual bool GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) {
+    return false;
+  };
 
   /**
    * API for getting connected display's pipe id.
@@ -132,6 +143,12 @@ class NativeDisplay {
 
   virtual int RegisterVsyncCallback(std::shared_ptr<VsyncCallback> callback,
                                     uint32_t display_id) = 0;
+
+  virtual int RegisterVsyncPeriodCallback(
+      std::shared_ptr<VsyncPeriodCallback> callback, uint32_t display_id) {
+    return false;
+  };
+
   virtual void VSyncControl(bool enabled) = 0;
 
   /**

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -575,7 +575,13 @@ void DrmDisplay::UpdateDisplayConfig() {
   }
   flags_ |= DRM_MODE_ATOMIC_ALLOW_MODESET;
   SetDisplayAttribute(modes_[config_]);
+  vsync_period_ = modes_[config_].vrefresh;
   SPIN_UNLOCK(display_lock_);
+}
+
+bool DrmDisplay::GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) {
+  return GetDisplayAttribute(config_, HWCDisplayAttribute::kRefreshRate,
+                             reinterpret_cast<int32_t *>(outVsyncPeriod));
 }
 
 void DrmDisplay::PowerOn() {

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -78,6 +78,8 @@ class DrmDisplay : public PhysicalDisplay {
   bool InitializeDisplay() override;
   void PowerOn() override;
   void UpdateDisplayConfig() override;
+  bool GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) override;
+
   void SetColorCorrection(struct gamma_colors gamma, uint32_t contrast,
                           uint32_t brightness) const override;
   void SetPipeCanvasColor(uint16_t bpc, uint16_t red, uint16_t green,
@@ -215,6 +217,7 @@ class DrmDisplay : public PhysicalDisplay {
   std::vector<drmModeModeInfo> modes_;
   SpinLock display_lock_;
   DrmDisplayManager *manager_;
+  uint32_t vsync_period_ = 0;
 };
 
 }  // namespace hwcomposer

--- a/wsi/physicaldisplay.cpp
+++ b/wsi/physicaldisplay.cpp
@@ -379,6 +379,11 @@ int PhysicalDisplay::RegisterVsyncCallback(
   return display_queue_->RegisterVsyncCallback(callback, display_id);
 }
 
+int PhysicalDisplay::RegisterVsyncPeriodCallback(
+    std::shared_ptr<VsyncPeriodCallback> callback, uint32_t display_id) {
+  return display_queue_->RegisterVsyncPeriodCallback(callback, display_id);
+}
+
 void PhysicalDisplay::RegisterRefreshCallback(
     std::shared_ptr<RefreshCallback> callback, uint32_t display_id) {
   display_queue_->RegisterRefreshCallback(callback, display_id);

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -78,6 +78,9 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
   int RegisterVsyncCallback(std::shared_ptr<VsyncCallback> callback,
                             uint32_t display_id) override;
 
+  int RegisterVsyncPeriodCallback(std::shared_ptr<VsyncPeriodCallback> callback,
+                                  uint32_t display_id) override;
+
   void RegisterRefreshCallback(std::shared_ptr<RefreshCallback> callback,
                                uint32_t display_id) override;
 
@@ -200,6 +203,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
    * Implementations need to reset any state in this case.
    */
   virtual void UpdateDisplayConfig() = 0;
+
+  virtual bool GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) = 0;
 
   /**
    * API for powering on the display


### PR DESCRIPTION
implement vsync2.4 callback, setactiveconfigwithconstraints
and getdisplayvsyncperiod.

Add an empty SetDisplayBrightness to resolove boot problem

Tracked-On: OAM-92711
Signed-Off-By: Liu, Yuanzhe <yuanzhe.liu@intel.com>