### PR TITLE
WA for Allocater & Mapper 4.0

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -81,6 +81,8 @@ LOCAL_SRC_FILES := \
         utils/hwcutils.cpp \
         utils/disjoint_layers.cpp
 
+LOCAL_CPPFLAGS += -DUSE_GRALLOC1
+
 ifeq ($(strip $(ENABLE_HYPER_DMABUF_SHARING)), true)
 LOCAL_CPPFLAGS += -DENABLE_PANORAMA
 LOCAL_SRC_FILES += display/virtualpanoramadisplay.cpp

--- a/wsi/Android.mk
+++ b/wsi/Android.mk
@@ -60,6 +60,8 @@ LOCAL_SRC_FILES := \
         drm/drmdisplaymanager.cpp \
 	drm/drmscopedtypes.cpp
 
+LOCAL_CPPFLAGS += -DUSE_GRALLOC1
+
 ifeq ($(strip $(ENABLE_HYPER_DMABUF_SHARING)), true)
 LOCAL_CPPFLAGS += -DHYPER_DMABUF_SHARING
 endif


### PR DESCRIPTION
HWC has some dependence for gralloc1, this changes is
to help add some parameter from latest gralloc4 and one
wa for null pointer on GVT-d

Tracked-On: OAM-95365
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>