### PR TITLE
Revert "support Iris driver"

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -141,19 +141,8 @@ LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/common/compositor/vk \
 	$(LOCAL_PATH)/../mesa/include
 else
-
-# iris driver flags
-ifneq ($(filter iris, $(BOARD_GPU_DRIVERS)),)
-$(warning "Iris driver not fully supported, instability or lower performance may occur!")
-LOCAL_CPPFLAGS += \
-	-DUSE_GL \
-	-DDISABLE_EXPLICIT_SYNC
-else
-# i965 driver flags
 LOCAL_CPPFLAGS += \
 	-DUSE_GL
-endif
-
 endif
 
 ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -177,12 +177,6 @@ HWC2::Error IAHWC2::Init() {
   char value[PROPERTY_VALUE_MAX];
   property_get("board.disable.explicit.sync", value, "0");
   disable_explicit_sync_ = atoi(value);
-
-/* Build wants to explicitly disable sync. */
-#ifdef DISABLE_EXPLICIT_SYNC
-  disable_explicit_sync_ = true;
-#endif
-
   if (disable_explicit_sync_)
     ALOGI("EXPLICIT SYNC support is disabled");
   else


### PR DESCRIPTION
This reverts commit 9cc7cdc490349db1fa7abd83c85223bcfe5e8cc1.

For CIV, we need keep both i965 driver and iris driver.
i965 driver is used for KBL/CML, iris driver is used for
TGL, and the two driver is built into one image. We can't
check "BOARD_GPU_DRIVERS" flag to disable EXPLICIT_SYNC,
as it will cause PnP regression on CML.

Tracked-On: OAM-95784
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>