### PR TITLE
Default return brightness support to pass VTS

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -1237,6 +1237,10 @@ HWC2::Error IAHWC2::HwcDisplay::GetDisplayCapabilities(
     *outCapabilities |= HWC2_DISPLAY_CAPABILITY_DOZE;
   }
 
+  ++*outNumCapabilities;
+  setNumCapabilities(*outNumCapabilities);
+  *outCapabilities |= HWC2_DISPLAY_CAPABILITY_BRIGHTNESS;
+
   if (numCap_ == maxNumCap_) {
     ALOGI("Maximum number of display capabilities reached");
   }

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -169,7 +169,7 @@ class IAHWC2 : public hwc2_device_t {
     HwcDisplay(const HwcDisplay &) = delete;
     HwcDisplay &operator=(const HwcDisplay &) = delete;
 
-    uint32_t numCap_ = 1;  // at least support the doze
+    uint32_t numCap_ = 2;  // at least support the doze and brightness chaning
     uint32_t maxNumCap_ = HWC2_DISPLAY_CAPABILITY_DOZE -
                           HWC2_DISPLAY_CAPABILITY_INVALID; /* last - first */
 


### PR DESCRIPTION
As for now we initialize brightness as defult support no matter
whethere display turely support it or not. This is fitting to current
dummy setBrightness API which do nothing except return no::error.

Tracked-On: OAM-96695
Signed-Off-By: Liu, Yuanzhe <yuanzhe.liu@intel.com>