### PR TITLE
Implement the 2.4 new Vsync Callback for Mosaic

### DIFF
--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -61,6 +61,9 @@ class MosaicDisplay : public NativeDisplay {
   int RegisterVsyncCallback(std::shared_ptr<VsyncCallback> callback,
                             uint32_t display_id) override;
 
+  int RegisterVsyncPeriodCallback(std::shared_ptr<VsyncPeriodCallback> callback,
+                                  uint32_t display_id) override;
+
   void RegisterRefreshCallback(std::shared_ptr<RefreshCallback> callback,
                                uint32_t display_id) override;
 
@@ -95,6 +98,8 @@ class MosaicDisplay : public NativeDisplay {
   bool GetDisplayAttribute(uint32_t /*config*/, HWCDisplayAttribute attribute,
                            int32_t *value) override;
 
+  bool GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) override;
+
   bool GetDisplayConfigs(uint32_t *num_configs, uint32_t *configs) override;
   bool GetDisplayName(uint32_t *size, char *name) override;
 
@@ -116,6 +121,8 @@ class MosaicDisplay : public NativeDisplay {
   }
 
   void VSyncUpdate(int64_t timestamp);
+
+  void VSyncPeriodUpdate(int64_t timestamp, uint32_t vsyncPeriodNanos);
 
   void RefreshUpdate();
 
@@ -141,6 +148,7 @@ class MosaicDisplay : public NativeDisplay {
   std::vector<NativeDisplay *> connected_displays_;
   std::shared_ptr<RefreshCallback> refresh_callback_ = NULL;
   std::shared_ptr<VsyncCallback> vsync_callback_ = NULL;
+  std::shared_ptr<VsyncPeriodCallback> vsync_period_callback_ = NULL;
   std::shared_ptr<HotPlugCallback> hotplug_callback_ = NULL;
   int32_t dpix_;
   int32_t dpiy_;

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -104,7 +104,10 @@ class NativeDisplay {
   virtual void GetDisplayCapabilities(uint32_t *outNumCapabilities,
                                       uint32_t *outCapabilities) = 0;
   virtual bool GetDisplayVsyncPeriod(uint32_t *outVsyncPeriod) {
-    return false;
+    // TODO implement this method in all displays
+    // FTB, return 16ms by default.
+    *outVsyncPeriod = 16666666;
+    return true;
   };
 
   /**


### PR DESCRIPTION
Without the implementation of new Vsync API. SurfaceFlinger
will crash in init once mosaic is enabled.
This one should be part of the implementation of HAL2.4.

Remaining issue: need check LogicDisplay, PanoramaDisplay and so on.
All of them need to support the new API.

Change-Id: I3f602343a9dcf097444bd832b4f6a53cf7af4a36
Tracked-On: OAM-96194
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>