### PR TITLE
Set the primary display as internal display for AOSP rebase to Beta 1

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -173,6 +173,9 @@ IAHWC2::IAHWC2() {
   getFunction = HookDevGetFunction;
 }
 
+bool IAHWC2::is_primary_display = false;
+size_t IAHWC2::connector_num = 0;
+
 HWC2::Error IAHWC2::Init() {
   char value[PROPERTY_VALUE_MAX];
   property_get("board.disable.explicit.sync", value, "0");
@@ -207,6 +210,7 @@ HWC2::Error IAHWC2::Init() {
   primary_display_.Init(primary_display, 0, disable_explicit_sync_,
                         scaling_mode_);
   size_t size = displays.size();
+  connector_num = size;
 
   for (size_t i = 0; i < size; ++i) {
     hwcomposer::NativeDisplay *display = displays.at(i);
@@ -885,7 +889,8 @@ HWC2::Error IAHWC2::HwcDisplay::GetDisplayVsyncPeriod(
  */
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayConnectionType(uint32_t *outType) {
   supported(__func__);
-  if (display_->IsInternalConnection())
+  if (display_->IsInternalConnection() || is_primary_display == true ||
+      connector_num == 1)
     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::Internal);
   else if (display_->IsExternalConnection())
     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::External);

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -342,6 +342,7 @@ class IAHWC2 : public hwc2_device_t {
 
     if (display_handle == HWC_DISPLAY_PRIMARY) {
       HwcDisplay &display = hwc->primary_display_;
+      is_primary_display = true;
       return static_cast<int32_t>((display.*func)(std::forward<Args>(args)...));
     }
 
@@ -379,6 +380,7 @@ class IAHWC2 : public hwc2_device_t {
 
     if (display_handle == HWC_DISPLAY_PRIMARY) {
       HwcDisplay &display = hwc->primary_display_;
+      is_primary_display = true;
       Hwc2Layer &layer = display.get_layer(layer_handle);
       return static_cast<int32_t>((layer.*func)(std::forward<Args>(args)...));
     }
@@ -430,6 +432,8 @@ class IAHWC2 : public hwc2_device_t {
   hwcomposer::GpuDevice &device_ = GpuDevice::getInstance();
   std::vector<std::unique_ptr<HwcDisplay>> extended_displays_;
   HwcDisplay primary_display_;
+  static bool is_primary_display;
+  static size_t connector_num;
   std::map<uint32_t, std::unique_ptr<HwcDisplay>> virtual_displays_;
   uint32_t virtual_display_index_ = 0;
   SpinLock spin_lock_;


### PR DESCRIPTION
After AOSP rebase to Beta 1, the gvt-d couldn't
boot up as couldn't find the DefaultDisplay.
The Android by defualt assume there is one internal
display, but in our scenario, we connected to hdmi,
hwc set the display as extended display.
This WA deem the primary display as internal display.

Change-Id: I1754e07f90be7618318e4fab2838b7a65dbe056b
Tracked-On: OAM-97157
Signed-off-by: HeYue <yue.he@intel.com>