### PR TITLE
Set the primary display as internal display for AOSP rebase to Beta 1 on Android S

### DIFF
--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -879,13 +879,17 @@ HWC2::Error IAHWC2::HwcDisplay::GetDisplayVsyncPeriod(
     return HWC2::Error::BadConfig;
 }
 
-/**
- * A dummy API
- * TODO need to get the type from drm.
+/*
+ * After AOSP rebase to Beta 1 on Android S, the gvt-d couldn't
+ * boot up as couldn't find the DefaultDisplay.
+ * The Android by defualt assume there is one internal display,
+ * but in our scenario, we connected to hdmi,
+ * hwc set the display as extended display.
+ * This WA deem the primary display as internal display.
  */
 HWC2::Error IAHWC2::HwcDisplay::GetDisplayConnectionType(uint32_t *outType) {
   supported(__func__);
-  if (display_->IsInternalConnection())
+  if (display_->IsInternalConnection() || primary_display_)
     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::Internal);
   else if (display_->IsExternalConnection())
     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::External);

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -181,6 +181,7 @@ class IAHWC2 : public hwc2_device_t {
       numCap_ = num;
     }
 
+    bool primary_display_ = false;
     uint32_t num_intents_ = 1;  // at least support the COLORIMETRIC
     uint32_t GetNumRenderIntents() {
       return num_intents_;
@@ -342,6 +343,7 @@ class IAHWC2 : public hwc2_device_t {
 
     if (display_handle == HWC_DISPLAY_PRIMARY) {
       HwcDisplay &display = hwc->primary_display_;
+      display.primary_display_ = true;
       return static_cast<int32_t>((display.*func)(std::forward<Args>(args)...));
     }
 
@@ -379,6 +381,7 @@ class IAHWC2 : public hwc2_device_t {
 
     if (display_handle == HWC_DISPLAY_PRIMARY) {
       HwcDisplay &display = hwc->primary_display_;
+      display.primary_display_ = true;
       Hwc2Layer &layer = display.get_layer(layer_handle);
       return static_cast<int32_t>((layer.*func)(std::forward<Args>(args)...));
     }


### PR DESCRIPTION
After AOSP rebase to Beta 1, the gvt-d couldn't
boot up as couldn't find the DefaultDisplay.
The Android by defualt assume there is one internal
display, but in our scenario, we connected to hdmi,
hwc set the display as extended display.
This WA deem the primary display as internal display.

Change-Id: I86cef98231ac25cb52796325534d1eb7e5c9a54d
Tracked-On: OAM-97157
Signed-off-by: HeYue <yue.he@intel.com>