### PR TITLE
Add missing move constructor for DrawState

### DIFF
--- a/common/compositor/renderstate.h
+++ b/common/compositor/renderstate.h
@@ -74,6 +74,18 @@ struct DrawState {
     }
   }
 
+  DrawState() = default;
+
+  DrawState(DrawState &&other) {
+    surface_ = other.surface_;
+    destroy_surface_ = other.destroy_surface_;
+    retire_fence_ = other.retire_fence_;
+
+    states_.swap(other.states_);
+    acquire_fences_.swap(other.acquire_fences_);
+    media_state_ = std::move(other.media_state_);
+  }
+
   std::vector<RenderState> states_;
   MediaState media_state_;
   NativeSurface *surface_;


### PR DESCRIPTION
The manner in which DrawState is used within a vector can cause the file descriptors in the acquire fence list to be closed due to the behavior of the default copy constructor for DrawState.
https://github.com/intel/IA-Hardware-Composer/blob/efe339ff5aa656e40b43312c133b142ac2cc227f/common/compositor/compositor.cpp#L146
As noted e.g. [here](https://stackoverflow.com/questions/21646324/why-is-emplace-back-calling-destructor), this can, and in my case did, result in the destructor for the struct running and closing the file descriptors, _after_ being successfully copy-constructed to a new instance when the vector's storage is resized.
```
07-09 13:59:41.031  2251  2366 E iahwcomposer: CalculateRenderState adding fence fd 49 from tid 2366
07-09 13:59:41.031  2251  2366 E iahwcomposer: CalculateRenderState adding fence fd 51 from tid 2366
07-09 13:59:41.031  2251  2366 E iahwcomposer:   # 0: 0x7f5411eacebb  _ZN10hwcomposer9DrawStateD1Ev
07-09 13:59:41.031  2251  2366 E iahwcomposer:   # 1: 0x7f5411ea9bef  _ZNSt3__16vectorIN10hwcomposer9DrawStateENS_9allocatorIS2_EEE24__emplace_back_slow_pathIJEEEvDpOT_
07-09 13:59:41.031  2251  2366 E iahwcomposer:   # 2: 0x7f5411ea7727  _ZN10hwcomposer10Compositor4DrawERNSt3__16vectorINS_17DisplayPlaneStateENS1_9allocatorIS3_EEEERNS2_INS_12OverlayLayerENS4_IS8_EEEERKNS2_INS_4RectIiEENS4_ISD_EEEE
07-09 13:59:41.031  2251  2366 E iahwcomposer:   # 3: 0x7f5411ec8f31  _ZN10hwcomposer12DisplayQueue11QueueUpdateERNSt3__16vectorIPNS_8HwcLayerENS1_9allocatorIS4_EEEEPiPbb
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 4: 0x7f5411ed24ae  _ZN10hwcomposer15PhysicalDisplay7PresentERNSt3__16vectorIPNS_8HwcLayerENS1_9allocatorIS4_EEEEPib
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 5: 0x7f5411ea0393  _ZN7android6IAHWC210HwcDisplay14PresentDisplayEPi
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 6: 0x7f5412498315  _ZN7android8hardware8graphics8composer4V2_114implementation6HwcHal14presentDisplayEmPiPNSt3__16vectorImNS7_9allocatorImEEEEPNS8_IiNS9_IiEEEE
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 7: 0x7f541249dca9  _ZN7android8hardware8graphics8composer4V2_114implementation14ComposerClient13CommandReader19parsePresentDisplayEt
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 8: 0x7f541249cb73  _ZN7android8hardware8graphics8composer4V2_114implementation14ComposerClient13CommandReader12parseCommandENS3_15IComposerClient7CommandEt
07-09 13:59:41.032  2251  2366 E iahwcomposer:   # 9: 0x7f541249c661  _ZN7android8hardware8graphics8composer4V2_114implementation14ComposerClient13CommandReader5parseEv
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #10: 0x7f541249c278  _ZN7android8hardware8graphics8composer4V2_114implementation14ComposerClient15executeCommandsEjRKNS0_8hidl_vecINS0_11hidl_handleEEENSt3__18functionIFvNS3_5ErrorEbjSA_EEE
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #11: 0x7f541327dcf6  _ZN7android8hardware8graphics8composer4V2_118BnHwComposerClient21_hidl_executeCommandsEPNS_4hidl4base4V1_08BnHwBaseERKNS0_6ParcelEPSA_NSt3__18functionIFvRSA_EEE
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #12: 0x7f541327efbd  _ZN7android8hardware8graphics8composer4V2_118BnHwComposerClient10onTransactEjRKNS0_6ParcelEPS5_jNSt3__18functionIFvRS5_EEE
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #13: 0x7f5413366e0b  _ZN7android8hardware9BHwBinder8transactEjRKNS0_6ParcelEPS2_jNSt3__18functionIFvRS2_EEE
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #14: 0x7f541336aa56  _ZN7android8hardware14IPCThreadState14executeCommandEi
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #15: 0x7f541336a730  _ZN7android8hardware14IPCThreadState20getAndExecuteCommandEv
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #16: 0x7f541336aea0  _ZN7android8hardware14IPCThreadState14joinThreadPoolEb
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #17: 0x7f5413376158  _ZN7android8hardware10PoolThread10threadLoopEv
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #18: 0x7f54130d182b  _ZN7android6Thread11_threadLoopEPv
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #19: 0x7f5412ec226c  
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #20: 0x7f5412e70ede  
07-09 13:59:41.032  2251  2366 E iahwcomposer:   #21: 0x7f5412e6f7d6  
07-09 13:59:41.032  2251  2366 E iahwcomposer: closing fence fd 49 from tid 2366
07-09 13:59:41.032  2251  2366 E iahwcomposer: closing fence fd 51 from tid 2366
07-09 13:59:41.032  2251  2366 E iahwcomposer: CalculateRenderState adding fence fd 53 from tid 2366
07-09 13:59:41.032  2251  2366 E iahwcomposer: CalculateRenderState adding fence fd 54 from tid 2366
07-09 13:59:41.196  2251  2297 E iahwcomposer: inserting fence fd 49 from tid 2297
```
Usually, this does not actually manage to cause a crash, because identically-numbered fence file descriptors are reopened before the rendering thread attempts to submit a new buffer to the kernel driver. However, rarely, other files will end up opened between the close and reopen, and an unusable file descriptor will be passed to the kernel driver, [bringing down the system](https://github.com/intel/external-mesa/pull/154).